### PR TITLE
Support to consider checked pointers as regular pointers

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -2045,11 +2045,11 @@ public:
   bool isCheckedPointerNtArrayType() const;        // Checked C Nt_Array type.
   bool isOrigCheckedPointerType() const;
   bool isOrigUncheckedPointerType() const;
-  bool isOrigCheckedPointerPtrType() const;            // Checked C _Ptr type.
-  bool isOrigCheckedPointerArrayType() const;          // Checked C _Array_ptr or
+  bool isOrigCheckedPointerPtrType() const;        // Is Originally a Checked C _Ptr type.
+  bool isOrigCheckedPointerArrayType() const;      // Is Originally a Checked C _Array_ptr or
   // _Nt_array_ptr type.
-  bool isOrigExactlyCheckedPointerArrayType() const;   // Checked C _Array_ptr type.
-  bool isOrigCheckedPointerNtArrayType() const;        // Checked C Nt_Array type.
+  bool isOrigExactlyCheckedPointerArrayType() const; // Originally a Checked C _Array_ptr type.
+  bool isOrigCheckedPointerNtArrayType() const;      // Originally a Checked C Nt_Array type.
   bool isAnyPointerType() const;   // Any C pointer or ObjC object pointer
   bool isBlockPointerType() const;
   bool isVoidPointerType() const;

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -94,7 +94,7 @@ LANGOPT(CPlusPlus17       , 1, 0, "C++17")
 LANGOPT(CPlusPlus2a       , 1, 0, "C++2a")
 LANGOPT(ObjC              , 1, 0, "Objective-C")
 LANGOPT(CheckedC          , 1, 0, "Checked C extension")
-LANGOPT(NoCheckedPtr      , 1, 0, "No Checked Pointers")
+LANGOPT(IgnoreCheckedPtr      , 1, 0, "No Checked Pointers")
 BENIGN_LANGOPT(ObjCDefaultSynthProperties , 1, 0,
                "Objective-C auto-synthesized properties")
 BENIGN_LANGOPT(EncodeExtendedBlockSig , 1, 0,

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -94,6 +94,7 @@ LANGOPT(CPlusPlus17       , 1, 0, "C++17")
 LANGOPT(CPlusPlus2a       , 1, 0, "C++2a")
 LANGOPT(ObjC              , 1, 0, "Objective-C")
 LANGOPT(CheckedC          , 1, 0, "Checked C extension")
+LANGOPT(NoCheckedPtr      , 1, 0, "No Checked Pointers")
 BENIGN_LANGOPT(ObjCDefaultSynthProperties , 1, 0,
                "Objective-C auto-synthesized properties")
 BENIGN_LANGOPT(EncodeExtendedBlockSig , 1, 0,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -783,7 +783,7 @@ def fborland_extensions : Flag<["-"], "fborland-extensions">, Group<f_Group>, Fl
 def fbuiltin : Flag<["-"], "fbuiltin">, Group<f_Group>, Flags<[CoreOption]>;
 def fbuiltin_module_map : Flag <["-"], "fbuiltin-module-map">, Group<f_Group>,
   Flags<[DriverOption]>, HelpText<"Load the clang builtins module map file.">;
-def nonchecked_pointers : Flag<["-"], "fnoncheckedc-pointers">, Group<f_Group>, Flags<[CC1Option]>,
+def fignore_checkedc_pointers : Flag<["-"], "fignore-checkedc-pointers">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Consider all pointers as non-checked pointers">;
 def fcheckedc_extension : Flag<["-"], "fcheckedc-extension">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Accept Checked C extension">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -783,10 +783,12 @@ def fborland_extensions : Flag<["-"], "fborland-extensions">, Group<f_Group>, Fl
 def fbuiltin : Flag<["-"], "fbuiltin">, Group<f_Group>, Flags<[CoreOption]>;
 def fbuiltin_module_map : Flag <["-"], "fbuiltin-module-map">, Group<f_Group>,
   Flags<[DriverOption]>, HelpText<"Load the clang builtins module map file.">;
+def nonchecked_pointers : Flag<["-"], "fnoncheckedc-pointers">, Group<f_Group>, Flags<[CC1Option]>,
+  HelpText<"Consider all pointers as non-checked pointers">;
 def fcheckedc_extension : Flag<["-"], "fcheckedc-extension">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Accept Checked C extension">;
 def fno_checkedc_extension : Flag<["-"], "fno-checkedc-extension">, Group<f_Group>, Flags<[CC1Option]>,
-  HelpText<"Do ont accept Checked C extension">;
+  HelpText<"Do not accept Checked C extension">;
 def fdump_extracted_comparison_facts : Flag<["-"], "fdump-extracted-comparison-facts">, Group<f_Group>, Flags<[CC1Option]>,
   HelpText<"Dump extracted comparison facts">;
 def fdump_inferred_bounds : Flag<["-"], "fdump-inferred-bounds">, Group<f_Group>, Flags<[CC1Option]>,

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -2880,7 +2880,7 @@ QualType ASTContext::getPointerType(QualType T, CheckedPointerKind kind) const {
     assert(!NewIP && "Shouldn't be in the map!"); (void)NewIP;
   }
   PointerType *New = nullptr;
-  if (!LangOpts.NoCheckedPtr) {
+  if (!LangOpts.IgnoreCheckedPtr) {
     New = new (*this, TypeAlignment) PointerType(T, Canonical, kind);
   } else {
     New = new (*this, TypeAlignment) PointerType(T, Canonical,

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -8511,7 +8511,10 @@ bool ASTContext::typesAreCompatible(QualType LHS, QualType RHS,
                                     bool IgnoreBounds) {
   if (getLangOpts().CPlusPlus)
     return hasSameType(LHS, RHS);
-
+  
+  // Ignore bounds if checked pointers are ignored
+  IgnoreBounds = IgnoreBounds && !getLangOpts().IgnoreCheckedPtr;
+  
   return !mergeTypes(LHS, RHS, false, CompareUnqualified, 
                      /*BlockReturnType=*/false, IgnoreBounds).isNull();
 }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -8513,7 +8513,7 @@ bool ASTContext::typesAreCompatible(QualType LHS, QualType RHS,
     return hasSameType(LHS, RHS);
   
   // Ignore bounds if checked pointers are ignored
-  IgnoreBounds = IgnoreBounds && !getLangOpts().IgnoreCheckedPtr;
+  IgnoreBounds = IgnoreBounds || getLangOpts().IgnoreCheckedPtr;
   
   return !mergeTypes(LHS, RHS, false, CompareUnqualified, 
                      /*BlockReturnType=*/false, IgnoreBounds).isNull();

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -2879,7 +2879,14 @@ QualType ASTContext::getPointerType(QualType T, CheckedPointerKind kind) const {
     PointerType *NewIP = PointerTypes.FindNodeOrInsertPos(ID, InsertPos);
     assert(!NewIP && "Shouldn't be in the map!"); (void)NewIP;
   }
-  auto *New = new (*this, TypeAlignment) PointerType(T, Canonical, kind);
+  PointerType *New = nullptr;
+  if (!LangOpts.NoCheckedPtr) {
+    New = new (*this, TypeAlignment) PointerType(T, Canonical, kind);
+  } else {
+    New = new (*this, TypeAlignment) PointerType(T, Canonical,
+                                                 CheckedPointerKind::Unchecked,
+                                                 kind);
+  }
   Types.push_back(New);
   PointerTypes.InsertNode(New, InsertPos);
   return QualType(New, 0);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4720,7 +4720,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT_fcheckedc_extension);
   Args.AddLastArg(CmdArgs, options::OPT_fno_checkedc_extension);
   Args.AddLastArg(CmdArgs, options::OPT_fdump_inferred_bounds);
-  Args.AddLastArg(CmdArgs, options::OPT_nonchecked_pointers);
+  Args.AddLastArg(CmdArgs, options::OPT_fignore_checkedc_pointers);
 
   Args.AddLastArg(CmdArgs, options::OPT_fcheckedc_null_ptr_arith,
                            options::OPT_fno_checkedc_null_ptr_arith);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4720,6 +4720,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT_fcheckedc_extension);
   Args.AddLastArg(CmdArgs, options::OPT_fno_checkedc_extension);
   Args.AddLastArg(CmdArgs, options::OPT_fdump_inferred_bounds);
+  Args.AddLastArg(CmdArgs, options::OPT_nonchecked_pointers);
 
   Args.AddLastArg(CmdArgs, options::OPT_fcheckedc_null_ptr_arith,
                            options::OPT_fno_checkedc_null_ptr_arith);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2564,6 +2564,10 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     } else
       Opts.CheckedC = true;
   }
+
+  if (Args.hasArg(OPT_nonchecked_pointers))
+    Opts.NoCheckedPtr = true;
+
   if (Args.hasArg(OPT_fno_checkedc_extension))
     Opts.CheckedC = false;
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2565,8 +2565,8 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
       Opts.CheckedC = true;
   }
 
-  if (Args.hasArg(OPT_nonchecked_pointers))
-    Opts.NoCheckedPtr = true;
+  if (Args.hasArg(OPT_fignore_checkedc_pointers))
+    Opts.IgnoreCheckedPtr = true;
 
   if (Args.hasArg(OPT_fno_checkedc_extension))
     Opts.CheckedC = false;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13494,7 +13494,8 @@ static bool checkBoundsDeclWithTypeAnnotation(Sema &S, QualType DeclaredTy,
   }
 
   // Make sure that the annotation type is a checked type.
-  if (!(Errors & Annot_Illegal_Type) && !AnnotTy->isOrContainsCheckedType()) {
+  if (!(Errors & Annot_Illegal_Type) && !AnnotTy->isOrContainsCheckedType()
+      && !S.getLangOpts().NoCheckedPtr) {
     S.Diag(AnnotTyLoc,
            diag::err_typecheck_bounds_type_annotation_must_be_checked_type);
     Errors |= Annot_Unchecked;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4005,7 +4005,7 @@ bool Sema::DiagnoseCheckedCFunctionCompatibility(FunctionDecl *New,
                                  /*CompareUnqualified=*/false,
                                  /*IgnoreBounds=*/true);
     // If they are, make sure an error message has been emitted.
-    if (BoundsOnlyError && !Err) {
+    if (BoundsOnlyError && !Err && !getLangOpts().IgnoreCheckedPtr) {
           Diag(New->getLocation(), diag::err_conflicting_annots) <<
             New->getDeclName();
           int PrevDiag;
@@ -4014,7 +4014,7 @@ bool Sema::DiagnoseCheckedCFunctionCompatibility(FunctionDecl *New,
             = getNoteDiagForInvalidRedeclaration(Old, New);
           Diag(OldLocation, PrevDiag);
     }
-    return BoundsOnlyError;
+    return BoundsOnlyError && !getLangOpts().IgnoreCheckedPtr;
   } else {
     // One declaration has a prototype and the other doesn't.
     // Look for checked parameters that are not allowed when mixing prototype

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13495,7 +13495,7 @@ static bool checkBoundsDeclWithTypeAnnotation(Sema &S, QualType DeclaredTy,
 
   // Make sure that the annotation type is a checked type.
   if (!(Errors & Annot_Illegal_Type) && !AnnotTy->isOrContainsCheckedType()
-      && !S.getLangOpts().NoCheckedPtr) {
+      && !S.getLangOpts().IgnoreCheckedPtr) {
     S.Diag(AnnotTyLoc,
            diag::err_typecheck_bounds_type_annotation_must_be_checked_type);
     Errors |= Annot_Unchecked;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -12221,7 +12221,7 @@ void Sema::ActOnUninitializedDecl(Decl *RealDecl) {
       // An unchecked pointer in a checked scope with a bounds expression must
       // be initialized
       if (Ty->isUncheckedPointerType() && InCheckedScope &&
-          Var->hasBoundsExpr())
+          Var->hasBoundsExpr() && !getLangOpts().IgnoreCheckedPtr)
         Diag(Var->getLocation(),
              diag::err_initializer_expected_for_unchecked_pointer)
           << Var;
@@ -13723,9 +13723,9 @@ void Sema::ActOnBoundsDecl(DeclaratorDecl *D, BoundsAnnotations Annots,
     }
 
     if (BoundsExpr) {
-      if (Ty->isPointerType() && !Ty->isCheckedPointerType())
+      if (Ty->isPointerType() && !Ty->isCheckedPointerType() && !getLangOpts().IgnoreCheckedPtr)
         DiagId = diag::err_bounds_declaration_unchecked_local_pointer;
-      else if (Ty->isArrayType() && !Ty->isCheckedArrayType())
+      else if (Ty->isArrayType() && !Ty->isCheckedArrayType() && !getLangOpts().IgnoreCheckedPtr)
         DiagId = diag::err_bounds_declaration_unchecked_local_array;
 
       if (DiagId) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3870,7 +3870,7 @@ static bool diagnoseBoundsError(Sema &S,
   const InteropTypeExpr *OldIType = OldAnnots.getInteropTypeExpr();
   const InteropTypeExpr *NewIType = NewAnnots.getInteropTypeExpr();
   if (!S.Context.EquivalentInteropTypes(OldIType, NewIType)) {
-    if (OldIType && NewIType)
+    if (OldIType && NewIType && !S.getLangOpts().IgnoreCheckedPtr)
       DiagId = diag::err_decl_conflicting_annot;
     else if (!IsUncheckedType || IsInconsistent)
       DiagId = NewIType ?

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1874,7 +1874,7 @@ ExprResult Sema::ConvertToFullyCheckedType(Expr *E,
   if (CheckedTy.isNull())
     return ExprError();
 
-  assert(!CheckedTy->isOrContainsUncheckedType());
+  assert(!CheckedTy->isOrContainsUncheckedType() || getLangOpts().IgnoreCheckedPtr);
   if (VK == ExprValueKind::VK_RValue) {
     ExprResult ER = ImpCastExprToType(E, CheckedTy, CK_BitCast, VK, nullptr,
                                       Sema::CCK_ImplicitConversion, true);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14313,7 +14313,7 @@ ExprResult Sema::ActOnBoundsCastExprBounds(
   if (CheckBoundsCastBaseType(E1))
     return ExprError();
 
-  if (!DestTy->isCheckedPointerArrayType()) {
+  if (!DestTy->isCheckedPointerArrayType() && !getLangOpts().IgnoreCheckedPtr) {
     Diag(TypeLoc, diag::err_bounds_cast_expected_array_ptr);
     return ExprError();
   } else if (Bounds->isElementCount() && DestTy->isVoidPointerType()) {


### PR DESCRIPTION
We want to add support to the conversion tool to support partially annotated code. However, partially annotated code could fail type-checking and consequently, the generated AST might not be complete.
For instance, if we want to convert the following code:
```
void foo(_Ptr<int> z) {
  int *x = z;
}
```
clang emits an error:
```
error: initializing 'int *' with an expression of incompatible type

      '_Ptr<int>'
  int *x = z;
```

And the AST we get is also not complete:
```
./clang -cc1 -ast-dump foo.c
....
`-FunctionDecl 0x10f2fbd0 </home/machiry/checkedc/dd.c:1:1, line:3:1> line:1:6 foo 'void (_Ptr<int>)'
  |-ParmVarDecl 0x10f2faf8 <col:10, col:20> col:20 used z '_Ptr<int>'
  `-CompoundStmt 0x10f301c8 <col:23, line:3:1>
    `-DeclStmt 0x10f301b0 <line:2:3, col:13>
      `-VarDecl 0x10f2fd08 <col:3, col:8> col:8 invalid x 'int *'
1 error generated.
```
More details refer: https://github.com/plum-umd/checkedc-clang/issues/38

The goal of this change is to add support to clang so that all pointers (checked and others) will be treated as non-checked. Our conversion tool can use this option to get complete AST, thus making progress in the conversions.

Details on approach: https://gist.github.com/Machiry/7c9ae442d8692ec41f91a7902d01e23b