### PR TITLE
Added Regression Tests

### DIFF
--- a/clang/test/CheckedCRewriter/arrboth.c
+++ b/clang/test/CheckedCRewriter/arrboth.c
@@ -1,0 +1,101 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+z += 2;
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrboth.c
+++ b/clang/test/CheckedCRewriter/arrboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -84,6 +89,7 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -91,6 +97,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -99,3 +108,6 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *, int *);
@@ -87,6 +92,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -95,3 +103,6 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti1.c
@@ -1,0 +1,97 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrbothmulti1.checked.c %s
+//RUN: rm %S/arrbothmulti1.checked.c %S/arrbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *, int *);
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int * x, int * y) {
 x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
@@ -73,4 +90,3 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti2.c
@@ -1,0 +1,76 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrbothmulti2.checked2.c %s
+//RUN: rm %S/arrbothmulti1.checked2.c %S/arrbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+z += 2;
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti2.c
@@ -90,3 +90,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrcallee.c
+++ b/clang/test/CheckedCRewriter/arrcallee.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+z += 2;
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrcallee.c
+++ b/clang/test/CheckedCRewriter/arrcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -84,6 +89,7 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -91,6 +97,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -98,3 +107,6 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *, int *);
@@ -87,6 +92,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -94,3 +102,6 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti1.c
@@ -1,0 +1,96 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrcalleemulti1.checked.c %s
+//RUN: rm %S/arrcalleemulti1.checked.c %S/arrcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *, int *);
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti2.c
@@ -1,0 +1,76 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrcalleemulti2.checked2.c %s
+//RUN: rm %S/arrcalleemulti1.checked2.c %S/arrcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+z += 2;
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int * x, int * y) {
 x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
@@ -73,4 +90,3 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti2.c
@@ -90,3 +90,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrcaller.c
+++ b/clang/test/CheckedCRewriter/arrcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -83,6 +88,7 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -90,6 +96,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -98,3 +107,6 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcaller.c
+++ b/clang/test/CheckedCRewriter/arrcaller.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *, int *);
@@ -87,6 +92,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -95,3 +103,6 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti1.c
@@ -1,0 +1,97 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrcallermulti1.checked.c %s
+//RUN: rm %S/arrcallermulti1.checked.c %S/arrcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *, int *);
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti2.c
@@ -1,0 +1,75 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrcallermulti2.checked2.c %s
+//RUN: rm %S/arrcallermulti1.checked2.c %S/arrcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti2.c
@@ -89,3 +89,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,10 +81,11 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int * x, int * y) {
 x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrinstructboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructboth.c
@@ -1,0 +1,106 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
@@ -96,6 +101,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -104,3 +111,5 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
@@ -1,0 +1,97 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrinstructbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructbothmulti1.checked.c %s
+//RUN: rm %S/arrinstructbothmulti1.checked.c %S/arrinstructbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: struct warr * sus(struct warr *, struct warr *);
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: struct warr * sus(struct warr *, struct warr *);
@@ -87,6 +92,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -95,3 +102,5 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
@@ -95,3 +95,4 @@ x = (struct warr *) 5;
         
 z += 2;
 return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
@@ -1,0 +1,81 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrinstructbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructbothmulti2.checked2.c %s
+//RUN: rm %S/arrinstructbothmulti1.checked2.c %S/arrinstructbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
         char name[20]; 
@@ -78,4 +95,3 @@ x = (struct warr *) 5;
         
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
@@ -96,6 +101,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -103,3 +110,5 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallee.c
@@ -1,0 +1,105 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: struct warr * sus(struct warr *, struct warr *);
@@ -87,6 +92,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -94,3 +101,5 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
@@ -1,0 +1,96 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrinstructcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructcalleemulti1.checked.c %s
+//RUN: rm %S/arrinstructcalleemulti1.checked.c %S/arrinstructcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: struct warr * sus(struct warr *, struct warr *);
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
@@ -95,3 +95,4 @@ x = (struct warr *) 5;
         
 z += 2;
 return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
@@ -1,0 +1,81 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrinstructcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructcalleemulti2.checked2.c %s
+//RUN: rm %S/arrinstructcalleemulti1.checked2.c %S/arrinstructcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
         char name[20]; 
@@ -78,4 +95,3 @@ x = (struct warr *) 5;
         
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructcaller.c
@@ -1,0 +1,105 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
@@ -95,6 +100,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -103,3 +110,5 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
@@ -1,0 +1,97 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrinstructcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructcallermulti1.checked.c %s
+//RUN: rm %S/arrinstructcallermulti1.checked.c %S/arrinstructcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: struct warr * sus(struct warr *, struct warr *);
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: struct warr * sus(struct warr *, struct warr *);
@@ -87,6 +92,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -95,3 +102,5 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrinstructcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructcallermulti2.checked2.c %s
+//RUN: rm %S/arrinstructcallermulti1.checked2.c %S/arrinstructcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
         char name[20]; 
@@ -77,4 +94,3 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
@@ -94,3 +94,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotoboth.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
@@ -85,6 +90,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -93,6 +100,8 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocallee.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
@@ -85,6 +90,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -92,6 +99,8 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
@@ -85,6 +90,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -93,6 +100,8 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocaller.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Array_ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: _Array_ptr<struct warr> bar(void) {
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+return z; }
+//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotosafe.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>));
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Ptr<struct warr> bar(void) {
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+return z; }
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>));
@@ -85,6 +90,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -92,6 +99,8 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     char name[];
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
@@ -95,6 +100,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -102,3 +109,5 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafe.c
@@ -1,0 +1,104 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     char name[];
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+return z; }
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
 //CHECK: struct warr * sus(struct warr *, struct warr *);
@@ -87,6 +92,8 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -94,3 +101,5 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
+//CHECK:         struct warr * x = malloc(sizeof(struct warr));
+//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
@@ -1,0 +1,96 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrinstructsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructsafemulti1.checked.c %s
+//RUN: rm %S/arrinstructsafemulti1.checked.c %S/arrinstructsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct warr * sus(struct warr *, struct warr *);
+//CHECK: struct warr * sus(struct warr *, struct warr *);
+
+struct warr * foo() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Ptr<struct warr> foo(void) {
+
+struct warr * bar() {
+        struct warr * x = malloc(sizeof(struct warr));
+        struct warr * y = malloc(sizeof(struct warr));
+        struct warr * z = sus(x, y);
+return z; }
+//CHECK: _Ptr<struct warr> bar(void) {

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrinstructsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrinstructsafemulti2.checked2.c %s
+//RUN: rm %S/arrinstructsafemulti1.checked2.c %S/arrinstructsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct warr * sus(struct warr * x, struct warr * y) {
+x = (struct warr *) 5;
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        
+return z; }
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     char name[];
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
         char name[20]; 
@@ -77,4 +94,3 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
@@ -94,3 +94,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrofstructboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructboth.c
@@ -1,0 +1,119 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -88,6 +93,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;
 
 struct general ** foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -102,6 +109,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,3 +128,7 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
@@ -1,0 +1,111 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrofstructbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructbothmulti1.checked.c %s
+//RUN: rm %S/arrofstructbothmulti1.checked.c %S/arrofstructbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *, struct general *);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -109,3 +118,7 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
@@ -77,4 +94,3 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -94,3 +94,6 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrofstructbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructbothmulti2.checked2.c %s
+//RUN: rm %S/arrofstructbothmulti1.checked2.c %S/arrofstructbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -88,6 +93,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;
 
 struct general ** foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -102,6 +109,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,3 +127,7 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallee.c
@@ -1,0 +1,118 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -108,3 +117,7 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrofstructcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructcalleemulti1.checked.c %s
+//RUN: rm %S/arrofstructcalleemulti1.checked.c %S/arrofstructcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *, struct general *);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
@@ -77,4 +94,3 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrofstructcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructcalleemulti2.checked2.c %s
+//RUN: rm %S/arrofstructcalleemulti1.checked2.c %S/arrofstructcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -94,3 +94,6 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructcaller.c
@@ -1,0 +1,118 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -87,6 +92,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;
 
 struct general ** foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -101,6 +108,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,3 +127,7 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
@@ -1,0 +1,111 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrofstructcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructcallermulti1.checked.c %s
+//RUN: rm %S/arrofstructcallermulti1.checked.c %S/arrofstructcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *, struct general *);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -109,3 +118,7 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrofstructcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructcallermulti2.checked2.c %s
+//RUN: rm %S/arrofstructcallermulti1.checked2.c %S/arrofstructcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -93,3 +93,6 @@ x = (struct general *) 5;
         } 
         
 return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
@@ -76,4 +93,3 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotoboth.c
@@ -1,0 +1,122 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *x, struct general *y);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: struct general ** bar() {
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -107,6 +116,10 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -120,3 +133,5 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocallee.c
@@ -1,0 +1,121 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *x, struct general *y);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** bar() {
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -106,6 +115,10 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -119,3 +132,5 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocaller.c
@@ -1,0 +1,121 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *x, struct general *y);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: struct general ** bar() {
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -107,6 +116,10 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -119,3 +132,5 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -106,6 +115,10 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -118,3 +131,5 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotosafe.c
@@ -1,0 +1,120 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *x, struct general *y);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** bar() {
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
@@ -87,6 +92,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;
 
 struct general ** foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -101,6 +108,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -115,3 +126,7 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafe.c
@@ -1,0 +1,117 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct general ** sus(struct general *, struct general *);
 //CHECK: struct general ** sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);
 
 struct general ** bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -108,3 +117,7 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK: struct general ** bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrofstructsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructsafemulti1.checked.c %s
+//RUN: rm %S/arrofstructsafemulti1.checked.c %S/arrofstructsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct general ** sus(struct general *, struct general *);
+//CHECK: struct general ** sus(struct general *, struct general *);
+
+struct general ** foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** foo() {
+
+struct general ** bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        struct general ** z = sus(x, y);
+return z; }
+//CHECK: struct general ** bar() {

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrofstructsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrofstructsafemulti2.checked2.c %s
+//RUN: rm %S/arrofstructsafemulti1.checked2.c %S/arrofstructsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct general ** sus(struct general * x, struct general * y) {
+x = (struct general *) 5; 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        
+return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -93,3 +93,6 @@ x = (struct general *) 5;
         } 
         
 return z; }
+//CHECK: struct general ** sus(struct general *x, struct general *y) {
+//CHECK:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct general ** sus(struct general * x, struct general * y) {
 x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
@@ -76,4 +93,3 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: struct general ** sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrprotoboth.c
@@ -1,0 +1,104 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+z += 2;
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
@@ -85,6 +90,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -93,6 +101,9 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -102,3 +113,4 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
@@ -85,6 +90,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -92,6 +100,9 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -101,3 +112,4 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrprotocallee.c
@@ -1,0 +1,103 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+z += 2;
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
@@ -85,6 +90,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -93,6 +101,9 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -101,3 +112,4 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrprotocaller.c
@@ -1,0 +1,103 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrprotosafe.c
@@ -1,0 +1,102 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
@@ -85,6 +90,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -92,6 +100,9 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -100,3 +111,4 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrsafe.c
+++ b/clang/test/CheckedCRewriter/arrsafe.c
@@ -1,0 +1,99 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrsafe.c
+++ b/clang/test/CheckedCRewriter/arrsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int * x, int * y) {
 x = (int *) 5;
@@ -83,6 +88,7 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -90,6 +96,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -97,3 +106,6 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
 //CHECK: int * sus(int *, int *);
@@ -87,6 +92,9 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         int * x = malloc(sizeof(int));
@@ -94,3 +102,6 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int * x = malloc(sizeof(int));
+//CHECK:         int * y = malloc(sizeof(int));
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti1.c
@@ -1,0 +1,96 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrsafemulti1.checked.c %s
+//RUN: rm %S/arrsafemulti1.checked.c %S/arrsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int *, int *);
+//CHECK: int * sus(int *, int *);
+
+int * foo() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        int * x = malloc(sizeof(int));
+        int * y = malloc(sizeof(int));
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti2.c
@@ -1,0 +1,75 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrsafemulti2.checked2.c %s
+//RUN: rm %S/arrsafemulti1.checked2.c %S/arrsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int * x, int * y) {
+x = (int *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }
+return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti2.c
@@ -89,3 +89,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
+//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,10 +81,11 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int * x, int * y) {
 x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {

--- a/clang/test/CheckedCRewriter/arrstructboth.c
+++ b/clang/test/CheckedCRewriter/arrstructboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -87,6 +92,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -101,6 +108,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,3 +127,7 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructboth.c
+++ b/clang/test/CheckedCRewriter/arrstructboth.c
@@ -1,0 +1,118 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -109,3 +118,7 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti1.c
@@ -1,0 +1,111 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrstructbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructbothmulti1.checked.c %s
+//RUN: rm %S/arrstructbothmulti1.checked.c %S/arrstructbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti2.c
@@ -93,3 +93,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
@@ -76,4 +93,3 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/arrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrstructbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructbothmulti2.checked2.c %s
+//RUN: rm %S/arrstructbothmulti1.checked2.c %S/arrstructbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/arrstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrstructcallee.c
@@ -1,0 +1,117 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrstructcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -87,6 +92,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -101,6 +108,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -115,3 +126,7 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -108,3 +117,7 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrstructcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructcalleemulti1.checked.c %s
+//RUN: rm %S/arrstructcalleemulti1.checked.c %S/arrstructcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrstructcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructcalleemulti2.checked2.c %s
+//RUN: rm %S/arrstructcalleemulti1.checked2.c %S/arrstructcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
@@ -93,3 +93,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
@@ -76,4 +93,3 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/arrstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrstructcaller.c
@@ -1,0 +1,117 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrstructcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -86,6 +91,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -100,6 +107,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -115,3 +126,7 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti1.c
@@ -1,0 +1,111 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrstructcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructcallermulti1.checked.c %s
+//RUN: rm %S/arrstructcallermulti1.checked.c %S/arrstructcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -109,3 +118,7 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrstructcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructcallermulti2.checked2.c %s
+//RUN: rm %S/arrstructcallermulti1.checked2.c %S/arrstructcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/arrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti2.c
@@ -92,3 +92,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
@@ -75,4 +92,3 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/arrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrstructprotoboth.c
@@ -1,0 +1,121 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrstructprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -107,6 +116,10 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -119,3 +132,5 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocallee.c
@@ -1,0 +1,120 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -106,6 +115,10 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -118,3 +131,5 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -107,6 +116,10 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -118,3 +131,5 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocaller.c
@@ -1,0 +1,120 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrstructprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -92,6 +97,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -106,6 +115,10 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -117,3 +130,5 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrstructprotosafe.c
@@ -1,0 +1,119 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/arrstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrstructsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
@@ -86,6 +91,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -100,6 +107,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -114,3 +125,7 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrstructsafe.c
@@ -1,0 +1,116 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -94,6 +99,10 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);
 
 int * bar() {
         struct general * x = malloc(sizeof(struct general));
@@ -108,3 +117,7 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general * x = malloc(sizeof(struct general));
+//CHECK:         struct general * y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti1.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/arrstructsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructsafemulti1.checked.c %s
+//RUN: rm %S/arrstructsafemulti1.checked.c %S/arrstructsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+        struct general * x = malloc(sizeof(struct general));
+        struct general * y = malloc(sizeof(struct general));
+        
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * z = sus(x, y);
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/arrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/arrstructsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/arrstructsafemulti2.checked2.c %s
+//RUN: rm %S/arrstructsafemulti1.checked2.c %S/arrstructsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general * x, struct general * y) {
+x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/arrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti2.c
@@ -92,3 +92,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general * x, struct general * y) {
 x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
@@ -75,4 +92,3 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {

--- a/clang/test/CheckedCRewriter/fptrarrboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrboth.c
@@ -1,0 +1,115 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *x, int *y) {
 
@@ -88,6 +93,8 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
 
@@ -100,6 +107,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -113,3 +123,6 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *, int *);
@@ -92,6 +97,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -105,3 +113,6 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrbothmulti1.checked.c %s
+//RUN: rm %S/fptrarrbothmulti1.checked.c %S/fptrarrbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *, int *);
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrbothmulti2.checked2.c %s
+//RUN: rm %S/fptrarrbothmulti1.checked2.c %S/fptrarrbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -94,3 +94,6 @@ int ** sus(int *x, int *y) {
         
 z += 2;
 return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int ** sus(int *x, int *y) {
 
         x = (int *) 5;
@@ -77,4 +94,3 @@ int ** sus(int *x, int *y) {
         
 z += 2;
 return z; }
-//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *x, int *y) {
 
@@ -88,6 +93,8 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
 
@@ -100,6 +107,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -112,3 +122,6 @@ int ** bar() {
         
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallee.c
@@ -1,0 +1,114 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *, int *);
@@ -92,6 +97,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -104,3 +112,6 @@ int ** bar() {
         
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
@@ -1,0 +1,106 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrcalleemulti1.checked.c %s
+//RUN: rm %S/fptrarrcalleemulti1.checked.c %S/fptrarrcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *, int *);
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -94,3 +94,6 @@ int ** sus(int *x, int *y) {
         
 z += 2;
 return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrcalleemulti2.checked2.c %s
+//RUN: rm %S/fptrarrcalleemulti1.checked2.c %S/fptrarrcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int ** sus(int *x, int *y) {
 
         x = (int *) 5;
@@ -77,4 +94,3 @@ int ** sus(int *x, int *y) {
         
 z += 2;
 return z; }
-//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrcaller.c
@@ -1,0 +1,114 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *x, int *y) {
 
@@ -87,6 +92,8 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
 
@@ -99,6 +106,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -112,3 +122,6 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *, int *);
@@ -92,6 +97,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -105,3 +113,6 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrcallermulti1.checked.c %s
+//RUN: rm %S/fptrarrcallermulti1.checked.c %S/fptrarrcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *, int *);
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -93,3 +93,6 @@ int ** sus(int *x, int *y) {
         } 
         
 return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int ** sus(int *x, int *y) {
 
         x = (int *) 5;
@@ -76,4 +93,3 @@ int ** sus(int *x, int *y) {
         } 
         
 return z; }
-//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrcallermulti2.checked2.c %s
+//RUN: rm %S/fptrarrcallermulti1.checked2.c %S/fptrarrcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructboth.c
@@ -1,0 +1,121 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -92,6 +97,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -105,6 +111,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -119,3 +128,6 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrinstructbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructbothmulti1.checked.c %s
+//RUN: rm %S/fptrarrinstructbothmulti1.checked.c %S/fptrarrinstructbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
@@ -93,6 +98,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -107,3 +115,6 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
@@ -1,0 +1,84 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrinstructbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructbothmulti2.checked2.c %s
+//RUN: rm %S/fptrarrinstructbothmulti1.checked2.c %S/fptrarrinstructbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
         x = (struct arrfptr *) 5; 
@@ -81,4 +98,3 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
@@ -98,3 +98,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
@@ -1,0 +1,120 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -92,6 +97,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -105,6 +111,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -118,3 +127,6 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrinstructcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructcalleemulti1.checked.c %s
+//RUN: rm %S/fptrarrinstructcalleemulti1.checked.c %S/fptrarrinstructcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
@@ -93,6 +98,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -106,3 +114,6 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
@@ -1,0 +1,84 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrinstructcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructcalleemulti2.checked2.c %s
+//RUN: rm %S/fptrarrinstructcalleemulti1.checked2.c %S/fptrarrinstructcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
         x = (struct arrfptr *) 5; 
@@ -81,4 +98,3 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
@@ -98,3 +98,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -91,6 +96,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -104,6 +110,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -118,3 +127,6 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
@@ -1,0 +1,120 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
@@ -93,6 +98,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -107,3 +115,6 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrinstructcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructcallermulti1.checked.c %s
+//RUN: rm %S/fptrarrinstructcallermulti1.checked.c %S/fptrarrinstructcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
         x = (struct arrfptr *) 5; 
@@ -80,4 +97,3 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
@@ -1,0 +1,83 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrinstructcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructcallermulti2.checked2.c %s
+//RUN: rm %S/fptrarrinstructcallermulti1.checked2.c %S/fptrarrinstructcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
@@ -97,3 +97,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
@@ -1,0 +1,124 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * bar() {
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
@@ -91,6 +96,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -105,6 +113,9 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -122,3 +133,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
@@ -91,6 +96,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -104,6 +112,9 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -121,3 +132,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
@@ -1,0 +1,123 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * bar() {
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
@@ -91,6 +96,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -105,6 +113,9 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -121,3 +132,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
@@ -1,0 +1,123 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct arrfptr * bar() {
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
@@ -1,0 +1,122 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * bar() {
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
@@ -91,6 +96,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -104,6 +112,9 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -120,3 +131,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -91,6 +96,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -104,6 +110,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -117,3 +126,6 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
@@ -1,0 +1,119 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
 //CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
@@ -93,6 +98,9 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK: struct arrfptr * foo() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -106,3 +114,6 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK: struct arrfptr * bar() {
+//CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrinstructsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructsafemulti1.checked.c %s
+//RUN: rm %S/fptrarrinstructsafemulti1.checked.c %S/fptrarrinstructsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
+
+struct arrfptr * foo() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * foo() {
+
+struct arrfptr * bar() {
+ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        
+return z; }
+//CHECK: struct arrfptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
         x = (struct arrfptr *) 5; 
@@ -80,4 +97,3 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
@@ -1,0 +1,83 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrinstructsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrinstructsafemulti2.checked2.c %s
+//RUN: rm %S/fptrarrinstructsafemulti1.checked2.c %S/fptrarrinstructsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
+ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        
+return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
@@ -97,3 +97,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
+//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotoboth.c
@@ -1,0 +1,118 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int ** bar() {
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
@@ -90,6 +95,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -103,6 +111,9 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
 
@@ -116,3 +127,5 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
@@ -90,6 +95,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -102,6 +110,9 @@ int ** bar() {
         
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
 
@@ -115,3 +126,5 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocallee.c
@@ -1,0 +1,117 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** bar() {
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
@@ -90,6 +95,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -103,6 +111,9 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
 
@@ -115,3 +126,5 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocaller.c
@@ -1,0 +1,117 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int ** bar() {
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotosafe.c
@@ -1,0 +1,116 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** bar() {
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>));
@@ -90,6 +95,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -102,6 +110,9 @@ int ** bar() {
         
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
 
@@ -114,3 +125,5 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafe.c
@@ -1,0 +1,113 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *x, int *y) {
 
@@ -87,6 +92,8 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
 
@@ -99,6 +106,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -111,3 +121,6 @@ int ** bar() {
         
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int ** sus(int *, int *);
 //CHECK: int ** sus(int *, int *);
@@ -92,6 +97,9 @@ int ** foo() {
         
 return z; }
 //CHECK: int ** foo() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);
 
 int ** bar() {
 
@@ -104,3 +112,6 @@ int ** bar() {
         
 return z; }
 //CHECK: int ** bar() {
+//CHECK:         int *x = malloc(sizeof(int)); 
+//CHECK:         int *y = calloc(5, sizeof(int)); 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
@@ -1,0 +1,106 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrsafemulti1.checked.c %s
+//RUN: rm %S/fptrarrsafemulti1.checked.c %S/fptrarrsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int ** sus(int *, int *);
+//CHECK: int ** sus(int *, int *);
+
+int ** foo() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** foo() {
+
+int ** bar() {
+
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int ** bar() {

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -93,3 +93,6 @@ int ** sus(int *x, int *y) {
         } 
         
 return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {
+//CHECK:         int **z = calloc(5, sizeof(int *)); 
+//CHECK:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int ** sus(int *x, int *y) {
 
         x = (int *) 5;
@@ -76,4 +93,3 @@ int ** sus(int *x, int *y) {
         } 
         
 return z; }
-//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrsafemulti2.checked2.c %s
+//RUN: rm %S/fptrarrsafemulti1.checked2.c %S/fptrarrsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int ** sus(int *x, int *y) {
+
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        
+return z; }
+//CHECK: int ** sus(int *x, int *y : itype(_Array_ptr<int>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -91,6 +96,8 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");
 
 struct fptrarr * foo() {
  
@@ -109,6 +116,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -128,3 +139,7 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructboth.c
@@ -1,0 +1,130 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
@@ -98,6 +103,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -117,3 +126,7 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
@@ -1,0 +1,119 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrstructbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructbothmulti1.checked.c %s
+//RUN: rm %S/fptrarrstructbothmulti1.checked.c %S/fptrarrstructbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
@@ -97,3 +97,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
@@ -1,0 +1,83 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrstructbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructbothmulti2.checked2.c %s
+//RUN: rm %S/fptrarrstructbothmulti1.checked2.c %S/fptrarrstructbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Array_ptr<int> values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
         x = (struct fptrarr *) 5; 
@@ -80,4 +97,3 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallee.c
@@ -1,0 +1,129 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -91,6 +96,8 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");
 
 struct fptrarr * foo() {
  
@@ -109,6 +116,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -127,3 +138,7 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
@@ -1,0 +1,118 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrstructcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructcalleemulti1.checked.c %s
+//RUN: rm %S/fptrarrstructcalleemulti1.checked.c %S/fptrarrstructcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
@@ -98,6 +103,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -116,3 +125,7 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
@@ -1,0 +1,83 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrstructcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructcalleemulti2.checked2.c %s
+//RUN: rm %S/fptrarrstructcalleemulti1.checked2.c %S/fptrarrstructcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
@@ -97,3 +97,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Array_ptr<int> values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
         x = (struct fptrarr *) 5; 
@@ -80,4 +97,3 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -90,6 +95,8 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");
 
 struct fptrarr * foo() {
  
@@ -108,6 +115,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -127,3 +138,7 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcaller.c
@@ -1,0 +1,129 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
@@ -1,0 +1,119 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrstructcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructcallermulti1.checked.c %s
+//RUN: rm %S/fptrarrstructcallermulti1.checked.c %S/fptrarrstructcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
@@ -98,6 +103,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -117,3 +126,7 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
@@ -96,3 +96,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Array_ptr<int> values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
         x = (struct fptrarr *) 5; 
@@ -79,4 +96,3 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
@@ -1,0 +1,82 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrstructcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructcallermulti2.checked2.c %s
+//RUN: rm %S/fptrarrstructcallermulti1.checked2.c %S/fptrarrstructcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
@@ -1,0 +1,133 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * bar() {
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
@@ -96,6 +101,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -115,6 +124,10 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -131,3 +144,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
@@ -1,0 +1,132 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * bar() {
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
@@ -96,6 +101,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -114,6 +123,10 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -130,3 +143,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
@@ -96,6 +101,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -115,6 +124,10 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -130,3 +143,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
@@ -1,0 +1,132 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptrarr * bar() {
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
@@ -96,6 +101,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -114,6 +123,10 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -129,3 +142,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
@@ -1,0 +1,131 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * bar() {
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafe.c
@@ -1,0 +1,128 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -90,6 +95,8 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");
 
 struct fptrarr * foo() {
  
@@ -108,6 +115,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -126,3 +137,7 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
@@ -1,0 +1,118 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrarrstructsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructsafemulti1.checked.c %s
+//RUN: rm %S/fptrarrstructsafemulti1.checked.c %S/fptrarrstructsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     int *values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
+
+struct fptrarr * foo() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * foo() {
+
+struct fptrarr * bar() {
+ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptrarr * bar() {

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     int *values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     int *values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
 //CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
@@ -98,6 +103,10 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK: struct fptrarr * foo() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -116,3 +125,7 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK: struct fptrarr * bar() {
+//CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
+//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+//CHECK:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
@@ -96,3 +96,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK:         z->name = strcpy(((char *)name), "Hello World");

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Array_ptr<int> values; 
+//CHECK-NEXT:     char *name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
         x = (struct fptrarr *) 5; 
@@ -79,4 +96,3 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
@@ -1,0 +1,82 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrarrstructsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrarrstructsafemulti2.checked2.c %s
+//RUN: rm %S/fptrarrstructsafemulti1.checked2.c %S/fptrarrstructsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
+ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        
+return z; }
+//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -86,6 +91,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -95,6 +101,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -105,3 +114,6 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructboth.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *, struct fptr *);
@@ -89,6 +94,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -99,3 +107,6 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
@@ -1,0 +1,101 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrinstructbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructbothmulti1.checked.c %s
+//RUN: rm %S/fptrinstructbothmulti1.checked.c %S/fptrinstructbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *, struct fptr *);
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
@@ -92,3 +92,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrinstructbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructbothmulti2.checked2.c %s
+//RUN: rm %S/fptrinstructbothmulti1.checked2.c %S/fptrinstructbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
         x = (struct fptr *) 5; 
@@ -75,4 +92,3 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallee.c
@@ -1,0 +1,106 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -86,6 +91,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -95,6 +101,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -104,3 +113,6 @@ struct fptr * bar() {
         
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *, struct fptr *);
@@ -89,6 +94,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -98,3 +106,6 @@ struct fptr * bar() {
         
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrinstructcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructcalleemulti1.checked.c %s
+//RUN: rm %S/fptrinstructcalleemulti1.checked.c %S/fptrinstructcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *, struct fptr *);
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
@@ -92,3 +92,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
         x = (struct fptr *) 5; 
@@ -75,4 +92,3 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrinstructcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructcalleemulti2.checked2.c %s
+//RUN: rm %S/fptrinstructcalleemulti1.checked2.c %S/fptrinstructcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -85,6 +90,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -94,6 +100,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -104,3 +113,6 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcaller.c
@@ -1,0 +1,106 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *, struct fptr *);
@@ -89,6 +94,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -99,3 +107,6 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
@@ -1,0 +1,101 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrinstructcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructcallermulti1.checked.c %s
+//RUN: rm %S/fptrinstructcallermulti1.checked.c %S/fptrinstructcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *, struct fptr *);
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
@@ -91,3 +91,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
@@ -1,0 +1,77 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrinstructcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructcallermulti2.checked2.c %s
+//RUN: rm %S/fptrinstructcallermulti1.checked2.c %S/fptrinstructcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
         x = (struct fptr *) 5; 
@@ -74,4 +91,3 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
@@ -87,6 +92,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -97,6 +105,9 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -108,3 +119,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * bar() {
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
@@ -87,6 +92,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -96,6 +104,9 @@ struct fptr * bar() {
         
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -107,3 +118,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * bar() {
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: struct fptr * bar() {
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
@@ -87,6 +92,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -97,6 +105,9 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -107,3 +118,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
@@ -87,6 +92,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -96,6 +104,9 @@ struct fptr * bar() {
         
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -106,3 +117,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * bar() {
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafe.c
@@ -1,0 +1,105 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (int *)> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (int *)> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -85,6 +90,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -94,6 +100,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -103,3 +112,6 @@ struct fptr * bar() {
         
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
 //CHECK: struct fptr * sus(struct fptr *, struct fptr *);
@@ -89,6 +94,9 @@ struct fptr * foo() {
         
 return z; }
 //CHECK: struct fptr * foo() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -98,3 +106,6 @@ struct fptr * bar() {
         
 return z; }
 //CHECK: struct fptr * bar() {
+//CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
+//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
+//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrinstructsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructsafemulti1.checked.c %s
+//RUN: rm %S/fptrinstructsafemulti1.checked.c %S/fptrinstructsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+struct fptr * sus(struct fptr *, struct fptr *);
+//CHECK: struct fptr * sus(struct fptr *, struct fptr *);
+
+struct fptr * foo() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * foo() {
+
+struct fptr * bar() {
+ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        
+return z; }
+//CHECK: struct fptr * bar() {

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
@@ -91,3 +91,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
@@ -1,0 +1,77 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrinstructsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrinstructsafemulti2.checked2.c %s
+//RUN: rm %S/fptrinstructsafemulti1.checked2.c %S/fptrinstructsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+struct fptr * sus(struct fptr *x, struct fptr *y) {
+ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        
+return z; }
+//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (int *)> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
         x = (struct fptr *) 5; 
@@ -74,4 +91,3 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {

--- a/clang/test/CheckedCRewriter/fptrsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -88,6 +93,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -104,6 +111,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -121,3 +133,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeboth.c
@@ -1,0 +1,123 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
@@ -1,0 +1,115 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrsafebothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafebothmulti1.checked.c %s
+//RUN: rm %S/fptrsafebothmulti1.checked.c %S/fptrsafebothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -113,3 +123,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
@@ -94,3 +94,6 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrsafebothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafebothmulti2.checked2.c %s
+//RUN: rm %S/fptrsafebothmulti1.checked2.c %S/fptrsafebothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -77,4 +94,3 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallee.c
@@ -1,0 +1,122 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -88,6 +93,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -104,6 +111,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -120,3 +132,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
@@ -1,0 +1,114 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrsafecalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafecalleemulti1.checked.c %s
+//RUN: rm %S/fptrsafecalleemulti1.checked.c %S/fptrsafecalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -112,3 +122,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
@@ -94,3 +94,6 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -77,4 +94,3 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrsafecalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafecalleemulti2.checked2.c %s
+//RUN: rm %S/fptrsafecalleemulti1.checked2.c %S/fptrsafecalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafecaller.c
@@ -1,0 +1,122 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafecaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -87,6 +92,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -103,6 +110,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -120,3 +132,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
@@ -1,0 +1,115 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrsafecallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafecallermulti1.checked.c %s
+//RUN: rm %S/fptrsafecallermulti1.checked.c %S/fptrsafecallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -113,3 +123,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrsafecallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafecallermulti2.checked2.c %s
+//RUN: rm %S/fptrsafecallermulti1.checked2.c %S/fptrsafecallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -76,4 +93,3 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
@@ -93,3 +93,6 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
@@ -1,0 +1,126 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -111,6 +121,11 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -124,3 +139,5 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -110,6 +120,11 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -123,3 +138,5 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
@@ -1,0 +1,125 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
@@ -1,0 +1,125 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -111,6 +121,11 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -123,3 +138,5 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -110,6 +120,11 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -122,3 +137,5 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
@@ -1,0 +1,124 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -87,6 +92,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -103,6 +110,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -119,3 +131,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafe.c
@@ -1,0 +1,121 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
@@ -1,0 +1,114 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrsafesafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafesafemulti1.checked.c %s
+//RUN: rm %S/fptrsafesafemulti1.checked.c %S/fptrsafesafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
 
@@ -112,3 +122,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrsafesafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrsafesafemulti2.checked2.c %s
+//RUN: rm %S/fptrsafesafemulti1.checked2.c %S/fptrsafesafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -76,4 +93,3 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
@@ -93,3 +93,6 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -88,6 +93,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -104,6 +111,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -121,3 +133,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeboth.c
@@ -1,0 +1,123 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
@@ -1,0 +1,115 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrunsafebothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafebothmulti1.checked.c %s
+//RUN: rm %S/fptrunsafebothmulti1.checked.c %S/fptrunsafebothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -113,3 +123,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
@@ -94,3 +94,6 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrunsafebothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafebothmulti2.checked2.c %s
+//RUN: rm %S/fptrunsafebothmulti1.checked2.c %S/fptrunsafebothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -77,4 +94,3 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -88,6 +93,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -104,6 +111,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -120,3 +132,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallee.c
@@ -1,0 +1,122 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -112,3 +122,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
@@ -1,0 +1,114 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrunsafecalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafecalleemulti1.checked.c %s
+//RUN: rm %S/fptrunsafecalleemulti1.checked.c %S/fptrunsafecalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
@@ -94,3 +94,6 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
@@ -1,0 +1,80 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrunsafecalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafecalleemulti2.checked2.c %s
+//RUN: rm %S/fptrunsafecalleemulti1.checked2.c %S/fptrunsafecalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -77,4 +94,3 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecaller.c
@@ -1,0 +1,122 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -87,6 +92,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -103,6 +110,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -120,3 +132,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -113,3 +123,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
@@ -1,0 +1,115 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrunsafecallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafecallermulti1.checked.c %s
+//RUN: rm %S/fptrunsafecallermulti1.checked.c %S/fptrunsafecallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -76,4 +93,3 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrunsafecallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafecallermulti2.checked2.c %s
+//RUN: rm %S/fptrunsafecallermulti1.checked2.c %S/fptrunsafecallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
@@ -93,3 +93,6 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
@@ -1,0 +1,126 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -111,6 +121,11 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -124,3 +139,5 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
@@ -1,0 +1,125 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+z += 2;
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -110,6 +120,11 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -123,3 +138,5 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
@@ -1,0 +1,125 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -111,6 +121,11 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -123,3 +138,5 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *x, struct general *y);
@@ -94,6 +99,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -110,6 +120,11 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
 
@@ -122,3 +137,5 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
@@ -1,0 +1,124 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *x, struct general *y);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *x, struct general *y) {
 
@@ -87,6 +92,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -103,6 +110,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -119,3 +131,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafe.c
@@ -1,0 +1,121 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     struct general *next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
 //CHECK: int * sus(struct general *, struct general *);
@@ -96,6 +101,11 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);
 
 int * bar() {
 
@@ -112,3 +122,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         struct general *x = malloc(sizeof(struct general)); 
+//CHECK:         struct general *y = malloc(sizeof(struct general));
+//CHECK:         struct general *curr = y;
+//CHECK:         _Ptr<int (struct fptr *, struct fptr *)> sus_ptr =  sus;   
+//CHECK:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
@@ -1,0 +1,114 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/fptrunsafesafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafesafemulti1.checked.c %s
+//RUN: rm %S/fptrunsafesafemulti1.checked.c %S/fptrunsafesafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     struct general *next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, struct general *);
+
+int * foo() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     struct general *next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(struct general *x, struct general *y) {
 
         x = (struct general *) 5;
@@ -76,4 +93,3 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/fptrunsafesafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/fptrunsafesafemulti2.checked2.c %s
+//RUN: rm %S/fptrunsafesafemulti1.checked2.c %S/fptrunsafesafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(struct general *x, struct general *y) {
+
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        
+return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
@@ -93,3 +93,6 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
+//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK:         int *z = calloc(5, sizeof(int)); 
+//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/ptrTOptrboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -93,6 +98,10 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -100,6 +109,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -108,3 +120,6 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrboth.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+z += 2;
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
@@ -1,0 +1,97 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/ptrTOptrbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrbothmulti1.checked.c %s
+//RUN: rm %S/ptrTOptrbothmulti1.checked.c %S/ptrTOptrbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char * * *, char * * *);
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char * * *, char * * *);
@@ -87,6 +92,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -95,3 +103,6 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
@@ -99,3 +99,8 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
@@ -1,0 +1,85 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/ptrTOptrbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrbothmulti2.checked2.c %s
+//RUN: rm %S/ptrTOptrbothmulti1.checked2.c %S/ptrTOptrbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+z += 2;
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
         char *ch = malloc(sizeof(char)); 
@@ -82,4 +99,3 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrcallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallee.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+z += 2;
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrcallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -93,6 +98,10 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -100,6 +109,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -107,3 +119,6 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char * * *, char * * *);
@@ -87,6 +92,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -94,3 +102,6 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
@@ -1,0 +1,96 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/ptrTOptrcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrcalleemulti1.checked.c %s
+//RUN: rm %S/ptrTOptrcalleemulti1.checked.c %S/ptrTOptrcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char * * *, char * * *);
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
@@ -1,0 +1,85 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/ptrTOptrcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrcalleemulti2.checked2.c %s
+//RUN: rm %S/ptrTOptrcalleemulti1.checked2.c %S/ptrTOptrcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+z += 2;
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
@@ -99,3 +99,8 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
         char *ch = malloc(sizeof(char)); 
@@ -82,4 +99,3 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrcaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -92,6 +97,10 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -99,6 +108,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -107,3 +119,6 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcaller.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char * * *, char * * *);
@@ -87,6 +92,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -95,3 +103,6 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
@@ -1,0 +1,97 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/ptrTOptrcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrcallermulti1.checked.c %s
+//RUN: rm %S/ptrTOptrcallermulti1.checked.c %S/ptrTOptrcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char * * *, char * * *);
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
         char *ch = malloc(sizeof(char)); 
@@ -81,4 +98,3 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
@@ -1,0 +1,84 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/ptrTOptrcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrcallermulti2.checked2.c %s
+//RUN: rm %S/ptrTOptrcallermulti1.checked2.c %S/ptrTOptrcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
@@ -98,3 +98,8 @@ x = (char * * *) 5;
         }
         
 return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
@@ -85,6 +90,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -93,6 +101,9 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -111,3 +122,7 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
@@ -1,0 +1,113 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: char *** bar() {
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+z += 2;
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
@@ -1,0 +1,112 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** bar() {
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+z += 2;
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
@@ -85,6 +90,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -92,6 +100,9 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -110,3 +121,7 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
@@ -85,6 +90,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -93,6 +101,9 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -110,3 +121,7 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
@@ -1,0 +1,112 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+z += 2;
+return z; }
+//CHECK: char *** bar() {
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
@@ -1,0 +1,111 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** bar() {
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
@@ -85,6 +90,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -92,6 +100,9 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -109,3 +120,7 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrsafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafe.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrsafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -92,6 +97,10 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -99,6 +108,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -106,3 +118,6 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
 //CHECK: char *** sus(char * * *, char * * *);
@@ -87,6 +92,9 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** foo() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -94,3 +102,6 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK: char *** bar() {
+//CHECK:         char * * * x = malloc(sizeof(char * *));
+//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
@@ -1,0 +1,96 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/ptrTOptrsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrsafemulti1.checked.c %s
+//RUN: rm %S/ptrTOptrsafemulti1.checked.c %S/ptrTOptrsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+char *** sus(char * * *, char * * *);
+//CHECK: char *** sus(char * * *, char * * *);
+
+char *** foo() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** foo() {
+
+char *** bar() {
+        char * * * x = malloc(sizeof(char * *));
+        char * * * y = malloc(sizeof(char * *));
+        char *** z = sus(x, y);
+return z; }
+//CHECK: char *** bar() {

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
         char *ch = malloc(sizeof(char)); 
@@ -81,4 +98,3 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
@@ -1,0 +1,84 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/ptrTOptrsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/ptrTOptrsafemulti2.checked2.c %s
+//RUN: rm %S/ptrTOptrsafemulti1.checked2.c %S/ptrTOptrsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+char *** sus(char * * * x, char * * * y) {
+x = (char * * *) 5;
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        
+return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
@@ -98,3 +98,8 @@ x = (char * * *) 5;
         }
         
 return z; }
+//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK:         char *ch = malloc(sizeof(char)); 
+//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:             z[i] = malloc(5*sizeof(char *)); 
+//CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/safefptrargboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -87,6 +92,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -96,6 +102,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -106,3 +114,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargboth.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
@@ -1,0 +1,101 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/safefptrargbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargbothmulti1.checked.c %s
+//RUN: rm %S/safefptrargbothmulti1.checked.c %S/safefptrargbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -99,3 +106,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
@@ -93,3 +93,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/safefptrargbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargbothmulti2.checked2.c %s
+//RUN: rm %S/safefptrargbothmulti1.checked2.c %S/safefptrargbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -76,4 +93,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargcallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallee.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargcallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -87,6 +92,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -96,6 +102,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -105,3 +113,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/safefptrargcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargcalleemulti1.checked.c %s
+//RUN: rm %S/safefptrargcalleemulti1.checked.c %S/safefptrargcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -98,3 +105,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
@@ -93,3 +93,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/safefptrargcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargcalleemulti2.checked2.c %s
+//RUN: rm %S/safefptrargcalleemulti1.checked2.c %S/safefptrargcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -76,4 +93,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargcaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -86,6 +91,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -95,6 +101,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -105,3 +113,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargcaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargcaller.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
@@ -1,0 +1,101 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/safefptrargcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargcallermulti1.checked.c %s
+//RUN: rm %S/safefptrargcallermulti1.checked.c %S/safefptrargcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -99,3 +106,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/safefptrargcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargcallermulti2.checked2.c %s
+//RUN: rm %S/safefptrargcallermulti1.checked2.c %S/safefptrargcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -75,4 +92,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
@@ -92,3 +92,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotoboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -97,6 +104,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -109,3 +118,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotoboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotoboth.c
@@ -1,0 +1,111 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargprotocallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocallee.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargprotocallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -96,6 +103,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -108,3 +117,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotocaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocaller.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargprotocaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -97,6 +104,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -108,3 +117,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotosafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotosafe.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargprotosafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -96,6 +103,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -107,3 +116,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargsafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -86,6 +91,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -95,6 +101,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -104,3 +112,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargsafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafe.c
@@ -1,0 +1,106 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/safefptrargsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargsafemulti1.checked.c %s
+//RUN: rm %S/safefptrargsafemulti1.checked.c %S/safefptrargsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -98,3 +105,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/safefptrargsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/safefptrargsafemulti2.checked2.c %s
+//RUN: rm %S/safefptrargsafemulti1.checked2.c %S/safefptrargsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -75,4 +92,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
@@ -92,3 +92,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/testgenerator.py
+++ b/clang/test/CheckedCRewriter/testgenerator.py
@@ -616,7 +616,7 @@ def annot_gen(prefix, proto, suffix):
                 indefs = True
 
             # annotate the definition for sus
-            elif proto != "multi" and line.find("sus") != -1 and line.find("{") != -1: 
+            elif line.find("sus") != -1 and line.find("{") != -1: 
                 indefs = insus = infoo = inbar = False
                 insus = True
                 susc += "//CHECK: " + line

--- a/clang/test/CheckedCRewriter/testgenerator.py
+++ b/clang/test/CheckedCRewriter/testgenerator.py
@@ -1,0 +1,591 @@
+# Author: Shilpa Roy 
+# Last updated: May 9, 2020
+
+import itertools as it
+import os
+
+
+#### USERS PUT YOUR INFO HERE ##### 
+
+# Please remember to add a '/' at the very end!
+path_to_monorepo = "~/checkedc-clang/"
+
+
+
+prefixes = ["arr", "arrstruct", "arrinstruct", "arrofstruct", "safefptrarg", "unsafefptrarg", "fptrsafe", "fptrunsafe", "fptrarr", "fptrarrstruct", "fptrinstruct", "fptrarrinstruct", "ptrTOptr"] 
+addendums = ["", "proto", "multi"] 
+
+# casts are a whole different ballgame so leaving out for now, 
+# but they can always be added in later by adding them to the cartesian product
+# casts = ["", "expcastunsafe", "expcastsafe", "impcast"]
+
+suffixes = ["safe", "callee", "caller", "both"]
+
+# generate testnames by taking the cartesian product of the above
+testnames = [] 
+for e in it.product(prefixes, addendums, suffixes): 
+    testnames.append([e[0], e[1], e[2]]) 
+
+
+### FILE GENERATION ###
+
+# A typical program:
+#####################################################################
+#   header (llvm-lit run command, #defines, stdlib checked protos)
+#
+#   definitions (struct definitions, function prototypes)
+#   CHECK annotation for definitions 
+#
+#   f1 (foo, bar, sus) 
+#   CHECK annotation for f1 
+#
+#   f2 (foo, bar, sus) - (f1) 
+#   CHECK annotation for f2 
+#
+#   f3 (foo, bar, sus) - (f1, f2)
+#   CHECK annotation for f3 
+#####################################################################
+
+# header that should top every file
+header = """
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));\n""" 
+
+# miscallaneous struct definitions that may or may not be used by the files above
+definitions = """
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+"""
+
+# this function will generate a C file that contains 
+# the core of the example (before the addition of checked annotations)
+def method_gen(prefix, proto, suffix): 
+    return_type = arg_type = susbody = foobody = barbody = foo = bar = sus = susproto = ""
+
+    # main processing to distinguish between the different types of test we wish to create
+    if prefix=="arr": 
+        return_type = "int *" 
+        arg_type = "int *" 
+        susbody = """
+        int *z = calloc(5, sizeof(int)); 
+        for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
+        { *p = fac; }"""
+    elif prefix=="arrstruct":
+        return_type = "int *" 
+        arg_type = "struct general *" 
+        barbody = foobody = """
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        """
+        susbody = """
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        """
+    elif prefix=="arrinstruct":
+        return_type = "struct warr *" 
+        arg_type = "struct warr *"
+        susbody = """
+        char name[20]; 
+        struct warr *z = y;
+        z->name[1] = 'H';
+        struct warr *p = z;
+        for(int i = 0; i < 5; i++) { 
+            z->data1[i] = i; 
+        }
+        """
+    elif prefix=="arrofstruct":
+        return_type = "struct general **"
+        arg_type = "struct general *" 
+        susbody = """ 
+        struct general **z = calloc(5, sizeof(struct general *));
+        struct general *curr = y;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = curr; 
+            curr = curr->next; 
+        } 
+        """ 
+        barbody = foobody = """
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        """ 
+    elif prefix=="safefptrarg": 
+        sus = "\nint * sus(int (*x) (int), int (*y) (int)) {\n"
+        susproto = "\nint * sus(int (*) (int), int (*) (int));\n"
+        foo = "\nint * foo() {\n"
+        bar = "\nint * bar() {\n"
+        susbody = """ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        """
+        foobody = barbody = """ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *z = sus(x, y);
+        """
+    elif prefix=="unsafefptrarg":
+        sus = "\nint * sus(int (*x) (int), int (*y) (int)) {\n"
+        susproto = "\nint * sus(int (*) (int), int (*) (int));\n"
+        foo = "\nint * foo() {\n"
+        bar = "\nint * bar() {\n"
+        susbody = """ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        """
+        foobody = barbody = """ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        """
+    elif prefix=="safefptrs": 
+        susproto = "\nint * (*sus(int (*) (int), int (*) (int))) (int *);\n"
+        sus = "\nint * (*sus(int (*x) (int), int (*y) (int))) (int *) {\n"
+        foo = "\nint * (*foo(void)) (int *) {\n"
+        bar = "\nint * (*bar(void)) (int *) {\n" 
+        susbody = """ 
+        x = (int (*) (int)) 5; 
+        int * (*z)(int *) = mul2;
+        """
+        foobody = barbody = """
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *(*z)(int *) = sus(x, y);
+        """
+    elif prefix=="unsafefptrs": 
+        susproto = "\nchar * (*sus(int (*) (int), int (*) (int))) (int *);\n"
+        sus = "\nchar * (*sus(int (*x) (int), int (*y) (int))) (int *) {\n"
+        foo = "\nchar * (*foo(void)) (int *) {\n"
+        bar = "\nchar * (*bar(void)) (int *) {\n" 
+        susbody = """ 
+        x = (int (*) (int)) 5; 
+        char * (*z)(int *) = fib;
+        """
+        foobody = barbody = """
+        int (*x)(int) = add1; 
+        int (*y)(int) = sub1; 
+        int *(*z)(int *) = sus(x, y);
+        """
+    elif prefix=="fptrsafe":
+        sus = "\nint * sus(struct general *x, struct general *y) {\n"
+        susproto = "\nint * sus(struct general *, struct general *);\n"
+        foo = "\nint * foo() {\n"
+        bar = "\nint * bar() {\n"
+        barbody = foobody = """
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int * (*sus_ptr)(struct general *, struct general *) = sus;   
+        int *z = sus_ptr(x, y);
+        """
+        susbody = """
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        """
+    elif prefix=="fptrunsafe":
+        sus = "\nint * sus(struct general *x, struct general *y) {\n"
+        susproto = "\nint * sus(struct general *, struct general *);\n"
+        foo = "\nint * foo() {\n"
+        bar = "\nint * bar() {\n"
+        barbody = foobody = """
+        struct general *x = malloc(sizeof(struct general)); 
+        struct general *y = malloc(sizeof(struct general));
+        struct general *curr = y;
+        for(int i = 1; i < 5; i++, curr = curr->next) { 
+            curr->data = i;
+            curr->next = malloc(sizeof(struct general));
+            curr->next->data = i+1;
+        }
+        int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
+        int *z = (int *) sus_ptr(x, y);
+        """
+        susbody = """
+        x = (struct general *) 5;
+        int *z = calloc(5, sizeof(int)); 
+        struct general *p = y;
+        for(int i = 0; i < 5; p = p->next, i++) { 
+            z[i] = p->data; 
+        } 
+        """
+    elif prefix=="fptrarr":
+        sus = "\nint ** sus(int *x, int *y) {\n"
+        susproto = "\nint ** sus(int *, int *);\n"
+        foo = "\nint ** foo() {\n"
+        bar = "\nint ** bar() {\n"
+        susbody = """
+        x = (int *) 5;
+        int **z = calloc(5, sizeof(int *)); 
+        int * (*mul2ptr) (int *) = mul2;
+        for(int i = 0; i < 5; i++) { 
+            z[i] = mul2ptr(&y[i]);
+        } 
+        """
+        foobody = barbody = """
+        int *x = malloc(sizeof(int)); 
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) { 
+            y[i] = i+1;
+        } 
+        int *z = sus(x, y);
+        """
+    elif prefix=="arrOFfptr":
+        sus = "\nint (**sus(int *x, int *y)) (int) { \n"
+        susproto = "\nint (**sus(int *x, int *y)) (int);\n" 
+        foo = "\nint (**foo(void)) (int) {"
+        bar = "\nint (**bar(void)) (int) {"
+
+        foobody = barbody = """
+        int *x = malloc(sizeof(int));
+        int *y = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            y[i] = i+1;
+        } 
+        int (**z)(int) = sus(x, y);
+        """
+
+        susbody= """ 
+        x = (int *) 5;
+        int (**z)(int) = calloc(5, sizeof(int (*) (int))); 
+        z[0] = add1;
+        z[1] = sub1; 
+        z[2] = zerohuh;
+        z[3] = fib;
+        z[4] = fact;
+        
+        for(int i = 0; i < 5; i++) { 
+            y[i] = z[i](y[i]);
+        }
+        """
+    elif prefix=="fptrinstruct":
+        sus = "\nstruct fptr * sus(struct fptr *x, struct fptr *y) {\n"
+        susproto = "\nstruct fptr * sus(struct fptr *, struct fptr *);\n"
+        foo = "\nstruct fptr * foo() {\n"
+        bar = "\nstruct fptr * bar() {\n"
+        susbody = """ 
+        x = (struct fptr *) 5; 
+        struct fptr *z = malloc(sizeof(struct fptr)); 
+        z->value = y->value; 
+        z->func = fact;
+        """
+        foobody = barbody = """ 
+        struct fptr * x = malloc(sizeof(struct fptr)); 
+        struct fptr *y =  malloc(sizeof(struct fptr));
+        struct fptr *z = sus(x, y);
+        """
+    elif prefix=="fptrarrstruct":
+        sus = "\nstruct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {\n"
+        susproto = "\nstruct fptrarr * sus(struct fptrarr *, struct fptrarr *);\n"
+        foo = "\nstruct fptrarr * foo() {\n"
+        bar = "\nstruct fptrarr * bar() {\n"
+        susbody = """ 
+        x = (struct fptrarr *) 5; 
+        char name[30]; 
+        struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+        z->values = y->values; 
+        z->name = strcpy(name, "Hello World");
+        z->mapper = fact; 
+        for(int i = 0; i < 5; i++) { 
+            z->values[i] = z->mapper(z->values[i]);
+        }
+        """ 
+        foobody = barbody = """ 
+        char name[20]; 
+        struct fptrarr * x = malloc(sizeof(struct fptrarr));
+        struct fptrarr *y =  malloc(sizeof(struct fptrarr));
+        int *yvals = calloc(5, sizeof(int)); 
+        for(int i = 0; i < 5; i++) {
+            yvals[i] = i+1; 
+            }  
+        y->values = yvals; 
+        y->name = name; 
+        y->mapper = NULL;
+        strcpy(y->name, "Example"); 
+        struct fptrarr *z = sus(x, y);
+        """ 
+    elif prefix=="fptrarrinstruct":
+        sus = "\nstruct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {\n"
+        susproto = "\nstruct arrfptr * sus(struct arrfptr *, struct arrfptr *);\n"
+        foo = "\nstruct arrfptr * foo() {\n"
+        bar = "\nstruct arrfptr * bar() {\n"
+        susbody = """ 
+        x = (struct arrfptr *) 5; 
+        struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = i + 1; 
+        } 
+        z->funcs[0] = add1;
+        z->funcs[1] = sub1; 
+        z->funcs[2] = zerohuh;
+        z->funcs[3] = fib;
+        z->funcs[4] = fact;
+        """ 
+        foobody = barbody = """ 
+        struct arrfptr * x = malloc(sizeof(struct arrfptr));
+        struct arrfptr * y =  malloc(sizeof(struct arrfptr));
+       
+        struct arrfptr *z = sus(x, y); 
+        for(int i = 0; i < 5; i++) { 
+            z->args[i] = z->funcs[i](z->args[i]);
+        }
+        """
+    elif prefix=="ptrTOptr":
+        return_type = "char ***"
+        arg_type = "char * * *"
+        susbody = """
+        char *ch = malloc(sizeof(char)); 
+        *ch = 'A'; /*Capital A*/
+        char *** z = malloc(5*sizeof(char**)); 
+        for(int i = 0; i < 5; i++) { 
+            z[i] = malloc(5*sizeof(char *)); 
+            for(int j = 0; j < 5; j++) { 
+                z[i][j] = malloc(2*sizeof(char)); 
+                strcpy(z[i][j], ch);
+                *ch = *ch + 1; 
+            }
+        }
+        """
+
+    # generate standard enders and duplications that occur in all generated tests
+
+    if not "fptr" in prefix: 
+        barbody += "{} z = sus(x, y);".format(return_type) 
+        foobody += "{} z = sus(x, y);".format(return_type)
+        data = [return_type, arg_type, arg_type]
+        susproto = "\n{} sus({}, {});\n".format(*data)
+        sus = "\n{} sus({} x, {} y) {}\nx = ({}) 5;".format(data[0], data[1], data[2], "{", arg_type)
+        arg_np = " ".join(arg_type.split(" ")[:-1])
+        foo = """\n{} foo() {}
+        {} x = malloc(sizeof({}));
+        {} y = malloc(sizeof({}));
+        """.format(return_type, "{", arg_type, arg_np, arg_type, arg_np) 
+        bar = """\n{} bar() {}
+        {} x = malloc(sizeof({}));
+        {} y = malloc(sizeof({}));
+        """.format(return_type, "{", arg_type, arg_np, arg_type, arg_np)       
+        
+    # create unsafe use cases based on the suffix (by default, the generated code is safe)
+
+    if suffix == "both": 
+        susbody += "\nz += 2;"
+        barbody += "\nz += 2;" 
+    elif suffix == "callee": 
+        susbody += "\nz += 2;" 
+    elif suffix == "caller": 
+        barbody += "\nz += 2;"
+    
+    susbody += "\nreturn z; }\n"
+    foobody += "\nreturn z; }\n" 
+    barbody += "\nreturn z; }\n"
+
+    return [susproto, sus+susbody, foo+foobody, bar+barbody] 
+
+# this function will generate a C file using method_gen(), 
+# run the porting tool on that C file, and generate a new
+# C file that contains the annotations for llvm-lit
+def annot_gen(prefix, proto, suffix): 
+    # generate the body of the file
+    [susproto, sus, foo, bar] = method_gen(prefix, proto, suffix) 
+    name = prefix + proto + suffix + ".c"
+    cname = prefix + proto + suffix + ".checked.c"  
+    name2 = name 
+    cname2 = cname
+
+    if proto=="multi": 
+        name = prefix + suffix + proto + "1.c" 
+        name2 = prefix + suffix + proto + "2.c"
+        cname = prefix + suffix + proto + "1.checked.c"
+        cname2 = prefix + suffix + proto + "2.checked.c"
+    
+    if proto=="proto": test = header + definitions + susproto + foo + bar + sus
+    elif proto=="multi": test = header + definitions + susproto + foo + bar
+    else: test = header + definitions + sus + foo + bar 
+
+    # write the main file 
+    file = open(name, "w+") 
+    file.write(test)
+    file.close() 
+    
+    # generate the second file if a multi example
+    if proto=="multi": 
+        test2 = header + definitions + sus
+        file = open(name2, "w+") 
+        file.write(test2)
+        file.close()
+    
+    # run the porting tool on the file(s)
+    if proto=="multi": 
+        os.system("{}build/bin/cconv-standalone -alltypes -output-postfix=checked {} {}".format(path_to_monorepo, name, name2))
+        os.system("rm {} {}".format(name, name2))
+    else: 
+        os.system("{}build/bin/cconv-standalone -alltypes -output-postfix=checked {}".format(path_to_monorepo, name))
+        os.system("rm {}".format(name))
+    
+    # read the checked generated file for new types
+    file = open(cname, "r")
+    susprotoc = susc = fooc = barc = ""
+    defchecked = "" 
+    found1 = found2 = found3 = found4 = found5 = found6 = found7 = found8 = False
+
+    # generate the check annotations
+    for line in file.readlines(): 
+        if proto != "" and line.find("sus") != -1 and line.find("=") == -1 and line.find(";") != -1: 
+            susprotoc += "//CHECK: " + line 
+        elif proto != "multi" and line.find("sus") != -1 and line.find("{") != -1: 
+            susc += "//CHECK: " + line
+        elif line.find("foo") != -1:
+            fooc += "//CHECK: " + line 
+        elif line.find("bar") != -1: 
+            barc += "//CHECK: " + line
+        elif line.find("name") != -1 and (not found6): 
+            found6 = True 
+            defchecked += "//CHECK: " + line
+        elif line.find("args") != -1 and (not found7): 
+            found7 = True 
+            defchecked += "//CHECK: " + line 
+        elif line.find("funcs") != -1 and (not found8): 
+            found8 = True 
+            defchecked += "//CHECK: " + line
+        elif line.find("general") != -1 and line.find(";") != -1 and (not found1): 
+            found1 = True
+            defchecked += "//CHECK: " + line
+        elif line.find("data1") != -1 and line.find(";") != -1 and (not found2): 
+            found2 = True 
+            defchecked += "\n//CHECK: " + line
+        elif line.find("values") != -1 and line.find(";") != -1 and (not found3): 
+            found3 = True 
+            defchecked += "\n//CHECK: " + line
+        elif line.find("mapper") != -1 and line.find(";") != -1 and (not found4): 
+            found4 = True 
+            defchecked += "\n//CHECK: " + line
+        elif line.find("func") != -1 and line.find(";") != -1 and (not found5): 
+            found5 = True 
+            defchecked += "\n//CHECK: " + line
+    
+    if proto=="multi": 
+        file2 = open(cname2, "r")
+        for line in file2.readlines(): 
+            if line.find("sus") != -1 and line.find("{") != -1: 
+                susc += "//CHECK: " + line
+        file2.close()
+    
+    file.close() 
+    os.system("rm {}".format(cname))
+    if proto=="multi": os.system("rm {}".format(cname2))
+
+    run = "// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s"
+    run2 = ""
+    if proto=="multi": 
+        run = "// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/" + name2 
+        run += "\n//RUN: FileCheck -match-full-lines --input-file %S/{} %s".format(cname)
+        run += "\n//RUN: rm %S/{} %S/{}".format(cname, cname2)
+        cname21 = prefix + suffix + proto + "1.checked2.c"
+        cname22 = prefix + suffix + proto + "2.checked2.c"
+        run2 = "// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/" + name 
+        run2 += "\n//RUN: FileCheck -match-full-lines --input-file %S/{} %s".format(cname22) 
+        run2 += "\n//RUN: rm %S/{} %S/{}".format(cname21, cname22)
+
+    # generate the final file with all annotations
+    ctest = run + header + definitions + defchecked + sus + susc + foo + fooc + bar + barc
+    if proto == "proto": 
+        ctest = run + header + definitions + defchecked + susproto + susprotoc + foo + fooc + bar + barc + sus + susc
+    elif proto == "multi": 
+        ctest = run + header + definitions + defchecked + susproto + susprotoc + foo + fooc + bar + barc
+        ctest2 = run2 + header + definitions + sus + susc
+    
+    file = open(name, "w+") 
+    file.write(ctest) 
+    file.close() 
+    if proto=="multi": 
+        file = open(name2, "w+") 
+        file.write(ctest2) 
+        file.close()
+
+    return
+
+#arr, arrinstruct, arrofstruct
+if __name__ == "__main__":
+    for skeleton in testnames: 
+        annot_gen(skeleton[0], skeleton[1], skeleton[2])

--- a/clang/test/CheckedCRewriter/unsafefptrargboth.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -87,6 +92,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -96,6 +102,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -106,3 +114,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargboth.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargboth.c
@@ -1,0 +1,108 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargbothmulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargbothmulti1.c
@@ -1,0 +1,101 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/unsafefptrargbothmulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargbothmulti1.checked.c %s
+//RUN: rm %S/unsafefptrargbothmulti1.checked.c %S/unsafefptrargbothmulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargbothmulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargbothmulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -99,3 +106,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargbothmulti2.c
@@ -93,3 +93,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargbothmulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/unsafefptrargbothmulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargbothmulti2.checked2.c %s
+//RUN: rm %S/unsafefptrargbothmulti1.checked2.c %S/unsafefptrargbothmulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargbothmulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -76,4 +93,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargcallee.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -87,6 +92,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -96,6 +102,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -105,3 +113,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargcallee.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcallee.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcalleemulti1.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/unsafefptrargcalleemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargcalleemulti1.checked.c %s
+//RUN: rm %S/unsafefptrargcalleemulti1.checked.c %S/unsafefptrargcalleemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcalleemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -98,3 +105,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcalleemulti2.c
@@ -93,3 +93,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcalleemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -76,4 +93,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcalleemulti2.c
@@ -1,0 +1,79 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/unsafefptrargcalleemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargcalleemulti2.checked2.c %s
+//RUN: rm %S/unsafefptrargcalleemulti1.checked2.c %S/unsafefptrargcalleemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargcaller.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -86,6 +91,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -95,6 +101,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -105,3 +113,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargcaller.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcaller.c
@@ -1,0 +1,107 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargcallermulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcallermulti1.c
@@ -1,0 +1,101 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/unsafefptrargcallermulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargcallermulti1.checked.c %s
+//RUN: rm %S/unsafefptrargcallermulti1.checked.c %S/unsafefptrargcallermulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargcallermulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcallermulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -99,3 +106,5 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcallermulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -75,4 +92,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcallermulti2.c
@@ -92,3 +92,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargcallermulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/unsafefptrargcallermulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargcallermulti2.checked2.c %s
+//RUN: rm %S/unsafefptrargcallermulti1.checked2.c %S/unsafefptrargcallermulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargprotoboth.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotoboth.c
@@ -1,0 +1,111 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargprotoboth.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotoboth.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -97,6 +104,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -109,3 +118,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargprotocallee.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotocallee.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+z += 2;
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargprotocallee.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotocallee.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -96,6 +103,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -108,3 +117,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargprotocaller.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotocaller.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -97,6 +104,8 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -108,3 +117,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargprotocaller.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotocaller.c
@@ -1,0 +1,110 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+z += 2;
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargprotosafe.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotosafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
@@ -87,6 +92,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -96,6 +103,8 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -107,3 +116,4 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargprotosafe.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargprotosafe.c
@@ -1,0 +1,109 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y);
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargsafe.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargsafe.c
@@ -12,27 +12,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -63,18 +78,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*x) (int), int (*y) (int)) {
  
@@ -86,6 +91,7 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));
 
 int * foo() {
  
@@ -95,6 +101,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -104,3 +112,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargsafe.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargsafe.c
@@ -1,0 +1,106 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargsafemulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargsafemulti1.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -65,18 +80,8 @@ int *mul2(int *x) {
     *x *= 2; 
     return x;
 }
-//CHECK:     _Ptr<struct general> next;
 
-//CHECK:     int data1 _Checked[5];
-//CHECK:     _Ptr<char> name;
-
-//CHECK:     _Ptr<int> values; 
-
-//CHECK:     _Ptr<int (int )> mapper;
-
-//CHECK:     _Ptr<int (_Ptr<int> )> func;
-//CHECK:     int args _Checked[5]; 
-//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+//CHECK: int * mul2(int *x) { 
 
 int * sus(int (*) (int), int (*) (int));
 //CHECK: int * sus(int (*) (int), int (*) (int));
@@ -89,6 +94,8 @@ int * foo() {
         
 return z; }
 //CHECK: int * foo() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);
 
 int * bar() {
  
@@ -98,3 +105,5 @@ int * bar() {
         
 return z; }
 //CHECK: int * bar() {
+//CHECK:         int (*x)(int) = add1; 
+//CHECK:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/unsafefptrargsafemulti1.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargsafemulti1.c
@@ -1,0 +1,100 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked %s %S/unsafefptrargsafemulti2.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargsafemulti1.checked.c %s
+//RUN: rm %S/unsafefptrargsafemulti1.checked.c %S/unsafefptrargsafemulti2.checked.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+//CHECK:     _Ptr<struct general> next;
+
+//CHECK:     int data1 _Checked[5];
+//CHECK:     _Ptr<char> name;
+
+//CHECK:     _Ptr<int> values; 
+
+//CHECK:     _Ptr<int (int )> mapper;
+
+//CHECK:     _Ptr<int (_Ptr<int> )> func;
+//CHECK:     int args _Checked[5]; 
+//CHECK:     _Ptr<int (int )> funcs _Checked[5];
+
+int * sus(int (*) (int), int (*) (int));
+//CHECK: int * sus(int (*) (int), int (*) (int));
+
+int * foo() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * foo() {
+
+int * bar() {
+ 
+        int (*x)(int) = add1; 
+        int (*y)(int) = mul2; 
+        int *z = sus(x, y);
+        
+return z; }
+//CHECK: int * bar() {

--- a/clang/test/CheckedCRewriter/unsafefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargsafemulti2.c
@@ -14,27 +14,42 @@ struct general {
     int data; 
     struct general *next;
 };
+//CHECK:     _Ptr<struct general> next;
+
 
 struct warr { 
     int data1[5];
     char name[];
 };
+//CHECK:     int data1 _Checked[5];
+//CHECK-NEXT:     _Ptr<char> name;
+
 
 struct fptrarr { 
     int *values; 
     char *name;
     int (*mapper)(int);
 };
+//CHECK:     _Ptr<int> values; 
+//CHECK-NEXT:     _Ptr<char> name;
+//CHECK-NEXT:     _Ptr<int (int )> mapper;
+
 
 struct fptr { 
     int *value; 
     int (*func)(int*);
 };  
+//CHECK:     _Ptr<int> value; 
+//CHECK-NEXT:     _Ptr<int (_Ptr<int> )> func;
+
 
 struct arrfptr { 
     int args[5]; 
     int (*funcs[5]) (int);
 };
+//CHECK:     int args _Checked[5]; 
+//CHECK-NEXT:     _Ptr<int (int )> funcs _Checked[5];
+
 
 int add1(int x) { 
     return x+1;
@@ -66,6 +81,8 @@ int *mul2(int *x) {
     return x;
 }
 
+//CHECK: int * mul2(int *x) { 
+
 int * sus(int (*x) (int), int (*y) (int)) {
  
         x = (int (*) (int)) 5;
@@ -75,4 +92,3 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
-//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {

--- a/clang/test/CheckedCRewriter/unsafefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargsafemulti2.c
@@ -92,3 +92,5 @@ int * sus(int (*x) (int), int (*y) (int)) {
         }
         
 return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {
+//CHECK:         int *z = calloc(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/unsafefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/unsafefptrargsafemulti2.c
@@ -1,0 +1,78 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checked2 %s %S/unsafefptrargsafemulti1.c
+//RUN: FileCheck -match-full-lines --input-file %S/unsafefptrargsafemulti2.checked2.c %s
+//RUN: rm %S/unsafefptrargsafemulti1.checked2.c %S/unsafefptrargsafemulti2.checked2.c
+#define size_t int
+#define NULL 0
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+
+struct general { 
+    int data; 
+    struct general *next;
+};
+
+struct warr { 
+    int data1[5];
+    char name[];
+};
+
+struct fptrarr { 
+    int *values; 
+    char *name;
+    int (*mapper)(int);
+};
+
+struct fptr { 
+    int *value; 
+    int (*func)(int*);
+};  
+
+struct arrfptr { 
+    int args[5]; 
+    int (*funcs[5]) (int);
+};
+
+int add1(int x) { 
+    return x+1;
+} 
+
+int sub1(int x) { 
+    return x-1; 
+} 
+
+int fact(int n) { 
+    if(n==0) { 
+        return 1;
+    } 
+    return n*fact(n-1);
+} 
+
+int fib(int n) { 
+    if(n==0) { return 0; } 
+    if(n==1) { return 1; } 
+    return fib(n-1) + fib(n-2);
+} 
+
+int zerohuh(int n) { 
+    return !n;
+}
+
+int *mul2(int *x) { 
+    *x *= 2; 
+    return x;
+}
+
+int * sus(int (*x) (int), int (*y) (int)) {
+ 
+        x = (int (*) (int)) 5;
+        int *z = calloc(5, sizeof(int));
+        for(int i = 0; i < 5; i++) { 
+            z[i] = y(i);
+        }
+        
+return z; }
+//CHECK: int * sus(int (*x)(int), _Ptr<int (int )> y) {


### PR DESCRIPTION
...for arrays, function pointers, pointers to pointers, loops, multi-files, struct dereference, prototypes, and combinations of the above. 

In total, 156 tests were added (this amounts to 208 `.c` files, but some are double-counted since a single multi-file test encompasses multiple `.c` files.)

The tests come in variations of `safe`, `caller`, `callee`, and `both`, which indicate which methods (if any) use their return values unsafely. Additional files that test returned function pointers have not been included (as per issue #75) but their source code is available in the script `testgenerator.py`. 

Information on how the tests were created and annotated is in `testgenerator.py`. Running `python3 testgenerator.py` (after updating the path variables at the top of the file) will overwrite all added files (unless the script is otherwise changed), and create files with updated checked annotations. (so if the tests fail, but because the tool has done a good thing, the script just needs to get re-run once). 