### PR TITLE
Implement fix for issue #74

### DIFF
--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -175,25 +175,23 @@ public:
     return true;
   }
 
-  // Pointer arithmetic ==> Must have at least an array
-
   bool VisitUnaryPreInc(UnaryOperator *O) {
-    constraintInBodyVariable(O->getSubExpr(),Info.getConstraints().getArr());
+    constraintPointerArithmetic(O->getSubExpr());
     return true;
   }
 
   bool VisitUnaryPostInc(UnaryOperator *O) {
-    constraintInBodyVariable(O->getSubExpr(),Info.getConstraints().getArr());
+    constraintPointerArithmetic(O->getSubExpr());
     return true;
   }
 
   bool VisitUnaryPreDec(UnaryOperator *O) {
-    constraintInBodyVariable(O->getSubExpr(),Info.getConstraints().getArr());
+    constraintPointerArithmetic(O->getSubExpr());
     return true;
   }
 
   bool VisitUnaryPostDec(UnaryOperator *O) {
-    constraintInBodyVariable(O->getSubExpr(),Info.getConstraints().getArr());
+    constraintPointerArithmetic(O->getSubExpr());
     return true;
   }
 
@@ -305,9 +303,22 @@ private:
   }
 
   void arithBinop(BinaryOperator *O) {
-      ConstAtom *ARR = Info.getConstraints().getArr();
-      constraintInBodyVariable(O->getLHS(),ARR);
-      constraintInBodyVariable(O->getRHS(),ARR);
+      constraintPointerArithmetic(O->getLHS());
+      constraintPointerArithmetic(O->getRHS());
+  }
+
+  // Pointer arithmetic constrains the expression to be at least ARR,
+  // unless it is on a function pointer. In this case the function pointer
+  // is WILD.
+  void constraintPointerArithmetic(Expr *E) {
+    if (E->getType()->isFunctionPointerType()) {
+      std::set<ConstraintVariable *> Var =
+          CB.getExprConstraintVars(E, E->getType());
+      std::string Rsn = "Pointer arithmetic performed on a function pointer.";
+      CB.constraintAllCVarsToWild(Var, Rsn, E);
+    } else {
+      constraintInBodyVariable(E, Info.getConstraints().getArr());
+    }
   }
 
   ASTContext *Context;

--- a/clang/test/CheckedCRewriter/fp_arith.c
+++ b/clang/test/CheckedCRewriter/fp_arith.c
@@ -1,0 +1,45 @@
+// RUN: cconv-standalone %s -- | FileCheck %s
+// RUN: cconv-standalone -alltypes %s -- | FileCheck %s
+
+// Tests for the error outlined in issue 74. Pointer arithmetic on function
+// pointers with -alltypes active causes the pointers be ARR pointers, but
+// this operation is not defined.
+
+int add(int,int);
+
+// Baseline check of the behavior of function pointers. A function pointer
+// before pointer arithmetic is used should be a checked pointer regardless of
+// alltypes flag.
+void basic_fn_ptr() {
+    int (*x0) (int, int) = add;
+    // CHECK: {{^}} _Ptr<int (int , int )> x0
+}
+
+// Tests of bad Pointer arithmetic that should result in WILD pointers.
+// As described in issue #74, these are rewritten as ARR pointers when
+// alltypes is active.
+void bad_ptr_arith() {
+    int (*x0) (int, int) = add;
+    // CHECK: {{^}} int (*x0) (int, int)
+    x0++;
+
+    int (*x1) (int, int) = add;
+    // CHECK: {{^}} int (*x1) (int, int)
+    x1--;
+
+    int (*x2) (int, int) = add;
+    // CHECK: {{^}} int (*x2) (int, int)
+    ++x2;
+
+    int (*x3) (int, int) = add;
+    // CHECK: {{^}} int (*x3) (int, int)
+    --x3;
+
+    int (*x4) (int, int) = add;
+    // CHECK: {{^}} int (*x4) (int, int)
+    x4 += 1;
+
+    int (*x5) (int, int) = add;
+    // CHECK: {{^}} int (*x5) (int, int)
+    x5 -= 1;
+}


### PR DESCRIPTION
Implement fix for issue #74

When adding constraints for pointer arithmetic, first check that the
pointer in question is not a function pointer. If it is a function pointer, then constrain it to be WILD; otherwise proceed as before. 

Add test to validate this behavior.