### PR TITLE
Array initializer

### DIFF
--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -91,6 +91,11 @@ private:
 
 
   std::set<ConstraintVariable *> getWildPVConstraint();
+
+  std::set<ConstraintVariable *> getAllSubExprConstraintVars(
+      std::set<ConstraintVariable *> &LHSConstraints, std::vector<Expr *> &Exprs,
+      std::set<ConstraintVariable *> &RvalCons, QualType LhsType,
+      bool &IsAssigned);
 };
 
 #endif // _CONSTRAINTRESOLVER_H

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -152,13 +152,6 @@ enum ConsAction {
 };
 
 void constrainConsVarGeq(std::set<ConstraintVariable *> &LHS,
-                      std::set<ConstraintVariable *> &RHS,
-                      Constraints &CS,
-                      PersistentSourceLoc *PL,
-                      ConsAction CA,
-                      bool doEqType,
-                      ProgramInfo *Info);
-void constrainConsVarGeq(std::set<ConstraintVariable *> &LHS,
                          std::set<ConstraintVariable *> &RHS,
                          Constraints &CS,
                          PersistentSourceLoc *PL,
@@ -166,13 +159,6 @@ void constrainConsVarGeq(std::set<ConstraintVariable *> &LHS,
                          bool doEqType,
                          bool derefLHS,
                          ProgramInfo *Info);
-void constrainConsVarGeq(ConstraintVariable *LHS,
-                      ConstraintVariable *RHS,
-                      Constraints &CS,
-                      PersistentSourceLoc *PL,
-                      ConsAction CA,
-                      bool doEqType,
-                      ProgramInfo *Info);
 void constrainConsVarGeq(ConstraintVariable *LHS,
                          ConstraintVariable *RHS,
                          Constraints &CS,

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -158,6 +158,14 @@ void constrainConsVarGeq(std::set<ConstraintVariable *> &LHS,
                       ConsAction CA,
                       bool doEqType,
                       ProgramInfo *Info);
+void constrainConsVarGeq(std::set<ConstraintVariable *> &LHS,
+                         std::set<ConstraintVariable *> &RHS,
+                         Constraints &CS,
+                         PersistentSourceLoc *PL,
+                         ConsAction CA,
+                         bool doEqType,
+                         bool derefLHS,
+                         ProgramInfo *Info);
 void constrainConsVarGeq(ConstraintVariable *LHS,
                       ConstraintVariable *RHS,
                       Constraints &CS,
@@ -165,6 +173,14 @@ void constrainConsVarGeq(ConstraintVariable *LHS,
                       ConsAction CA,
                       bool doEqType,
                       ProgramInfo *Info);
+void constrainConsVarGeq(ConstraintVariable *LHS,
+                         ConstraintVariable *RHS,
+                         Constraints &CS,
+                         PersistentSourceLoc *PL,
+                         ConsAction CA,
+                         bool doEqType,
+                         bool derefLHS,
+                         ProgramInfo *Info);
 
 // True if [C] is a PVConstraint that contains at least one Atom (i.e.,
 //   it represents a C pointer)

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -136,7 +136,7 @@ public:
         // This is to ensure that the return type of the function is same
         // as the type of return expression.
         constrainConsVarGeq(FV->getReturnVars(), RconsVar,
-                            Info.getConstraints(), &PL, Same_to_Same,
+                            Info.getConstraints(), &PL, Same_to_Same, false,
                             false, &Info);
       }
     }
@@ -198,7 +198,7 @@ private:
               std::set<ConstraintVariable *> ParameterDC =
                   TargetFV->getParamVar(i);
               constrainConsVarGeq(ParameterDC, ArgumentConstraints, CS, &PL,
-                                  Wild_to_Safe, false, &Info);
+                                  Wild_to_Safe, false, false, &Info);
             } else {
               // This is the case of an argument passed to a function
               // with varargs.

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -334,7 +334,8 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
       std::set<ConstraintVariable *> TmpCVs;
       for (ConstraintVariable *CV : TR) {
         ConstraintVariable *NewCV = getTemporaryConstraintVariable(CE, CV);
-        constrainConsVarGeq(NewCV, CV, CS, nullptr, Safe_to_Wild, false, &Info);
+        constrainConsVarGeq(NewCV, CV, CS, nullptr, Safe_to_Wild, false, false,
+                            &Info);
         TmpCVs.insert(NewCV);
       }
 
@@ -348,7 +349,7 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
       if (!LHSConstraints.empty()) {
         auto PL = PersistentSourceLoc::mkPSL(CE, *Context);
         constrainConsVarGeq(LHSConstraints, TmpCVs, CS, &PL, Safe_to_Wild,
-                            false, &Info);
+                            false, false, &Info);
         // We assigned the constraints to the LHS.
         // We do not need to propagate the constraints.
         IsAssigned = true;
@@ -461,8 +462,8 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, Expr *LHS, Expr *RHS,
       for (auto CR : R)
         CR->constrainToWild(Info.getConstraints(), Rsn, &PL);
     }
-    constrainConsVarGeq(L, R, Info.getConstraints(), &PL,
-                        CAction, false, &Info);
+    constrainConsVarGeq(L, R, Info.getConstraints(), &PL, CAction, false, false,
+                        &Info);
   }
 }
 

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -341,7 +341,8 @@ bool ProgramInfo::link() {
       if (Verbose)
         llvm::errs() << "Global variables:" << V.first << "\n";
       while (J != C.end()) {
-        constrainConsVarGeq(*I, *J, CS, nullptr, Same_to_Same, true, this);
+        constrainConsVarGeq(*I, *J, CS, nullptr, Same_to_Same, true, false,
+                            this);
         ++I;
         ++J;
       }

--- a/clang/test/CheckedCRewriter/ptr_array.c
+++ b/clang/test/CheckedCRewriter/ptr_array.c
@@ -1,0 +1,70 @@
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines --check-prefixes="CHECK_NOALL" %s
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL" %s
+
+// Tests for issue 60. Array initialization had not been implemented, so wild
+// pointer inside and array initializer did not cause the array to be an array
+// of wild pointer.
+
+// A checked pointer should allow the array to be checked.
+void test0(int *a) {
+// CHECK_NOALL: void test0(int *a) {
+// CHECK_ALL:   void test0(_Ptr<int> a) {
+
+  int *b[1] = {a};
+  // CHECK_NOALL: int *b[1] = {a};
+  // CHECK_ALL:   _Ptr<int> b _Checked[1] =  {a};
+}
+
+// An unchecked pointer should cause the array to be unchecked.
+void test1(int *a) {
+// CHECK_NOALL: void test1(int *a) {
+// CHECK_ALL:   void test1(int *a) {
+
+  a = (int*) 4;
+
+  int *b[1] = {a};
+  // CHECK_NOALL: int *b[1] = {a};
+  // CHECK_ALL:   int* b _Checked[1] =  {a};
+}
+
+// Example from from the issue
+int *foo() {
+// CHECK_NOALL: int *foo() {
+// CHECK_ALL:   int *foo() {
+
+  int x = 1;
+  int y = 2;
+  int z = 3;
+  int *ptrs[4] = { &x, &y, &z, (int *)5 };
+  // CHECK_NOALL: int *ptrs[4] = { &x, &y, &z, (int *)5 };
+  // CHECK_ALL:   int* ptrs _Checked[4] =  { &x, &y, &z, (int *)5 };
+  int *ret;
+  // CHECK_NOALL: int *ret;
+  // CHECK_ALL:   int *ret;
+  for (int i = 0; i < 4; i++) {
+    ret = ptrs[i];
+  }
+
+  return ret;
+}
+
+// Example from the issue, but everthing should check
+int *foo2() {
+// CHECK_NOALL: int *foo2() {
+// CHECK_ALL:   _Ptr<int> foo2(void) {
+
+  int x = 1;
+  int y = 2;
+  int z = 3;
+  int *ptrs[4] = { &x, &y, &z, &x};
+  // CHECK_NOALL: int *ptrs[4] = { &x, &y, &z, &x};
+  // CHECK_ALL:   _Ptr<int> ptrs _Checked[4] =  { &x, &y, &z, &x};
+  int *ret;
+  // CHECK_NOALL: int *ret;
+  // CHECK_ALL:   _Ptr<int> ret = ((void *)0);
+  for (int i = 0; i < 4; i++) {
+    ret = ptrs[i];
+  }
+
+  return ret;
+}


### PR DESCRIPTION
Fix issue #60 .

Implement handling for array initializers by (1) collecting all constraint variables generated by all elements of the initializer into the set returned by `getExprConstraintVars`, and (2) and removing the
first pointer level when adding constraints for array initializers in `constrainConsVarGeq`.

This doesn't fully implement everything needed for `InitListExpr` since I haven't done anything about structures yet.