### PR TITLE
Get expr constraint vars refactor lhs

### DIFF
--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -35,8 +35,7 @@ public:
   // Returns a set of ConstraintVariables which represent the result of
   // evaluating the expression E. Will explore E recursively, but will
   // ignore parts of it that do not contribute to the final result
-  std::set<ConstraintVariable *> getExprConstraintVars(Expr *E,
-                                                       QualType LhsType);
+  std::set<ConstraintVariable *> getExprConstraintVars(Expr *E);
 
   // Handle assignment of RHS expression to LHS expression using the
   // given action.
@@ -69,8 +68,8 @@ private:
   std::set<ConstraintVariable *> getWildPVConstraint();
   std::set<ConstraintVariable *> PVConstraintFromType(QualType TypE);
 
-  std::set<ConstraintVariable *> getAllSubExprConstraintVars(
-    std::vector<Expr *> &Exprs, QualType LhsType);
+  std::set<ConstraintVariable *>
+      getAllSubExprConstraintVars(std::vector<Expr *> &Exprs);
 };
 
 #endif // _CONSTRAINTRESOLVER_H

--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -32,32 +32,11 @@ public:
                                 std::string rsn,
                                 Expr *AtExpr = nullptr);
 
-  // This function gets the constraint variables for the given expression.
-  // The flag NonEmptyCons is used to indicate that this expression is used as
-  // an Rvalue.
-  std::set<ConstraintVariable *>
-  getExprConstraintVars(Expr *E, QualType LhsType);
-
-  // This is a bit of a hack. What we need to do is traverse the AST in a
-  // bottom-up manner, and, for a given expression, decide which singular,
-  // if any, constraint variable is involved in that expression. However,
-  // in the current version of clang (3.8.1), bottom-up traversal is not
-  // supported. So instead, we do a manual top-down traversal, considering
-  // the different cases and their meaning on the value of the constraint
-  // variable involved. This is probably incomplete, but, we're going to
-  // go with it for now.
-  //
-  // V is (currentVariable, baseVariable, limitVariable)
-  // E is an expression to recursively traverse.
-  //
-  // Returns true if E resolves to a constraint variable q_i and the
-  // currentVariable field of V is that constraint variable. Returns false if
-  // a constraint variable cannot be found.
-  // ifc mirrors the inFunctionContext boolean parameter to getVariable.
-  std::set<ConstraintVariable *>  getExprConstraintVars(
-      std::set<ConstraintVariable *> &LHSConstraints,
-      Expr                            *E,
-      QualType                   LhsType);
+  // Returns a set of ConstraintVariables which represent the result of
+  // evaluating the expression E. Will explore E recursively, but will
+  // ignore parts of it that do not contribute to the final result
+  std::set<ConstraintVariable *> getExprConstraintVars(Expr *E,
+                                                       QualType LhsType);
 
   // Handle assignment of RHS expression to LHS expression using the
   // given action.
@@ -87,13 +66,11 @@ private:
   // Update a PVConstraint with one additional level of indirection
   PVConstraint *addAtom(PVConstraint *PVC, Atom *NewA, Constraints &CS);
 
-
   std::set<ConstraintVariable *> getWildPVConstraint();
   std::set<ConstraintVariable *> PVConstraintFromType(QualType TypE);
 
   std::set<ConstraintVariable *> getAllSubExprConstraintVars(
-    std::set<ConstraintVariable *> &LHSConstraints, std::vector<Expr *> &Exprs,
-      QualType LhsType);
+    std::vector<Expr *> &Exprs, QualType LhsType);
 };
 
 #endif // _CONSTRAINTRESOLVER_H

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -110,8 +110,7 @@ public:
   bool VisitCStyleCastExpr(CStyleCastExpr *C) {
     // Is cast compatible with LHS type?
     if (!isCastSafe(C->getType(), C->getSubExpr()->getType())) {
-      auto CVs = CB.getExprConstraintVars(C->getSubExpr(),
-                                          C->getSubExpr()->getType());
+      auto CVs = CB.getExprConstraintVars(C->getSubExpr());
       CB.constraintAllCVarsToWild(CVs, "Casted to a different type.", C);
     }
     return true;
@@ -148,7 +147,7 @@ public:
       // sort of indirect call through an array or conditional. FV constraints
       // can be obtained for this from getExprConstraintVars.
       Expr *CalledExpr = E->getCallee();
-      FVCons = CB.getExprConstraintVars(CalledExpr, CalledExpr->getType());
+      FVCons = CB.getExprConstraintVars(CalledExpr);
 
       // When multiple function variables are used in the same expression, they
       // must have the same type.
@@ -201,8 +200,7 @@ public:
     Expr *RetExpr = S->getRetValue();
     QualType Typ = Function->getReturnType();
 
-    std::set<ConstraintVariable *> RconsVar =
-        CB.getExprConstraintVars(RetExpr, Typ);
+    std::set<ConstraintVariable *> RconsVar = CB.getExprConstraintVars(RetExpr);
     // Constrain the return type of the function
     // to the type of the return expression.
     for (const auto &F : Fun) {
@@ -265,7 +263,7 @@ private:
       unsigned i = 0;
       for (const auto &A : E->arguments()) {
         std::set<ConstraintVariable *> ArgumentConstraints =
-            CB.getExprConstraintVars(A, A->getType());
+            CB.getExprConstraintVars(A);
         for (auto *TmpC : FuncCVars) {
           if (PVConstraint *PVC = dyn_cast<PVConstraint>(TmpC)) {
             TmpC = PVC->getFV();
@@ -321,8 +319,7 @@ private:
 
   // Constraint helpers.
   void constraintInBodyVariable(Expr *e, ConstAtom *CAtom) {
-    std::set<ConstraintVariable *> Var =
-        CB.getExprConstraintVars(e, e->getType());
+    std::set<ConstraintVariable *> Var = CB.getExprConstraintVars(e);
     constrainVarsTo(Var, CAtom);
   }
 
@@ -338,8 +335,7 @@ private:
     for (const auto &A : E->arguments()) {
       // Get constraint from within the function body
       // of the caller.
-      std::set<ConstraintVariable *> ParameterEC =
-          CB.getExprConstraintVars(A, A->getType());
+      std::set<ConstraintVariable *> ParameterEC = CB.getExprConstraintVars(A);
 
       // Assign WILD to each of the constraint variables.
       FunctionDecl *FD = E->getDirectCallee();
@@ -360,8 +356,7 @@ private:
   // is WILD.
   void constraintPointerArithmetic(Expr *E) {
     if (E->getType()->isFunctionPointerType()) {
-      std::set<ConstraintVariable *> Var =
-          CB.getExprConstraintVars(E, E->getType());
+      std::set<ConstraintVariable *> Var = CB.getExprConstraintVars(E);
       std::string Rsn = "Pointer arithmetic performed on a function pointer.";
       CB.constraintAllCVarsToWild(Var, Rsn, E);
     } else {

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -45,14 +45,6 @@ void ConstraintResolver::constraintAllCVarsToWild(
 }
 
 std::set<ConstraintVariable *>
-ConstraintResolver::getExprConstraintVars(Expr *E, QualType LhsType) {
-  std::set<ConstraintVariable *> IgnCons;
-  std::set<ConstraintVariable *> ExprCons =
-      getExprConstraintVars(IgnCons, E, LhsType);
-  return ExprCons;
-}
-
-std::set<ConstraintVariable *>
     ConstraintResolver::handleDeref(std::set<ConstraintVariable *> T) {
   std::set<ConstraintVariable *> tmp;
   for (const auto &CV : T) {
@@ -148,25 +140,11 @@ ConstraintResolver::getTemporaryConstraintVariable(clang::Expr *E,
   return ExprTmpConstraints[ExpKey];
 }
 
-// We traverse the AST in a
-// bottom-up manner, and, for a given expression, decide which singular,
-// if any, constraint variable is involved in that expression. However,
-// in the current version of clang (3.8.1), bottom-up traversal is not
-// supported. So instead, we do a manual top-down traversal, considering
-// the different cases and their meaning on the value of the constraint
-// variable involved. This is probably incomplete, but, we're going to
-// go with it for now.
-//
-// V is (currentVariable, baseVariable, limitVariable)
-// E is an expression to recursively traverse.
-//
-// Returns true if E resolves to a constraint variable q_i and the
-// currentVariable field of V is that constraint variable. Returns false if
-// a constraint variable cannot be found.
-// ifc mirrors the inFunctionContext boolean parameter to getVariable.
+// Returns a set of ConstraintVariables which represent the result of
+// evaluating the expression E. Will explore E recursively, but will
+// ignore parts of it that do not contribute to the final result
 std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
-    std::set<ConstraintVariable *> &LHSConstraints, Expr *E,
-    QualType LhsType) {
+    Expr *E, QualType LhsType) {
   if (E != nullptr) {
     auto &CS = Info.getConstraints();
     QualType TypE = E->getType();
@@ -184,8 +162,7 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
     //   but also weird int->int * conversions (and back)
     } else if (ImplicitCastExpr *IE = dyn_cast<ImplicitCastExpr>(E)) {
       QualType SubTypE = IE->getSubExpr()->getType();
-      auto CVs = getExprConstraintVars(
-          LHSConstraints, IE->getSubExpr(), LhsType);
+      auto CVs = getExprConstraintVars(IE->getSubExpr(), LhsType);
       // if TypE is a pointer type, and the cast is unsafe, return WildPtr
       if (TypE->isPointerType()
           && !(SubTypE->isFunctionType()
@@ -200,19 +177,14 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
 
     // (T)e
     } else if (ExplicitCastExpr *ECE = dyn_cast<ExplicitCastExpr>(E)) {
-      // Is cast compatible with LHS type?
       assert(ECE->getType() == TypE);
-      if (!isCastSafe(LhsType, TypE)) {
-        constraintAllCVarsToWild(LHSConstraints, "Casted From a different type.", E);
-      }
       // Is cast internally safe? Return WILD if not
       Expr *TmpE = ECE->getSubExpr();
       if (TypE->isPointerType() && !isCastSafe(TypE, TmpE->getType()))
         return getWildPVConstraint();
         // NB: Expression ECE itself handled in ConstraintBuilder::FunctionVisitor
       else
-        return getExprConstraintVars(
-              LHSConstraints, TmpE, LhsType);
+        return getExprConstraintVars(TmpE, LhsType);
 
     // variable (x)
     } else if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E)) {
@@ -230,17 +202,14 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
       case BO_AddAssign:
       case BO_SubAssign:
       case BO_Comma:
-        return getExprConstraintVars(LHSConstraints, BO->getLHS(),
-                                     LhsType);
+        return getExprConstraintVars(BO->getLHS(), LhsType);
       /* Possible pointer arithmetic: Could be LHS or RHS */
       case BO_Add:
       case BO_Sub:
         if (BO->getLHS()->getType()->isPointerType())
-          return getExprConstraintVars(
-              LHSConstraints, BO->getLHS(), LhsType);
+          return getExprConstraintVars(BO->getLHS(), LhsType);
         else if (BO->getRHS()->getType()->isPointerType())
-          return getExprConstraintVars(
-              LHSConstraints, BO->getRHS(), LhsType);
+          return getExprConstraintVars(BO->getRHS(), LhsType);
         else
           return PVConstraintFromType(TypE);
       /* Pointer-to-member ops unsupported */
@@ -279,7 +248,8 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
 
     // x[e]
     } else if (ArraySubscriptExpr *AE = dyn_cast<ArraySubscriptExpr>(E)) {
-      std::set<ConstraintVariable *> T = getExprConstraintVars(AE->getBase(), AE->getBase()->getType());
+      std::set<ConstraintVariable *> T =
+          getExprConstraintVars(AE->getBase(), AE->getBase()->getType());
       std::set<ConstraintVariable *> tmp = handleDeref(T);
       T.swap(tmp);
       return T;
@@ -296,11 +266,10 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
         std::set<ConstraintVariable *> tmp;
 
         UOExpr = UOExpr->IgnoreParenImpCasts();
-        //UOExpr = getNormalizedExpr(UOExpr);
 
-        if(T.empty()){
+        if (T.empty()) {
           // If no constraint vars are found, an empty one must be created.
-          // TODO: can we come up with meaningfull names in more cases?
+          // TODO: can we come up with meaningful names in more cases?
           std::string Name;
           if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(UOExpr)) {
             Name = DRE->getDecl()->getNameAsString();
@@ -318,11 +287,11 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
         if (SubUO && SubUO->getOpcode() == UO_Deref) {
           // Taking the address of a dereference is a NoOp, so the constraint
           // vars for the subexpression can be passed through.
-          return getExprConstraintVars(LHSConstraints, SubUO->getSubExpr(),
+          return getExprConstraintVars(SubUO->getSubExpr(),
                                        SubUO->getSubExpr()->getType());
         // TODO: this should also work for array subscript (issue #51), but it break some regression tests.
         //} else if (ArraySubscriptExpr *ASE = dyn_cast<ArraySubscriptExpr>(UOExpr)) {
-        //  return getExprConstraintVars(LHSConstraints, ASE->getBase(),
+        //  return getExprConstraintVars(ASE->getBase(),
         //                               ASE->getBase()->getType());
         } else {
           for (auto *CV : T) {
@@ -352,7 +321,7 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
       case UO_PostDec:
       case UO_PreInc:
       case UO_PreDec:
-        return getExprConstraintVars(LHSConstraints, UOExpr, LhsType);
+        return getExprConstraintVars(UOExpr, LhsType);
       /* Integer operators */
       // +e, -e, ~e
       case UO_Plus:
@@ -380,8 +349,8 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
         // There are a few reasons that we couldn't get a decl. For example,
         // the call could be done through an array subscript.
         Expr *CalledExpr = CE->getCallee();
-        std::set<ConstraintVariable *> tmp = getExprConstraintVars(
-            LHSConstraints, CalledExpr, LhsType);
+        std::set<ConstraintVariable *> tmp =
+            getExprConstraintVars(CalledExpr, LhsType);
 
         for (ConstraintVariable *C : tmp) {
           if (FVConstraint *FV = dyn_cast<FVConstraint>(C)) {
@@ -393,9 +362,6 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
           }
         }
       } else if (DeclaratorDecl *FD = dyn_cast<DeclaratorDecl>(D)) {
-        // D could be a FunctionDecl, or a VarDecl, or a FieldDecl.
-        // Really it could be any DeclaratorDecl.
-
         /* Allocator call */
         if (isFunctionAllocator(FD->getName())) {
           bool didInsert = false;
@@ -433,12 +399,7 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
               ReturnCVs.insert(FVC->getReturnVars().begin(),
                                FVC->getReturnVars().end());
             else {
-              // Our options are slim. For some reason, we have failed to find a
-              // FVConstraint for the Decl that we are calling. This can't be
-              // good so we should constrain everything in the caller to top. We
-              // can fake this by returning a nullary-ish FVConstraint and that
-              // will make the logic above us freak out and over-constrain
-              // everything.
+              // No FVConstraint -- make WILD
               auto *TmpFV = new FVConstraint();
               TempConstraintVars.insert(TmpFV);
               ReturnCVs.insert(TmpFV);
@@ -455,18 +416,11 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
       std::set<ConstraintVariable *> TmpCVs;
       for (ConstraintVariable *CV : ReturnCVs) {
         ConstraintVariable *NewCV = getTemporaryConstraintVariable(CE, CV);
+        // Important: Do Safe_to_Wild call in this copy, which itself
+        //   might be assigned Same_to_Same to a local variable
         constrainConsVarGeq(NewCV, CV, CS, nullptr, Safe_to_Wild, false, false,
                             &Info);
         TmpCVs.insert(NewCV);
-      }
-
-      // If LHS constraints are not empty? Assign to LHS.
-      if (!LHSConstraints.empty()) {
-        auto PL = PersistentSourceLoc::mkPSL(CE, *Context);
-        constrainConsVarGeq(LHSConstraints, TmpCVs, CS, &PL, Safe_to_Wild,
-                            false, false, &Info);
-        // We assigned the constraints to the LHS; no need to propagate
-        TmpCVs.clear();
       }
       return TmpCVs;
 
@@ -475,16 +429,13 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
       std::vector<Expr *> SubExprs;
       SubExprs.push_back(CO->getLHS());
       SubExprs.push_back(CO->getRHS());
-      return getAllSubExprConstraintVars(LHSConstraints, SubExprs,
-                                         LhsType);
+      return getAllSubExprConstraintVars(SubExprs, LhsType);
 
     // { e1, e2, e3, ... }
     } else if (InitListExpr *ILE = dyn_cast<InitListExpr>(E)) {
       if (LhsType->isArrayType()) {
         std::vector<Expr *> SubExprs = ILE->inits().vec();
-        return
-            getAllSubExprConstraintVars(LHSConstraints, SubExprs,
-                                        LhsType);
+        return getAllSubExprConstraintVars(SubExprs, LhsType);
       } else if (LhsType->isStructureType()) {
         if (Verbose) {
           llvm::errs() << "WARNING! Structure initialization expression ignored: ";
@@ -510,8 +461,7 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
 
     // Checked-C temporary
     } else if (CHKCBindTemporaryExpr *CE = dyn_cast<CHKCBindTemporaryExpr>(E)) {
-      return getExprConstraintVars(
-          LHSConstraints, CE->getSubExpr(), LhsType);
+      return getExprConstraintVars(CE->getSubExpr(), LhsType);
 
     // Not specifically handled -- impose no constraint
     } else {
@@ -526,16 +476,14 @@ std::set<ConstraintVariable *> ConstraintResolver::getExprConstraintVars(
   return std::set<ConstraintVariable *>();
 }
 
-// Collect all constraint constraint variables for all expressions given in
-// Exprs into a single set.
+// Collect constraint variables for Exprs int a set
 std::set<ConstraintVariable *> ConstraintResolver::getAllSubExprConstraintVars(
-    std::set<ConstraintVariable *> &LHSConstraints, std::vector<Expr *> &Exprs,
-    QualType LhsType) {
+    std::vector<Expr *> &Exprs, QualType LhsType) {
 
   std::set<ConstraintVariable *> AggregateCons;
   for (const auto &E : Exprs) {
     std::set<ConstraintVariable *> ECons;
-    ECons = getExprConstraintVars(LHSConstraints, E, LhsType);
+    ECons = getExprConstraintVars(E, LhsType);
     AggregateCons.insert(ECons.begin(), ECons.end());
   }
 
@@ -543,18 +491,17 @@ std::set<ConstraintVariable *> ConstraintResolver::getAllSubExprConstraintVars(
 }
 
 void ConstraintResolver::constrainLocalAssign(Stmt *TSt, Expr *LHS, Expr *RHS,
-                                             ConsAction CAction) {
+                                              ConsAction CAction) {
   PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(TSt, *Context);
   std::set<ConstraintVariable *> L = getExprConstraintVars(LHS, LHS->getType());
-  std::set<ConstraintVariable *> R =
-      getExprConstraintVars(L, RHS, LHS->getType());
+  std::set<ConstraintVariable *> R = getExprConstraintVars(RHS, LHS->getType());
   constrainConsVarGeq(L, R, Info.getConstraints(), &PL, CAction, false, false,
                         &Info);
 }
 
 void ConstraintResolver::constrainLocalAssign(Stmt *TSt, DeclaratorDecl *D,
                                               Expr *RHS,
-                                             ConsAction CAction) {
+                                              ConsAction CAction) {
   PersistentSourceLoc PL, *PLPtr = nullptr;
   if (TSt != nullptr) {
    PL = PersistentSourceLoc::mkPSL(TSt, *Context);
@@ -562,7 +509,7 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, DeclaratorDecl *D,
   }
   // Get the in-context local constraints.
   std::set<ConstraintVariable *> V = Info.getVariable(D, Context);
-  auto RHSCons = getExprConstraintVars(V, RHS, D->getType());
+  auto RHSCons = getExprConstraintVars(RHS, D->getType());
 
   // When the RHS of the assignment is an array initializer, the LHS must be
   // dereferenced in order to generate the correct constraints. Not doing this

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -1210,7 +1210,7 @@ public:
               if (i < FD->getNumParams()) {
 
                 std::set<ConstraintVariable *> ArgumentConstraints =
-                    CR.getExprConstraintVars(A, A->getType());
+                    CR.getExprConstraintVars(A);
                 std::set<ConstraintVariable *> &ParameterConstraints =
                     FV->getParamVar(i);
                 bool CastInserted = false;
@@ -1248,8 +1248,7 @@ public:
       Expr *LHS = O->getLHS();
       Expr *RHS = O->getRHS();
       auto &CS = Info.getConstraints();
-      std::set<ConstraintVariable *> LCons =
-          CR.getExprConstraintVars(LHS, LHS->getType());
+      std::set<ConstraintVariable *> LCons = CR.getExprConstraintVars(LHS);
       ConstraintVariable *LCVariable = nullptr;
       bool LHSChkType = false;
       for (auto *LC : LCons) {


### PR DESCRIPTION
Gone: `LHSConstraints` and `LhsType` in `getExprConstraintVars`. The former was never necessary because we were making a copy of each return when calling a function. The latter was used in checking casts, but the prior `RvalCons`-removal commit made it redundant by leveraging `ImplicitCast` operators. `LhsType` was also used for list initializers, but that code checking it could be moved into the caller. Much cleaner!