### PR TITLE
Fix for issue 106

### DIFF
--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -287,9 +287,8 @@ std::set<ConstraintVariable *>
           // Taking the address of a dereference is a NoOp, so the constraint
           // vars for the subexpression can be passed through.
           return getExprConstraintVars(SubUO->getSubExpr());
-        // TODO: this should also work for array subscript (issue #51), but it break some regression tests.
-        //} else if (ArraySubscriptExpr *ASE = dyn_cast<ArraySubscriptExpr>(UOExpr)) {
-        //  return getExprConstraintVars(ASE->getBase());
+        } else if (ArraySubscriptExpr *ASE = dyn_cast<ArraySubscriptExpr>(UOExpr)) {
+          if(!AllTypes) return getExprConstraintVars(ASE->getBase());
         } else {
           for (auto *CV : T) {
             if (PVConstraint *PVC = dyn_cast<PVConstraint>(CV)) {

--- a/clang/test/CheckedCRewriter/basic_checks.c
+++ b/clang/test/CheckedCRewriter/basic_checks.c
@@ -21,7 +21,7 @@ void typd_driver(void) {
 }
 //CHECK: void typd_driver(void) {
 //CHECK-NEXT: wchar_t buf[10];
-//CHECK-NEXT: _Ptr<wchar_t> a = &buf[0];
+//CHECK-NEXT: wchar_t *a = &buf[0];
 //CHECK-NEXT: wchar_t *b = &buf[0];
 
 typedef struct _A {

--- a/clang/test/CheckedCRewriter/refarrsubscript.c
+++ b/clang/test/CheckedCRewriter/refarrsubscript.c
@@ -1,0 +1,10 @@
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines %s
+// RUN: cconv-standalone -output-postfix=checked %s 
+// RUN: %clang -c %S/refarrsubscript.checked.c
+// RUN: rm %S/refarrsubscript.checked.c
+
+int **foo(int **p, int *x) {
+  return &(p[1]);
+} 
+//CHECK: int ** foo(int **p, _Ptr<int> x) {
+

--- a/clang/test/CheckedCRewriter/refarrsubscriptstruct.c
+++ b/clang/test/CheckedCRewriter/refarrsubscriptstruct.c
@@ -1,0 +1,11 @@
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines %s
+// RUN: cconv-standalone -output-postfix=checked %s 
+// RUN: %clang -c %S/refarrsubscriptstruct.checked.c
+// RUN: rm %S/refarrsubscriptstruct.checked.c
+
+struct foo { int **b; };
+int **bar(struct foo *p) {
+  return &(p->b[1]);
+} 
+//CHECK: struct foo { int **b; };
+//CHECK: int ** bar(_Ptr<struct foo> p) {


### PR DESCRIPTION
Fixed issue 106 and added two (passing) tests. Also modified the checked annotations in `basic_checks.c` in order to account for the fix. All conversions result in files that compile with checked-c's clang. 