### PR TITLE
Structure initialization lists 

### DIFF
--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -64,7 +64,8 @@ private:
 
   // Update a PVConstraint with one additional level of indirection
   PVConstraint *addAtom(PVConstraint *PVC, Atom *NewA, Constraints &CS);
-
+  std::set<ConstraintVariable *> addAtomAll(std::set<ConstraintVariable *> CVS,
+                                            Atom *PtrTyp, Constraints &CS);
   std::set<ConstraintVariable *> getWildPVConstraint();
   std::set<ConstraintVariable *> PVConstraintFromType(QualType TypE);
 

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -136,16 +136,10 @@ void constrainConsVarGeq(std::set<ConstraintVariable *> &LHS,
                          PersistentSourceLoc *PL,
                          ConsAction CA,
                          bool doEqType,
-                         bool derefLHS,
                          ProgramInfo *Info);
-void constrainConsVarGeq(ConstraintVariable *LHS,
-                         ConstraintVariable *RHS,
-                         Constraints &CS,
-                         PersistentSourceLoc *PL,
-                         ConsAction CA,
-                         bool doEqType,
-                         bool derefLHS,
-                         ProgramInfo *Info);
+void constrainConsVarGeq(ConstraintVariable *LHS, ConstraintVariable *RHS,
+                         Constraints &CS, PersistentSourceLoc *PL,
+                         ConsAction CA, bool doEqType, ProgramInfo *Info);
 
 // True if [C] is a PVConstraint that contains at least one Atom (i.e.,
 //   it represents a C pointer)

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -149,7 +149,7 @@ public:
       if (FVCons.size() > 1) {
         PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(CalledExpr, *Context);
         constrainConsVarGeq(FVCons, FVCons, Info.getConstraints(), &PL,
-                            Same_to_Same, false, false, &Info);
+                            Same_to_Same, false, &Info);
       }
     } else if (FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
       FVCons = Info.getVariable(FD, Context);
@@ -180,7 +180,7 @@ public:
               std::set<ConstraintVariable *> ParameterDC =
                   TargetFV->getParamVar(i);
               constrainConsVarGeq(ParameterDC, ArgumentConstraints, CS, &PL,
-                                  Wild_to_Safe, false, false, &Info);
+                                  Wild_to_Safe, false, &Info);
             } else {
               // The argument passed to a function ith varargs; make it wild
               if (HandleVARARGS) {
@@ -232,7 +232,7 @@ public:
         // as the type of return expression.
         constrainConsVarGeq(FV->getReturnVars(), RconsVar,
                             Info.getConstraints(), &PL, Same_to_Same, false,
-                            false, &Info);
+                            &Info);
       }
     }
     return true;

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -518,19 +518,6 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, DeclaratorDecl *D,
   std::set<ConstraintVariable *> V = Info.getVariable(D, Context);
   auto RHSCons = getExprConstraintVars(RHS);
 
-  // When the RHS of the assignment is an array initializer, the LHS must be
-  // dereferenced in order to generate the correct constraints.
-  if (RHS != nullptr && dyn_cast<InitListExpr>(RHS) != nullptr) {
-    if (!D->getType()->isArrayType()) {
-      if (Verbose) {
-        llvm::errs()
-            << "WARNING! Non-array list initialization expression ignored: ";
-        RHS->dump(llvm::errs());
-        llvm::errs() << "\n";
-      }
-      RHSCons = std::set<ConstraintVariable *>();
-    }
-  }
   constrainConsVarGeq(V, RHSCons, Info.getConstraints(), PLPtr, CAction, false,
                       &Info);
 }

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -412,8 +412,7 @@ std::set<ConstraintVariable *>
         ConstraintVariable *NewCV = getTemporaryConstraintVariable(CE, CV);
         // Important: Do Safe_to_Wild from returnvar in this copy, which then
         //   might be assigned otherwise (Same_to_Same) to LHS
-        constrainConsVarGeq(NewCV, CV, CS, nullptr, Safe_to_Wild, false, false,
-                            &Info);
+        constrainConsVarGeq(NewCV, CV, CS, nullptr, Safe_to_Wild, false, &Info);
         TmpCVs.insert(NewCV);
       }
       return TmpCVs;
@@ -490,8 +489,7 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, Expr *LHS, Expr *RHS,
   PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(TSt, *Context);
   std::set<ConstraintVariable *> L = getExprConstraintVars(LHS);
   std::set<ConstraintVariable *> R = getExprConstraintVars(RHS);
-  constrainConsVarGeq(L, R, Info.getConstraints(), &PL, CAction, false, false,
-                        &Info);
+  constrainConsVarGeq(L, R, Info.getConstraints(), &PL, CAction, false, &Info);
 }
 
 void ConstraintResolver::constrainLocalAssign(Stmt *TSt, DeclaratorDecl *D,
@@ -519,7 +517,7 @@ void ConstraintResolver::constrainLocalAssign(Stmt *TSt, DeclaratorDecl *D,
     }
   }
   constrainConsVarGeq(V, RHSCons, Info.getConstraints(), PLPtr, CAction, false,
-                      false, &Info);
+                      &Info);
 }
 
 std::set<ConstraintVariable *> ConstraintResolver::getWildPVConstraint() {

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -336,8 +336,7 @@ bool ProgramInfo::link() {
       if (Verbose)
         llvm::errs() << "Global variables:" << V.first << "\n";
       while (J != C.end()) {
-        constrainConsVarGeq(*I, *J, CS, nullptr, Same_to_Same, true, false,
-                            this);
+        constrainConsVarGeq(*I, *J, CS, nullptr, Same_to_Same, true, this);
         ++I;
         ++J;
       }

--- a/clang/test/CheckedCRewriter/struct_init_list.c
+++ b/clang/test/CheckedCRewriter/struct_init_list.c
@@ -1,4 +1,5 @@
 // RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+// RUN: cconv-standalone -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 // RUN: cconv-standalone -alltypes %s -- | %clang_cc1 -fignore-checkedc-pointers -fno-builtin -verify -fcheckedc-extension -x c -
 // expected-no-diagnostics
 
@@ -15,8 +16,8 @@ int func(int *q) {
 }
 
 void bar(void) {
-  struct foo f = { &func };
-  f.fp = &xfunc;
+  struct foo f = { &xfunc };
+  struct foo g = { &func };
 }
 
 struct buz {

--- a/clang/test/CheckedCRewriter/struct_init_list.c
+++ b/clang/test/CheckedCRewriter/struct_init_list.c
@@ -1,0 +1,95 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+// RUN: cconv-standalone -alltypes %s -- | %clang_cc1 -fignore-checkedc-pointers -fno-builtin -verify -fcheckedc-extension -x c -
+// expected-no-diagnostics
+
+struct foo {
+  int (*fp)(int *p); 
+  // CHECK:  _Ptr<int (int *)> fp;
+};
+
+extern int xfunc(int *arg);
+
+int func(int *q) {
+// CHECK: int func(int *q) {
+  return *q;
+}
+
+void bar(void) {
+  struct foo f = { &func };
+  f.fp = &xfunc;
+}
+
+struct buz {
+  int *x;
+  // CHECK: int *x;
+};
+
+void buz_test() {
+  int x = 0;
+  struct buz bar = { (int*) 1};
+  bar.x = &x;
+}
+
+struct baz {
+  int *x;
+  // CHECK: _Ptr<int> x;
+};
+
+void baz_test() {
+  int x = 0;
+  int y = 1;
+  struct buz bar = {&x};
+  bar.x = &y;
+}
+
+struct a {
+  int *x;
+  // CHECK: _Ptr<int> x;
+  int *y;
+  // CHECK: int *y;
+};
+
+struct b {
+  int *j;
+  // CHECK: _Ptr<int> j;
+  struct a a;
+  int *k;
+  // CHECK: int *k;
+};
+
+struct c {
+  int *p;
+  // int *p;
+  struct a a;
+  struct b b;
+};
+
+void nested_test(int *a, int *b){
+// void nested_test(_Ptr<int> a, int *b){
+  struct c test = {
+    .p = b,
+    .a = {
+      .x = a,
+      .y = b},
+    .b = {
+      .j = a,
+      .a = {
+        .x = a,
+       	.y = (int*) 1}, 
+      .k = b}};
+}
+
+struct good {
+  int *arr[2];
+  // _Ptr<int> arr _Checked[2];
+};
+
+struct bad {
+  int *arr[2];
+  // int *arr _Checked[2];
+};
+
+void arr_in_struct(int *a, int *b, int *c) {
+  struct good test_good = {{a, b}};
+  struct bad test_bad = {{c, (int*)5}};
+}


### PR DESCRIPTION
Implements `getExprConstraintVars` for structure initialization lists, fixing issue #105. Structure initialization lists are treated as a series of variable assignments to each of the record fields.

This pull requests also improves the handling of array initialization lists. The `derefLHS` parameter has been removed from the `constrainConsVarGeq`, and array initialization is instead treated analogously to AddrOf using the `addAtom` method.