### PR TITLE
Handling itype params

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -87,6 +87,10 @@ public:
   virtual void dump() const = 0;
   virtual void dump_json(llvm::raw_ostream &O) const = 0;
 
+  virtual bool getItypePresent() = 0;
+
+  virtual bool haveSameAssignment(Constraints &, ConstraintVariable *) = 0;
+
   // Constrain all pointers in this ConstraintVariable to be Wild.
   virtual void constrainToWild(Constraints &CS) = 0;
   virtual void constrainToWild(Constraints &CS, std::string &Rsn) = 0;
@@ -229,6 +233,8 @@ public:
   bool getItypePresent() { return ItypeStr.size() > 0; }
   std::string getItype() { return ItypeStr; }
 
+  bool haveSameAssignment(Constraints &CS, ConstraintVariable *CV);
+
   // Constructor for when we have a Decl. K is the current free
   // constraint variable index. We don't need to explicitly pass
   // the name because it's available in 'D'.
@@ -346,6 +352,9 @@ public:
     assert(i < paramVars.size());
     return paramVars.at(i);
   }
+
+  bool getItypePresent();
+  bool haveSameAssignment(Constraints &CS, ConstraintVariable *CV);
 
   std::string mkString(EnvironmentMap &E, bool EmitName =true,
                        bool ForItype =false);

--- a/clang/include/clang/CConv/Constraints.h
+++ b/clang/include/clang/CConv/Constraints.h
@@ -105,10 +105,11 @@ public:
 
   static std::string VarKindToStr(VarKind V) {
     switch (V) {
-    case V_Param: return ">>";
-    case V_Return: return "<<";
-    case V_Other: return "";
+      case V_Param: return ">>";
+      case V_Return: return "<<";
+      case V_Other: return "";
     }
+    return "";
   }
 
   void print(llvm::raw_ostream &O) const {

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -957,6 +957,42 @@ bool PointerVariableConstraint::hasNtArr(EnvironmentMap &E)
   return false;
 }
 
+bool PointerVariableConstraint::
+    haveSameAssignment(Constraints &CS, ConstraintVariable *CV) {
+  bool Ret = false;
+  if (CV != nullptr) {
+    if (PVConstraint *PV = dyn_cast<PVConstraint>(CV)) {
+      auto &OthCVars = PV->vars;
+      if (vars.size() == OthCVars.size()) {
+        Ret = true;
+
+        // First compare Vars to see if they are same.
+        CAtoms::iterator I = vars.begin();
+        CAtoms::iterator J = OthCVars.begin();
+        while (I != vars.end()) {
+          if (CS.getAssignment(*I) != CS.getAssignment(*J)) {
+            Ret = false;
+            break;
+          }
+          ++I;
+          ++J;
+        }
+
+        if (Ret) {
+          FVConstraint *OtherFV = PV->getFV();
+          if (FV != nullptr && OtherFV != nullptr) {
+            Ret = FV->haveSameAssignment(CS, OtherFV);
+          } else if (FV != nullptr || OtherFV != nullptr) {
+            // One of them has FV null.
+            Ret = false;
+          }
+        }
+      }
+    }
+  }
+  return Ret;
+}
+
 void FunctionVariableConstraint::print(raw_ostream &O) const {
   O << "( ";
   for (const auto &I : returnVars)
@@ -1003,6 +1039,47 @@ void FunctionVariableConstraint::dump_json(raw_ostream &O) const {
   }
   O << "]";
   O << "}}";
+}
+
+bool FunctionVariableConstraint::getItypePresent() {
+  for (auto &RV : getReturnVars()) {
+    if (RV->getItypePresent()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool sameAssignmentCVSet(Constraints &CS,
+                                std::set<ConstraintVariable *> &CVS1,
+                                std::set<ConstraintVariable *> &CVS2) {
+  bool Ret = false;
+  if (CVS1.size() == CVS2.size()) {
+    Ret = CVS1.size() <= 1;
+    if (CVS1.size() == 1) {
+     auto *CV1 = getOnly(CVS1);
+     auto *CV2 = getOnly(CVS2);
+     Ret = CV1->haveSameAssignment(CS, CV2);
+    }
+  }
+  return Ret;
+}
+
+bool FunctionVariableConstraint::
+    haveSameAssignment(Constraints &CS, ConstraintVariable *CV) {
+  bool Ret = false;
+  if (CV != nullptr) {
+    if (FVConstraint *OtherFV = dyn_cast<FVConstraint>(CV)) {
+      Ret = (numParams() == OtherFV->numParams());
+      Ret = Ret && sameAssignmentCVSet(CS, getReturnVars(),
+                                       OtherFV->getReturnVars());
+      for (unsigned i=0; i < numParams(); i++) {
+        Ret = Ret && sameAssignmentCVSet(CS, getParamVar(i),
+                                         OtherFV->getParamVar(i));
+      }
+    }
+  }
+  return Ret;
 }
 
 std::string
@@ -1328,13 +1405,11 @@ void PointerVariableConstraint::mergeDeclaration(ConstraintVariable *FromCV) {
   CAtoms CFrom = From->getCvars();
   CAtoms::iterator I = vars.begin();
   CAtoms::iterator J = CFrom.begin();
-  bool EquateCons = true;
   while (I != vars.end()) {
     Atom *IAt = *I;
     Atom *JAt = *J;
     ConstAtom *ICAt = dyn_cast<ConstAtom>(IAt);
     ConstAtom *JCAt = dyn_cast<ConstAtom>(JAt);
-    EquateCons = true;
     if (JCAt && !ICAt) {
       NewVatoms.push_back(JAt);
     } else {

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -1174,7 +1174,8 @@ class CastPlacementVisitor :
 public:
   explicit CastPlacementVisitor(ASTContext *C, ProgramInfo &I,
                                 Rewriter &R)
-      : Context(C), Info(I), Writer(R), CR(Info, Context) {}
+      : Context(C), Info(I), Writer(R), CR(Info, Context),
+        FD(nullptr) {}
 
   bool VisitCallExpr(CallExpr *CE) {
     Decl *D = CE->getCalleeDecl();
@@ -1247,39 +1248,41 @@ public:
     if (O->getOpcode() == BO_Assign) {
       Expr *LHS = O->getLHS();
       Expr *RHS = O->getRHS();
-      auto &CS = Info.getConstraints();
       std::set<ConstraintVariable *> LCons = CR.getExprConstraintVars(LHS);
-      ConstraintVariable *LCVariable = nullptr;
-      bool LHSChkType = false;
-      for (auto *LC : LCons) {
-        if (LC->anyChanges(CS.getVariables())) {
-          LCVariable = LC;
-          LHSChkType = true;
+      std::string CastStr;
+      if (needsFancyCast(LCons, RHS, CastStr)) {
+        surroundByCast(CastStr, RHS);
+      }
+    }
+    return true;
+  }
+
+  bool VisitReturnStmt(ReturnStmt *S) {
+    Expr *RetExpr = S->getRetValue();
+
+    if (RetExpr != nullptr) {
+      assert(FD != nullptr && "Function Declaration should not be nullptr");
+
+      std::set<ConstraintVariable *> Fun = Info.getVariable(FD, Context);
+
+      std::set<ConstraintVariable *> FuncRet;
+      for (const auto &F : Fun) {
+        if (FVConstraint *FV = dyn_cast<FVConstraint>(F)) {
+          FuncRet = FV->getReturnVars();
           break;
         }
       }
-      if (LHSChkType) {
-        assert (LCVariable != nullptr && "Expected non-null");
-        // Now, check if RHS is either explicit cast or addr-of (&) expression
-        // in which case we insert fancy cast.
-        RHS = RHS->IgnoreParenImpCasts();
-        bool NeedFancyCast = false;
-        if (!isNULLExpression(RHS, *Context) &&
-            dyn_cast<ExplicitCastExpr>(RHS)) {
-          NeedFancyCast = true;
-        }
-        if (UnaryOperator *UO = dyn_cast<UnaryOperator>(RHS)) {
-          if (UO->getOpcode() == UO_AddrOf) {
-            NeedFancyCast = true;
-          }
-        }
-        if (NeedFancyCast) {
-          std::string CastStr = "_Assume_bounds_cast<" +
-              LCVariable->mkString(CS.getVariables(), false) + ">(";
-          surroundByCast(CastStr, O->getRHS());
-        }
+
+      std::string CastStr;
+      if (needsFancyCast(FuncRet, RetExpr, CastStr)) {
+        surroundByCast(CastStr, RetExpr);
       }
     }
+    return true;
+  }
+
+  bool VisitFunctionDecl(FunctionDecl *D) {
+    FD = D;
     return true;
   }
 
@@ -1291,9 +1294,21 @@ private:
                    IsChecked Dinfo) {
     auto &E = Info.getConstraints().getVariables();
     auto SrcChecked = Src->anyChanges(E);
-    // Check if the src is a checked type and destination is not.
-    return (SrcChecked && !Dst->anyChanges(E)) ||
-           (SrcChecked && Dinfo == WILD);
+    // Check if the src is a checked type.
+    if (SrcChecked) {
+      // Check if Dst is an itype, if yes then
+      // Src should have exactly same checked type else we need to insert cast.
+      if (Dst->getItypePresent()) {
+        return !Dst->haveSameAssignment(Info.getConstraints(), Src);
+      }
+
+      // Is Dst Wild?
+      if (!Dst->anyChanges(E) || Dinfo == WILD) {
+        return true;
+      }
+
+    }
+    return false;
   }
 
   // Get the type name to insert for casting.
@@ -1302,7 +1317,8 @@ private:
     assert(needCasting(Src, Dst, Dinfo) && "No casting needed.");
     auto &E = Info.getConstraints().getVariables();
     // The destination type should be a non-checked type.
-    assert(!Dst->anyChanges(E) || Dinfo == WILD);
+    // This is not necessary because of itypes
+    //assert(!Dst->anyChanges(E) || Dinfo == WILD);
     return "((" + Dst->getRewritableOriginalTy() + ")";
   }
 
@@ -1322,10 +1338,51 @@ private:
       Writer.InsertTextBefore(E->getBeginLoc(), CastPrefix);
     }
   }
+
+  bool needsFancyCast(std::set<ConstraintVariable *> &LHSCons, Expr *E,
+                      std::string &CastStr) {
+    ConstraintVariable *LCVariable = nullptr;
+    bool LHSChkType = false;
+    bool NeedFancyCast = false;
+    auto &CS = Info.getConstraints();
+    for (auto *LC : LHSCons) {
+      if (LC->anyChanges(CS.getVariables())) {
+        LCVariable = LC;
+        LHSChkType = true;
+        break;
+      }
+    }
+    if (LHSChkType) {
+      assert(LCVariable != nullptr && "Expected non-null");
+
+      // Now, check if RHS is either explicit cast or addr-of (&) expression
+      // in which case we insert fancy cast.
+      E = E->IgnoreParenImpCasts();
+      if (!isNULLExpression(E, *Context) &&
+          dyn_cast<ExplicitCastExpr>(E)) {
+        NeedFancyCast = true;
+      }
+      if (UnaryOperator *UO = dyn_cast<UnaryOperator>(E)) {
+        if (UO->getOpcode() == UO_AddrOf) {
+          NeedFancyCast = true;
+        }
+      }
+
+      if (NeedFancyCast) {
+        CastStr = "_Assume_bounds_cast<" +
+                  LCVariable->mkString(CS.getVariables(), false) +
+                  ">(";
+      }
+    }
+
+    return NeedFancyCast;
+  }
+
   ASTContext            *Context;
   ProgramInfo           &Info;
   Rewriter              &Writer;
   ConstraintResolver    CR;
+  FunctionDecl          *FD;
 
 };
 

--- a/clang/test/CheckedCRewriter/itypecast.c
+++ b/clang/test/CheckedCRewriter/itypecast.c
@@ -1,0 +1,47 @@
+// Tests for Checked C rewriter tool.
+//
+// Checks cast insertion while passing arguments to itype parameters.
+//
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines %s
+// RUN: cconv-standalone %s -- | %clang_cc1 -fignore-checkedc-pointers -verify -fcheckedc-extension -x c -
+// expected-no-diagnostics
+
+int foo(int **p:itype(_Ptr<_Ptr<int>>));
+int bar(int **p:itype(_Ptr<int *>));
+int baz(int ((*compar)(const int *, const int *)) :
+             itype(_Ptr<int (_Ptr<const int>, _Ptr<const int>)>));
+             
+int func(void) {
+    int ((*fptr1)(const int *, const int *));
+    int ((*fptr2)(const int *, const int *));
+    
+    int **fp1;
+    int **fp2;
+    int **bp1;
+    int **bp2;
+    
+    *fp2 = 2;
+    foo(fp1);
+    foo(fp2);
+    bar(bp1);
+    bp2 = 2;
+    *bp2 = 2;
+    bar(bp2);
+    fptr1(2, 0);
+    baz(fptr1);
+    baz(fptr2);
+    return 0;    
+}
+//CHECK: _Ptr<int (const int *, _Ptr<const int> )> fptr1 = ((void *)0);
+//CHECK-NEXT: _Ptr<int (_Ptr<const int> , _Ptr<const int> )> fptr2 = ((void *)0);
+//CHECK: _Ptr<_Ptr<int>> fp1 = ((void *)0);
+//CHECK-NEXT: _Ptr<int*> fp2 = ((void *)0);
+//CHECK-NEXT: _Ptr<int*> bp1 = ((void *)0);
+//CHECK-NEXT: int **bp2;
+//CHECK: foo(fp1);
+//CHECK-NEXT: foo(((int **)fp2));
+//CHECK-NEXT: bar(bp1);
+//CHECK: bar(bp2);
+//CHECK-NEXT: fptr1(2, 0);
+//CHECK-NEXT: baz(((int ((*)(const int *, const int *)) )fptr1));
+//CHECK-NEXT: baz(fptr2);

--- a/clang/test/CheckedCRewriter/itypecast.c
+++ b/clang/test/CheckedCRewriter/itypecast.c
@@ -3,8 +3,6 @@
 // Checks cast insertion while passing arguments to itype parameters.
 //
 // RUN: cconv-standalone %s -- | FileCheck -match-full-lines %s
-// RUN: cconv-standalone %s -- | %clang_cc1 -fignore-checkedc-pointers -verify -fcheckedc-extension -x c -
-// expected-no-diagnostics
 
 int foo(int **p:itype(_Ptr<_Ptr<int>>));
 int bar(int **p:itype(_Ptr<int *>));


### PR DESCRIPTION
This fix addresses assignment of arguments to itype parameters.
For `itype` parameters, the requirement is that if the argument is checked type, then it has to match the exact type specified inside `itype` annotation.

For example:
```
void foo(int **p:itype(_Ptr<_Ptr<int>>));
void bar() {
   _Ptr<_Ptr<int>> itype_match = 0;
  int **wild_match;
 _Ptr<int *> mis_match = 0;
  // This is Okay, as this matches the itype perfectly.
  foo(itype_match);
  // This is Okay, as this matches the wild type.
  foo(wild_match);
  // This is Not Okay, because the type does not match the WILD type or itype.
  foo(mis_match);
}
```
This fix, checks if the itype match is correct, if not, adds a cast to the argument.

I have also cleaned up code a bit to remove certain unused variables.

**With this fix, Complete automated conversion of `vsftpd` on ubuntu works!!**