### PR TITLE
Handling itype params latest

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -87,9 +87,9 @@ public:
   virtual void dump() const = 0;
   virtual void dump_json(llvm::raw_ostream &O) const = 0;
 
-  virtual bool getItypePresent() = 0;
+  virtual bool hasItype() = 0;
 
-  virtual bool haveSameAssignment(Constraints &, ConstraintVariable *) = 0;
+  virtual bool solutionEqualTo(Constraints &, ConstraintVariable *) = 0;
 
   // Constrain all pointers in this ConstraintVariable to be Wild.
   virtual void constrainToWild(Constraints &CS) = 0;
@@ -224,10 +224,10 @@ public:
 
   // Is an itype present for this constraint? If yes,
   // what is the text of that itype?
-  bool getItypePresent() { return ItypeStr.size() > 0; }
+  bool hasItype() { return ItypeStr.size() > 0; }
   std::string getItype() { return ItypeStr; }
 
-  bool haveSameAssignment(Constraints &CS, ConstraintVariable *CV);
+  bool solutionEqualTo(Constraints &CS, ConstraintVariable *CV);
 
   // Constructor for when we have a Decl. K is the current free
   // constraint variable index. We don't need to explicitly pass
@@ -347,8 +347,8 @@ public:
     return paramVars.at(i);
   }
 
-  bool getItypePresent();
-  bool haveSameAssignment(Constraints &CS, ConstraintVariable *CV);
+  bool hasItype();
+  bool solutionEqualTo(Constraints &CS, ConstraintVariable *CV);
 
   std::string mkString(EnvironmentMap &E, bool EmitName =true,
                        bool ForItype =false);

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -87,6 +87,10 @@ public:
   virtual void dump() const = 0;
   virtual void dump_json(llvm::raw_ostream &O) const = 0;
 
+  virtual bool getItypePresent() = 0;
+
+  virtual bool haveSameAssignment(Constraints &, ConstraintVariable *) = 0;
+
   // Constrain all pointers in this ConstraintVariable to be Wild.
   virtual void constrainToWild(Constraints &CS) = 0;
   virtual void constrainToWild(Constraints &CS, std::string &Rsn) = 0;
@@ -223,6 +227,8 @@ public:
   bool getItypePresent() { return ItypeStr.size() > 0; }
   std::string getItype() { return ItypeStr; }
 
+  bool haveSameAssignment(Constraints &CS, ConstraintVariable *CV);
+
   // Constructor for when we have a Decl. K is the current free
   // constraint variable index. We don't need to explicitly pass
   // the name because it's available in 'D'.
@@ -340,6 +346,9 @@ public:
     assert(i < paramVars.size());
     return paramVars.at(i);
   }
+
+  bool getItypePresent();
+  bool haveSameAssignment(Constraints &CS, ConstraintVariable *CV);
 
   std::string mkString(EnvironmentMap &E, bool EmitName =true,
                        bool ForItype =false);

--- a/clang/include/clang/CConv/Constraints.h
+++ b/clang/include/clang/CConv/Constraints.h
@@ -105,10 +105,11 @@ public:
 
   static std::string VarKindToStr(VarKind V) {
     switch (V) {
-    case V_Param: return ">>";
-    case V_Return: return "<<";
-    case V_Other: return "";
+      case V_Param: return ">>";
+      case V_Return: return "<<";
+      case V_Other: return "";
     }
+    return "";
   }
 
   void print(llvm::raw_ostream &O) const {

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -60,7 +60,7 @@ std::set<ConstraintVariable *>
       C.erase(C.begin());
       if (C.size() > 0) {
         bool a = PVC->getArrPresent();
-        bool c = PVC->getItypePresent();
+        bool c = PVC->hasItype();
         std::string d = PVC->getItype();
         FVConstraint *b = PVC->getFV();
         PVConstraint *TmpPV = new PVConstraint(C, PVC->getTy(), PVC->getName(),
@@ -108,7 +108,7 @@ PVConstraint *ConstraintResolver::addAtom(PVConstraint *PVC, Atom *PtrTyp, Const
   C.insert(C.begin(), NewA);
   bool a = PVC->getArrPresent();
   FVConstraint *b = PVC->getFV();
-  bool c = PVC->getItypePresent();
+  bool c = PVC->hasItype();
   std::string d = PVC->getItype();
   PVConstraint *TmpPV = new PVConstraint(C, PVC->getTy(), PVC->getName(),
                                          b, a, c, d);

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -957,6 +957,42 @@ bool PointerVariableConstraint::hasNtArr(EnvironmentMap &E)
   return false;
 }
 
+bool PointerVariableConstraint::
+    haveSameAssignment(Constraints &CS, ConstraintVariable *CV) {
+  bool Ret = false;
+  if (CV != nullptr) {
+    if (PVConstraint *PV = dyn_cast<PVConstraint>(CV)) {
+      auto &OthCVars = PV->vars;
+      if (vars.size() == OthCVars.size()) {
+        Ret = true;
+
+        // First compare Vars to see if they are same.
+        CAtoms::iterator I = vars.begin();
+        CAtoms::iterator J = OthCVars.begin();
+        while (I != vars.end()) {
+          if (CS.getAssignment(*I) != CS.getAssignment(*J)) {
+            Ret = false;
+            break;
+          }
+          ++I;
+          ++J;
+        }
+
+        if (Ret) {
+          FVConstraint *OtherFV = PV->getFV();
+          if (FV != nullptr && OtherFV != nullptr) {
+            Ret = FV->haveSameAssignment(CS, OtherFV);
+          } else if (FV != nullptr || OtherFV != nullptr) {
+            // One of them has FV null.
+            Ret = false;
+          }
+        }
+      }
+    }
+  }
+  return Ret;
+}
+
 void FunctionVariableConstraint::print(raw_ostream &O) const {
   O << "( ";
   for (const auto &I : returnVars)
@@ -1003,6 +1039,47 @@ void FunctionVariableConstraint::dump_json(raw_ostream &O) const {
   }
   O << "]";
   O << "}}";
+}
+
+bool FunctionVariableConstraint::getItypePresent() {
+  for (auto &RV : getReturnVars()) {
+    if (RV->getItypePresent()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool sameAssignmentCVSet(Constraints &CS,
+                                std::set<ConstraintVariable *> &CVS1,
+                                std::set<ConstraintVariable *> &CVS2) {
+  bool Ret = false;
+  if (CVS1.size() == CVS2.size()) {
+    Ret = CVS1.size() <= 1;
+    if (CVS1.size() == 1) {
+     auto *CV1 = getOnly(CVS1);
+     auto *CV2 = getOnly(CVS2);
+     Ret = CV1->haveSameAssignment(CS, CV2);
+    }
+  }
+  return Ret;
+}
+
+bool FunctionVariableConstraint::
+    haveSameAssignment(Constraints &CS, ConstraintVariable *CV) {
+  bool Ret = false;
+  if (CV != nullptr) {
+    if (FVConstraint *OtherFV = dyn_cast<FVConstraint>(CV)) {
+      Ret = (numParams() == OtherFV->numParams());
+      Ret = Ret && sameAssignmentCVSet(CS, getReturnVars(),
+                                       OtherFV->getReturnVars());
+      for (unsigned i=0; i < numParams(); i++) {
+        Ret = Ret && sameAssignmentCVSet(CS, getParamVar(i),
+                                         OtherFV->getParamVar(i));
+      }
+    }
+  }
+  return Ret;
 }
 
 std::string
@@ -1316,13 +1393,11 @@ void PointerVariableConstraint::mergeDeclaration(ConstraintVariable *FromCV) {
   CAtoms CFrom = From->getCvars();
   CAtoms::iterator I = vars.begin();
   CAtoms::iterator J = CFrom.begin();
-  bool EquateCons = true;
   while (I != vars.end()) {
     Atom *IAt = *I;
     Atom *JAt = *J;
     ConstAtom *ICAt = dyn_cast<ConstAtom>(IAt);
     ConstAtom *JCAt = dyn_cast<ConstAtom>(JAt);
-    EquateCons = true;
     if (JCAt && !ICAt) {
       NewVatoms.push_back(JAt);
     } else {

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -1174,8 +1174,7 @@ class CastPlacementVisitor :
 public:
   explicit CastPlacementVisitor(ASTContext *C, ProgramInfo &I,
                                 Rewriter &R)
-      : Context(C), Info(I), Writer(R), CR(Info, Context),
-        FD(nullptr) {}
+      : Context(C), Info(I), Writer(R), CR(Info, Context) {}
 
   bool VisitCallExpr(CallExpr *CE) {
     Decl *D = CE->getCalleeDecl();
@@ -1254,7 +1253,7 @@ private:
     if (SrcChecked) {
       // Check if Dst is an itype, if yes then
       // Src should have exactly same checked type else we need to insert cast.
-      if (Dst->getItypePresent()) {
+      if (Dst->hasItype()) {
         return !Dst->solutionEqualTo(Info.getConstraints(), Src);
       }
 

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -510,7 +510,7 @@ std::string TypeRewritingVisitor::getExistingIType(ConstraintVariable *DeclC) {
   std::string Ret = "";
   ConstraintVariable *T = DeclC;
   if (PVConstraint *PVC = dyn_cast<PVConstraint>(T)) {
-    if (PVC->getItypePresent()) {
+    if (PVC->hasItype()) {
       Ret = " : " + PVC->getItype();
     }
   }

--- a/clang/test/CheckedCRewriter/itypecast.c
+++ b/clang/test/CheckedCRewriter/itypecast.c
@@ -1,0 +1,47 @@
+// Tests for Checked C rewriter tool.
+//
+// Checks cast insertion while passing arguments to itype parameters.
+//
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines %s
+// RUN: cconv-standalone %s -- | %clang_cc1 -fignore-checkedc-pointers -verify -fcheckedc-extension -x c -
+// expected-no-diagnostics
+
+int foo(int **p:itype(_Ptr<_Ptr<int>>));
+int bar(int **p:itype(_Ptr<int *>));
+int baz(int ((*compar)(const int *, const int *)) :
+             itype(_Ptr<int (_Ptr<const int>, _Ptr<const int>)>));
+             
+int func(void) {
+    int ((*fptr1)(const int *, const int *));
+    int ((*fptr2)(const int *, const int *));
+    
+    int **fp1;
+    int **fp2;
+    int **bp1;
+    int **bp2;
+    
+    *fp2 = 2;
+    foo(fp1);
+    foo(fp2);
+    bar(bp1);
+    bp2 = 2;
+    *bp2 = 2;
+    bar(bp2);
+    fptr1(2, 0);
+    baz(fptr1);
+    baz(fptr2);
+    return 0;    
+}
+//CHECK: _Ptr<int (const int *, _Ptr<const int> )> fptr1 = ((void *)0);
+//CHECK-NEXT: _Ptr<int (_Ptr<const int> , _Ptr<const int> )> fptr2 = ((void *)0);
+//CHECK: _Ptr<_Ptr<int>> fp1 = ((void *)0);
+//CHECK-NEXT: _Ptr<int*> fp2 = ((void *)0);
+//CHECK-NEXT: _Ptr<int*> bp1 = ((void *)0);
+//CHECK-NEXT: int **bp2;
+//CHECK: foo(fp1);
+//CHECK-NEXT: foo(((int **)fp2));
+//CHECK-NEXT: bar(bp1);
+//CHECK: bar(bp2);
+//CHECK-NEXT: fptr1(2, 0);
+//CHECK-NEXT: baz(((int ((*)(const int *, const int *)) )fptr1));
+//CHECK-NEXT: baz(fptr2);

--- a/clang/test/CheckedCRewriter/itypecast.c
+++ b/clang/test/CheckedCRewriter/itypecast.c
@@ -3,8 +3,6 @@
 // Checks cast insertion while passing arguments to itype parameters.
 //
 // RUN: cconv-standalone %s -- | FileCheck -match-full-lines %s
-// RUN: cconv-standalone %s -- | %clang_cc1 -fignore-checkedc-pointers -verify -fcheckedc-extension -x c -
-// expected-no-diagnostics
 
 int foo(int **p:itype(_Ptr<_Ptr<int>>));
 int bar(int **p:itype(_Ptr<int *>));


### PR DESCRIPTION
is fix addresses assignment of arguments to itype parameters.
For itype parameters, the requirement is that if the argument is checked type, then it has to match the exact type specified inside itype annotation.

For example:

void foo(int **p:itype(_Ptr<_Ptr<int>>));
void bar() {
   _Ptr<_Ptr<int>> itype_match = 0;
  int **wild_match;
 _Ptr<int *> mis_match = 0;
  // This is Okay, as this matches the itype perfectly.
  foo(itype_match);
  // This is Okay, as this matches the wild type.
  foo(wild_match);
  // This is Not Okay, because the type does not match the WILD type or itype.
  foo(mis_match);
}
This fix, checks if the itype match is correct, if not, adds a cast to the argument.

I have also cleaned up code a bit to remove certain unused variables.

**With this fix, Complete automated conversion of vsftpd on ubuntu works!!**

This also removes the code to add fancy cast. Also, addresses all the comments in the old merge request: https://github.com/plum-umd/checkedc-clang/pull/111