### PR TITLE
GraphViz Improvements

### DIFF
--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -71,6 +71,7 @@ private:
 
   std::set<ConstraintVariable *>
       getAllSubExprConstraintVars(std::vector<Expr *> &Exprs);
+  std::set<ConstraintVariable *> getBaseVarPVConstraint(DeclRefExpr *Decl);
 };
 
 #endif // _CONSTRAINTRESOLVER_H

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -165,6 +165,8 @@ public:
   static PointerVariableConstraint *getWildPVConstraint(Constraints &CS);
   static PointerVariableConstraint *getPtrPVConstraint(Constraints &CS);
   static PointerVariableConstraint *getNonPtrPVConstraint(Constraints &CS);
+  static PointerVariableConstraint *getNamedNonPtrPVConstraint(StringRef name, Constraints &CS);
+
 private:
   std::string BaseType;
   CAtoms vars;

--- a/clang/include/clang/CConv/ConstraintsGraph.h
+++ b/clang/include/clang/CConv/ConstraintsGraph.h
@@ -19,9 +19,12 @@
 using namespace boost;
 using namespace std;
 
+enum EdgeType { Ptype, Checked };
+const std::string EdgeTypeColors[2] = { "blue", "red" };
+
 class ConstraintsGraph {
 public:
-  typedef adjacency_list<setS, vecS, bidirectionalS, Atom*> DirectedGraphType;
+  typedef adjacency_list<vecS, vecS, bidirectionalS, Atom*, EdgeType> DirectedGraphType;
   typedef boost::graph_traits<DirectedGraphType>::vertex_descriptor vertex_t;
   typedef std::map<Atom*, vertex_t> VertexMapType;
 
@@ -38,7 +41,7 @@ public:
 
   // Get all successors of a given Atom which are of particular type.
   template <typename ConstraintType>
-  bool getNeighbors(Atom *A, std::set<Atom*> &Atoms, bool Succs) {
+  bool getNeighbors(Atom *A, std::set<Atom*> &Atoms, bool Succs, EdgeType edgeType) {
     // Get the vertex descriptor.
     auto Vidx = addVertex(A);
     Atoms.clear();
@@ -47,8 +50,10 @@ public:
       for (boost::tie(ei, ei_end) = out_edges(Vidx, CG); ei != ei_end; ++ei) {
         auto source = boost::source(*ei, CG);
         auto target = boost::target(*ei, CG);
+
         assert(CG[source] == A && "Source has to be the given node.");
-        if (clang::dyn_cast<ConstraintType>(CG[target])) {
+
+        if (CG[*ei] == edgeType && clang::dyn_cast<ConstraintType>(CG[target])) {
           Atoms.insert(CG[target]);
         }
       }
@@ -58,7 +63,8 @@ public:
         auto source = boost::source ( *ei, CG );
         auto target = boost::target ( *ei, CG );
         assert(CG[target] == A && "Target has to be the given node.");
-        if (clang::dyn_cast<ConstraintType>(CG[source])) {
+
+        if (CG[*ei] == edgeType && clang::dyn_cast<ConstraintType>(CG[source])) {
           Atoms.insert(CG[source]);
         }
       }

--- a/clang/include/clang/CConv/ConstraintsGraph.h
+++ b/clang/include/clang/CConv/ConstraintsGraph.h
@@ -14,7 +14,6 @@
 
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/dijkstra_shortest_paths.hpp>
 #include "clang/CConv/Constraints.h"
 
 using namespace boost;
@@ -31,7 +30,6 @@ public:
     AtomToVDMap.clear();
   }
 
-  void addEdge(Atom *V1, Atom *V2, bool isBackward);
   void addConstraint(Geq *C, Constraints &CS);
 
   // Get all ConstAtoms, basically the points

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -68,6 +68,13 @@ PointerVariableConstraint::getNonPtrPVConstraint(Constraints &CS) {
   return GlobalNonPtrPV;
 }
 
+PointerVariableConstraint *
+PointerVariableConstraint::getNamedNonPtrPVConstraint(StringRef name,
+                                                      Constraints &CS) {
+  CAtoms NewVA; // empty -- represents a base type
+  return new PVConstraint(NewVA, "unsigned", name, nullptr, false, false, "");
+}
+
 PointerVariableConstraint::
     PointerVariableConstraint(PointerVariableConstraint *Ot,
                               Constraints &CS) :

--- a/clang/lib/CConv/Constraints.cpp
+++ b/clang/lib/CConv/Constraints.cpp
@@ -312,8 +312,10 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
     else
       llvm_unreachable("Bogus constraint type");
   }
-  if (DebugSolver)
-    CG.dumpCGDot("checked_constraints_graph.dot");
+
+  if (DebugSolver) {
+    CG.dumpCGDot("initial_constraints_graph.dot");
+  }
 
   // Solve Checked/unchecked constraints first
   env.doCheckedSolve(true);
@@ -322,8 +324,6 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
   // now solve PtrType constraints
   if (res && AllTypes) {
     env.doCheckedSolve(false);
-    if (DebugSolver)
-      CG.dumpCGDot("ptyp_constraints_graph.dot");
 
     // Step 1: Greatest solution
     res =
@@ -364,6 +364,10 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
     }
     // Final Step: Merge ptyp solution with checked solution
     env.mergePtrTypes();
+  }
+
+  if (DebugSolver) {
+    CG.dumpCGDot("implication_constraints_graph.dot");
   }
 
   return res;

--- a/clang/lib/CConv/Constraints.cpp
+++ b/clang/lib/CConv/Constraints.cpp
@@ -163,7 +163,8 @@ static bool do_solve(ConstraintsGraph &CG,
                      ConstraintsEnv & env,
                      Constraints *CS, bool doLeastSolution,
                      std::set<VarAtom *> *InitVs,
-                     Constraints::ConstraintSet &Conflicts) {
+                     Constraints::ConstraintSet &Conflicts,
+                     EdgeType edgeType) {
 
   std::vector<Atom *> WorkList;
   std::set<Implies *> FiredImplies;
@@ -185,7 +186,7 @@ static bool do_solve(ConstraintsGraph &CG,
 
       // get its neighbors
       std::set<Atom *> Neighbors;
-      CG.getNeighbors<VarAtom>(Curr, Neighbors, doLeastSolution);
+      CG.getNeighbors<VarAtom>(Curr, Neighbors, doLeastSolution, edgeType);
       // update each successor's solution
       for (auto *NeighborA : Neighbors) {
         bool Changed = false;
@@ -242,7 +243,7 @@ static bool do_solve(ConstraintsGraph &CG,
   std::set<Atom *> Neighbors;
   bool ok = true;
   for (ConstAtom *Cbound : CG.getAllConstAtoms()) {
-    if (CG.getNeighbors<VarAtom>(Cbound, Neighbors, !doLeastSolution)) {
+    if (CG.getNeighbors<VarAtom>(Cbound, Neighbors, !doLeastSolution, edgeType)) {
       for (Atom *A : Neighbors) {
         VarAtom *VA = dyn_cast<VarAtom>(A);
         assert (VA != nullptr && "bogus vertex");
@@ -289,8 +290,7 @@ auto isNonParamReturn =
     };
 
 bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
-  ConstraintsGraph ChkCG;
-  ConstraintsGraph PtrTypCG;
+  ConstraintsGraph CG;
   std::set<Implies *> SavedImplies;
   std::set<Implies *> Empty;
   ConstraintsEnv &env = environment;
@@ -301,10 +301,7 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
   // Setup the Checked Constraint Graph.
   for (const auto &C : constraints) {
     if (Geq *G = dyn_cast<Geq>(C)) {
-      if (G->constraintIsChecked())
-	ChkCG.addConstraint(G, *this);
-      else
-        PtrTypCG.addConstraint(G, *this);
+      CG.addConstraint(G, *this);
     }
     // Save the implies to solve them later.
     else if (Implies *Imp = dyn_cast<Implies>(C)) {
@@ -316,33 +313,33 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
       llvm_unreachable("Bogus constraint type");
   }
   if (DebugSolver)
-    ChkCG.dumpCGDot("checked_constraints_graph.dot");
+    CG.dumpCGDot("checked_constraints_graph.dot");
 
   // Solve Checked/unchecked constraints first
   env.doCheckedSolve(true);
-  bool res = do_solve(ChkCG, SavedImplies, env, this, true, nullptr, Conflicts);
+  bool res = do_solve(CG, SavedImplies, env, this, true, nullptr, Conflicts, Checked);
 
   // now solve PtrType constraints
   if (res && AllTypes) {
     env.doCheckedSolve(false);
     if (DebugSolver)
-      PtrTypCG.dumpCGDot("ptyp_constraints_graph.dot");
+      CG.dumpCGDot("ptyp_constraints_graph.dot");
 
     // Step 1: Greatest solution
     res =
-        do_solve(PtrTypCG, Empty, env, this, false, nullptr, Conflicts);
+        do_solve(CG, Empty, env, this, false, nullptr, Conflicts, Ptype);
 
     // Step 2: Reset all solutions but for function params, and compute the least
     if (res) {
       std::set<VarAtom *> rest = env.resetSolution(isNonParam, getNTArr());
-      res = do_solve(PtrTypCG, Empty, env, this, true, &rest, Conflicts);
+      res = do_solve(CG, Empty, env, this, true, &rest, Conflicts, Ptype);
 
       // Step 3: Reset local variable solutions, compute greatest
       if (res) {
         rest.clear();
         rest = env.resetSolution(isNonParamReturn, getPtr());
-        res = do_solve(PtrTypCG, Empty, env, this, false, &rest,
-                       Conflicts);
+        res = do_solve(CG, Empty, env, this, false, &rest,
+                       Conflicts, Ptype);
       }
     }
     // If PtrType solving (partly) failed, make the affected VarAtoms wild
@@ -361,8 +358,8 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
       }
       Conflicts.clear();
       /* FIXME: Should we propagate the old res? */
-      res = do_solve(ChkCG, SavedImplies, env, this, true, &rest,
-                     Conflicts);
+      res = do_solve(CG, SavedImplies, env, this, true, &rest,
+                     Conflicts, Checked);
 
     }
     // Final Step: Merge ptyp solution with checked solution

--- a/clang/lib/CConv/ConstraintsGraph.cpp
+++ b/clang/lib/CConv/ConstraintsGraph.cpp
@@ -50,14 +50,27 @@ void ConstraintsGraph::addConstraint(Geq *C, Constraints &CS) {
   }
   auto V1 = addVertex(A1);
   auto V2 = addVertex(A2);
-  add_edge(V2, V1, CG);
+
+  EdgeType edgeType;
+  if (C->constraintIsChecked()) {
+    edgeType = Checked;
+  } else {
+    edgeType = Ptype;
+  }
+
+  add_edge(V2, V1, edgeType, CG);
 }
 
 void ConstraintsGraph::dumpCGDot(const std::string& GraphDotFile) {
    std::ofstream DotFile;
    DotFile.open(GraphDotFile);
-   write_graphviz(DotFile, CG, [&] (std::ostream &out, unsigned v) {
-     out << "[label=\"" << CG[v]->getStr() << "\"]";
-   });
+   write_graphviz(DotFile, CG,
+       [&] (std::ostream &out, unsigned v) {
+         out << "[label=\"" << CG[v]->getStr() << "\"]";
+       },
+       [&] (std::ostream &out, boost::detail::edge_desc_impl<boost::bidirectional_tag, long unsigned int> e)  {
+         std::string color = EdgeTypeColors[CG[e]];
+         out << "[color=\"" << color << "\"]";
+       });
    DotFile.close();
 }


### PR DESCRIPTION
Some minor improvements to the visualization of constraint graphs:
 * Combine ptyp and checked graphs into a single image with shared nodes (edges color coded to show constraint type: red -> checked constraint; blue -> ptyp constraint).
 * Output a graph after implication constraints are resolved
 * More meaningful names for atoms in some cases
![initial_constraints_graph dot](https://user-images.githubusercontent.com/7480329/84915308-9d583300-b08a-11ea-9e72-2167514b2e48.png)

