### PR TITLE
Initial fix to iss96

### DIFF
--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -134,6 +134,10 @@ static Atom *analyzeAllocExpr(Expr *E, Constraints &CS, QualType &ArgTy) {
 
   // Look for sizeof(X); return Arr or Ptr if found
   for (Expr *Ex: Exprs) {
+    //normalize the expression if part of an implicit cast
+    if(ImplicitCastExpr *imp = dyn_cast<ImplicitCastExpr>(Ex)) {
+      Ex = imp->getSubExprAsWritten();
+    }
     UnaryExprOrTypeTraitExpr *arg = dyn_cast<UnaryExprOrTypeTraitExpr>(Ex);
     if (arg && arg->getKind() == UETT_SizeOf) {
       ArgTy = arg->getTypeOfArgument();

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -120,6 +120,7 @@ PVConstraint *ConstraintResolver::addAtom(PVConstraint *PVC, Atom *PtrTyp, Const
 // Processes E from malloc(E) to discern the pointer type this will be
 static Atom *analyzeAllocExpr(Expr *E, Constraints &CS, QualType &ArgTy) {
   Atom *ret = CS.getPtr();
+  E = E->IgnoreParenImpCasts();
   BinaryOperator *B = dyn_cast<BinaryOperator>(E);
   std::set<Expr *> Exprs;
 
@@ -134,10 +135,6 @@ static Atom *analyzeAllocExpr(Expr *E, Constraints &CS, QualType &ArgTy) {
 
   // Look for sizeof(X); return Arr or Ptr if found
   for (Expr *Ex: Exprs) {
-    //normalize the expression if part of an implicit cast
-    if(ImplicitCastExpr *imp = dyn_cast<ImplicitCastExpr>(Ex)) {
-      Ex = imp->getSubExprAsWritten();
-    }
     UnaryExprOrTypeTraitExpr *arg = dyn_cast<UnaryExprOrTypeTraitExpr>(Ex);
     if (arg && arg->getKind() == UETT_SizeOf) {
       ArgTy = arg->getTypeOfArgument();

--- a/clang/test/CheckedCRewriter/.gitignore
+++ b/clang/test/CheckedCRewriter/.gitignore
@@ -1,0 +1,1 @@
+lit.local.cfg

--- a/clang/test/CheckedCRewriter/.gitignore
+++ b/clang/test/CheckedCRewriter/.gitignore
@@ -1,1 +1,0 @@
-lit.local.cfg

--- a/clang/test/CheckedCRewriter/arrboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrboth-alltypes.c
@@ -103,7 +103,7 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -113,7 +113,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -124,5 +123,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrboth.c
+++ b/clang/test/CheckedCRewriter/arrboth.c
@@ -104,7 +104,7 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -114,7 +114,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -125,5 +124,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrbothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -111,7 +111,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -122,5 +121,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrbothmulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti-alltypes2.c
@@ -108,5 +108,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -110,7 +110,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -121,5 +120,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti2.c
@@ -106,5 +106,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrcallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrcallee-alltypes.c
@@ -103,7 +103,7 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -113,7 +113,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -123,5 +122,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcallee.c
+++ b/clang/test/CheckedCRewriter/arrcallee.c
@@ -104,7 +104,7 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -114,7 +114,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -124,5 +123,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -111,7 +111,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -121,5 +120,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti-alltypes2.c
@@ -108,5 +108,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -110,7 +110,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -120,5 +119,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti2.c
@@ -106,5 +106,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrcaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrcaller-alltypes.c
@@ -102,7 +102,7 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -112,7 +112,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -123,5 +122,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcaller.c
+++ b/clang/test/CheckedCRewriter/arrcaller.c
@@ -103,7 +103,7 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -113,7 +113,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -124,5 +123,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -111,7 +111,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -122,5 +121,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcallermulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti-alltypes2.c
@@ -107,5 +107,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -110,7 +110,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -121,5 +120,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti2.c
@@ -105,5 +105,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrinstructboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructboth-alltypes.c
@@ -113,7 +113,7 @@ struct warr * foo() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -123,6 +123,6 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti-alltypes1.c
@@ -109,7 +109,7 @@ struct warr * foo() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -119,6 +119,6 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallee-alltypes.c
@@ -106,14 +106,14 @@ x = (struct warr *) 5;
         
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -122,6 +122,6 @@ struct warr * bar() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti-alltypes1.c
@@ -102,14 +102,14 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: _Array_ptr<struct warr> sus(struct warr *, struct warr *y : itype(_Array_ptr<struct warr>));
+//CHECK: _Ptr<struct warr> sus(struct warr *, struct warr *y : itype(_Array_ptr<struct warr>));
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -118,6 +118,6 @@ struct warr * bar() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti-alltypes2.c
@@ -111,4 +111,4 @@ x = (struct warr *) 5;
         
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructcaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructcaller-alltypes.c
@@ -112,7 +112,7 @@ struct warr * foo() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -122,6 +122,6 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructcaller.c
@@ -106,7 +106,7 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: struct warr *sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) : itype(_Ptr<struct warr>) {
+//CHECK: struct warr *sus(struct warr *x, _Ptr<struct warr> y) : itype(_Ptr<struct warr>) {
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -115,7 +115,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -125,5 +124,4 @@ z += 2;
 return z; }
 //CHECK: struct warr * bar() {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 //CHECK:         struct warr * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti-alltypes1.c
@@ -109,7 +109,7 @@ struct warr * foo() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -119,6 +119,6 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: struct warr *sus(struct warr *, struct warr *y : itype(_Ptr<struct warr>)) : itype(_Ptr<struct warr>);
+//CHECK: struct warr *sus(struct warr *, _Ptr<struct warr> y) : itype(_Ptr<struct warr>);
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -110,7 +110,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -120,5 +119,4 @@ z += 2;
 return z; }
 //CHECK: struct warr * bar() {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 //CHECK:         struct warr * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti2.c
@@ -108,4 +108,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: struct warr *sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) : itype(_Ptr<struct warr>) {
+//CHECK: struct warr *sus(struct warr *x, _Ptr<struct warr> y) : itype(_Ptr<struct warr>) {

--- a/clang/test/CheckedCRewriter/arrinstructprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotoboth-alltypes.c
@@ -107,7 +107,7 @@ struct warr * foo() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -117,7 +117,7 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 

--- a/clang/test/CheckedCRewriter/arrinstructprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocallee-alltypes.c
@@ -100,14 +100,14 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -116,7 +116,7 @@ struct warr * bar() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -130,4 +130,4 @@ x = (struct warr *) 5;
         
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {

--- a/clang/test/CheckedCRewriter/arrinstructprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocaller-alltypes.c
@@ -107,7 +107,7 @@ struct warr * foo() {
         struct warr * y = malloc(sizeof(struct warr));
         struct warr * z = sus(x, y);
 return z; }
-//CHECK: _Array_ptr<struct warr> foo(void) {
+//CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
@@ -117,7 +117,7 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: _Array_ptr<struct warr> bar(void) {
+//CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
 //CHECK:         struct warr * y = malloc(sizeof(struct warr));
 

--- a/clang/test/CheckedCRewriter/arrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocaller.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: struct warr *sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) : itype(_Ptr<struct warr>);
+//CHECK: struct warr *sus(struct warr *x, _Ptr<struct warr> y) : itype(_Ptr<struct warr>);
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -110,7 +110,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -120,7 +119,6 @@ z += 2;
 return z; }
 //CHECK: struct warr * bar() {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 //CHECK:         struct warr * z = sus(x, y);
 
 struct warr * sus(struct warr * x, struct warr * y) {
@@ -132,4 +130,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: struct warr *sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) : itype(_Ptr<struct warr>) {
+//CHECK: struct warr *sus(struct warr *x, _Ptr<struct warr> y) : itype(_Ptr<struct warr>) {

--- a/clang/test/CheckedCRewriter/arrinstructprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotosafe-alltypes.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>));
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y);
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -108,7 +108,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -117,7 +116,6 @@ struct warr * bar() {
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
@@ -128,4 +126,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y) {

--- a/clang/test/CheckedCRewriter/arrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotosafe.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>));
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y);
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -109,7 +109,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -118,7 +117,6 @@ struct warr * bar() {
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * sus(struct warr * x, struct warr * y) {
 x = (struct warr *) 5;
@@ -129,4 +127,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y) {

--- a/clang/test/CheckedCRewriter/arrinstructsafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafe-alltypes.c
@@ -104,7 +104,7 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y) {
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -113,7 +113,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -122,4 +121,3 @@ struct warr * bar() {
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafe.c
@@ -105,7 +105,7 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y) {
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -114,7 +114,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -123,4 +122,3 @@ struct warr * bar() {
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti-alltypes1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: _Ptr<struct warr> sus(struct warr *, struct warr *y : itype(_Ptr<struct warr>));
+//CHECK: _Ptr<struct warr> sus(struct warr *, _Ptr<struct warr> y);
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -110,7 +110,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -119,4 +118,3 @@ struct warr * bar() {
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti-alltypes2.c
@@ -109,4 +109,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y) {

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct warr * sus(struct warr *, struct warr *);
-//CHECK: _Ptr<struct warr> sus(struct warr *, struct warr *y : itype(_Ptr<struct warr>));
+//CHECK: _Ptr<struct warr> sus(struct warr *, _Ptr<struct warr> y);
 
 struct warr * foo() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -109,7 +109,6 @@ struct warr * foo() {
 return z; }
 //CHECK: _Ptr<struct warr> foo(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));
 
 struct warr * bar() {
         struct warr * x = malloc(sizeof(struct warr));
@@ -118,4 +117,3 @@ struct warr * bar() {
 return z; }
 //CHECK: _Ptr<struct warr> bar(void) {
 //CHECK:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK:         struct warr * y = malloc(sizeof(struct warr));

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti2.c
@@ -107,4 +107,4 @@ x = (struct warr *) 5;
         }
         
 return z; }
-//CHECK: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Ptr<struct warr>)) {
+//CHECK: _Ptr<struct warr> sus(struct warr *x, _Ptr<struct warr> y) {

--- a/clang/test/CheckedCRewriter/arrprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrprotoboth-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -109,7 +109,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -120,7 +119,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -130,5 +128,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrprotoboth.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -110,7 +110,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -121,7 +120,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -131,5 +129,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrprotocallee-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -109,7 +109,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -119,7 +118,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -129,5 +127,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrprotocallee.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -110,7 +110,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -120,7 +119,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -130,5 +128,5 @@ x = (int *) 5;
         { *p = fac; }
 z += 2;
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrprotocaller-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -109,7 +109,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -120,7 +119,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -129,5 +127,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrprotocaller.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -110,7 +110,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -121,7 +120,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -130,5 +128,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrprotosafe-alltypes.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -108,7 +108,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -118,7 +117,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -127,5 +125,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrprotosafe.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *x, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -109,7 +109,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -119,7 +118,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -128,5 +126,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrsafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrsafe-alltypes.c
@@ -101,7 +101,7 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -111,7 +111,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -121,5 +120,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafe.c
+++ b/clang/test/CheckedCRewriter/arrsafe.c
@@ -102,7 +102,7 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
 
 int * foo() {
@@ -112,7 +112,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -122,5 +121,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti-alltypes1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -110,7 +110,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -120,5 +119,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti-alltypes2.c
@@ -106,5 +106,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(int *, int *);
-//CHECK: int * sus(int *, int *y : itype(_Ptr<int>));
+//CHECK: int * sus(int *, _Ptr<int> y);
 
 int * foo() {
         int * x = malloc(sizeof(int));
@@ -109,7 +109,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -119,5 +118,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         int * x = malloc(sizeof(int));
-//CHECK:         int * y = malloc(sizeof(int));
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti2.c
@@ -104,5 +104,5 @@ x = (int *) 5;
         for(int i = 0, *p = z, fac = 1; i < 5; ++i, p++, fac *= i) 
         { *p = fac; }
 return z; }
-//CHECK: int * sus(int *x, int *y : itype(_Ptr<int>)) {
+//CHECK: int * sus(int *x, _Ptr<int> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructboth-alltypes.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -106,9 +106,8 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -124,8 +123,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -143,6 +140,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructboth.c
+++ b/clang/test/CheckedCRewriter/arrstructboth.c
@@ -28,7 +28,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -107,9 +107,8 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -125,8 +124,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -144,6 +141,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructbothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti-alltypes1.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -118,8 +118,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -137,6 +135,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructbothmulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti-alltypes2.c
@@ -111,5 +111,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,8 +117,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -136,6 +134,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti2.c
@@ -109,5 +109,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructcallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructcallee-alltypes.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -106,9 +106,8 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -124,8 +123,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -142,6 +139,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrstructcallee.c
@@ -28,7 +28,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -107,9 +107,8 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -125,8 +124,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -143,6 +140,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti-alltypes1.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -118,8 +118,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -136,6 +134,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti-alltypes2.c
@@ -111,5 +111,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,8 +117,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -135,6 +133,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
@@ -109,5 +109,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructcaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructcaller-alltypes.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -105,9 +105,8 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -123,8 +122,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -142,6 +139,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrstructcaller.c
@@ -28,7 +28,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -106,9 +106,8 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -124,8 +123,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -143,6 +140,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti-alltypes1.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -118,8 +118,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -137,6 +135,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallermulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti-alltypes2.c
@@ -110,5 +110,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,8 +117,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -136,6 +134,4 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti2.c
@@ -108,5 +108,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructprotoboth-alltypes.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,8 +116,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -135,8 +133,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -149,6 +145,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrstructprotoboth.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,8 +117,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -136,8 +134,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -150,6 +146,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocallee-alltypes.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,8 +116,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -134,8 +132,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -148,6 +144,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocallee.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,8 +117,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -135,8 +133,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -149,6 +145,5 @@ x = (struct general *) 5;
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocaller-alltypes.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,8 +116,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -135,8 +133,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -148,6 +144,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocaller.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,8 +117,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -136,8 +134,6 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -149,6 +145,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructprotosafe-alltypes.c
@@ -29,7 +29,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -115,8 +115,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -133,8 +131,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -146,6 +142,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrstructprotosafe.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,8 +116,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -134,8 +132,6 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * sus(struct general * x, struct general * y) {
@@ -147,6 +143,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/arrstructsafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/arrstructsafe-alltypes.c
@@ -26,7 +26,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -104,9 +104,8 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -122,8 +121,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -140,6 +137,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrstructsafe.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -105,9 +105,8 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -123,8 +122,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -141,6 +138,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti-alltypes1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -117,8 +117,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -135,6 +133,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti-alltypes2.c
@@ -109,5 +109,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/arrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti1.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *y : itype(_Ptr<struct general>));
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
         struct general * x = malloc(sizeof(struct general));
@@ -116,8 +116,6 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);
 
 int * bar() {
@@ -134,6 +132,4 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general * x = malloc(sizeof(struct general));
-//CHECK:         struct general * y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
 //CHECK:         int * z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti2.c
@@ -107,5 +107,5 @@ x = (struct general *) 5;
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y : itype(_Ptr<struct general>)) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructboth-alltypes.c
@@ -111,7 +111,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
@@ -127,7 +127,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -144,5 +143,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructboth.c
@@ -112,7 +112,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
@@ -128,7 +128,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -145,5 +144,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -117,7 +117,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -134,5 +133,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti-alltypes2.c
@@ -116,5 +116,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -116,7 +116,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -133,5 +132,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
@@ -114,5 +114,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallee-alltypes.c
@@ -111,7 +111,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
@@ -127,7 +127,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -143,5 +142,4 @@ struct arrfptr * bar() {
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
@@ -112,7 +112,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
@@ -128,7 +128,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -144,5 +143,4 @@ struct arrfptr * bar() {
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -117,7 +117,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -133,5 +132,4 @@ struct arrfptr * bar() {
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti-alltypes2.c
@@ -116,5 +116,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -116,7 +116,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -132,5 +131,4 @@ struct arrfptr * bar() {
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
@@ -114,5 +114,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcaller-alltypes.c
@@ -110,7 +110,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
@@ -126,7 +126,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -143,5 +142,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
@@ -111,8 +111,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: struct arrfptr *sus(struct arrfptr *x, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>) {
 
 struct arrfptr * foo() {
  
@@ -125,10 +124,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -144,5 +141,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -117,7 +117,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -134,5 +133,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti-alltypes2.c
@@ -115,5 +115,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr *sus(struct arrfptr *, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>);
 
 struct arrfptr * foo() {
  
@@ -114,10 +114,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -133,5 +131,4 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
@@ -113,5 +113,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: struct arrfptr *sus(struct arrfptr *x, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotoboth-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -115,7 +115,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -132,7 +131,6 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -150,5 +148,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -116,7 +116,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -133,7 +132,6 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -151,5 +149,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocallee-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -115,7 +115,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -131,7 +130,6 @@ struct arrfptr * bar() {
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -149,5 +147,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -116,7 +116,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -132,7 +131,6 @@ struct arrfptr * bar() {
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -150,5 +148,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocaller-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -115,7 +115,6 @@ struct arrfptr * foo() {
 return z; }
 //CHECK: struct arrfptr * foo() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -132,7 +131,6 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -149,5 +147,5 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
+//CHECK: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 //CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: struct arrfptr *sus(struct arrfptr *x, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>);
 
 struct arrfptr * foo() {
  
@@ -114,10 +114,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -133,7 +131,6 @@ z += 2;
 return z; }
 //CHECK: struct arrfptr * bar() {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
 //CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -150,5 +147,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: struct arrfptr *sus(struct arrfptr *x, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotosafe-alltypes.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -112,10 +112,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -128,10 +126,8 @@ struct arrfptr * bar() {
         }
         
 return z; }
-//CHECK: struct arrfptr * bar() {
+//CHECK: _Ptr<struct arrfptr> bar(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -147,5 +143,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -113,10 +113,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -129,10 +127,8 @@ struct arrfptr * bar() {
         }
         
 return z; }
-//CHECK: struct arrfptr * bar() {
+//CHECK: _Ptr<struct arrfptr> bar(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
  
@@ -148,5 +144,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafe-alltypes.c
@@ -109,8 +109,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 
 struct arrfptr * foo() {
  
@@ -123,10 +122,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -139,7 +136,5 @@ struct arrfptr * bar() {
         }
         
 return z; }
-//CHECK: struct arrfptr * bar() {
+//CHECK: _Ptr<struct arrfptr> bar(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
@@ -110,8 +110,7 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
 
 struct arrfptr * foo() {
  
@@ -124,10 +123,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -140,7 +137,5 @@ struct arrfptr * bar() {
         }
         
 return z; }
-//CHECK: struct arrfptr * bar() {
+//CHECK: _Ptr<struct arrfptr> bar(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti-alltypes1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -114,10 +114,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -130,7 +128,5 @@ struct arrfptr * bar() {
         }
         
 return z; }
-//CHECK: struct arrfptr * bar() {
+//CHECK: _Ptr<struct arrfptr> bar(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti-alltypes2.c
@@ -114,5 +114,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct arrfptr * sus(struct arrfptr *, struct arrfptr *);
-//CHECK: struct arrfptr * sus(struct arrfptr *, struct arrfptr *y : itype(_Ptr<struct arrfptr>));
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *, _Ptr<struct arrfptr> y);
 
 struct arrfptr * foo() {
  
@@ -113,10 +113,8 @@ struct arrfptr * foo() {
         }
         
 return z; }
-//CHECK: struct arrfptr * foo() {
+//CHECK: _Ptr<struct arrfptr> foo(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
  
@@ -129,7 +127,5 @@ struct arrfptr * bar() {
         }
         
 return z; }
-//CHECK: struct arrfptr * bar() {
+//CHECK: _Ptr<struct arrfptr> bar(void) {
 //CHECK:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr * y =  malloc(sizeof(struct arrfptr));
-//CHECK:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
@@ -112,5 +112,4 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         z->funcs[4] = fact;
         
 return z; }
-//CHECK: struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y : itype(_Ptr<struct arrfptr>)) {
-//CHECK:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructboth-alltypes.c
@@ -110,7 +110,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
@@ -131,7 +131,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -154,6 +153,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructboth.c
@@ -111,7 +111,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
@@ -132,7 +132,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -155,6 +154,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -122,7 +122,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -145,6 +144,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti-alltypes2.c
@@ -115,5 +115,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -121,7 +121,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -144,6 +143,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
@@ -113,5 +113,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructcallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallee-alltypes.c
@@ -110,7 +110,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
@@ -131,7 +131,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -153,6 +152,5 @@ struct fptrarr * bar() {
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallee.c
@@ -111,7 +111,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
@@ -132,7 +132,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -154,6 +153,5 @@ struct fptrarr * bar() {
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -122,7 +122,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -144,6 +143,5 @@ struct fptrarr * bar() {
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti-alltypes2.c
@@ -115,5 +115,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -121,7 +121,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -143,6 +142,5 @@ struct fptrarr * bar() {
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
@@ -113,5 +113,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructcaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcaller-alltypes.c
@@ -109,7 +109,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
@@ -130,7 +130,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -153,6 +152,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcaller.c
@@ -110,8 +110,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: struct fptrarr *sus(struct fptrarr *x, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>) {
 
 struct fptrarr * foo() {
  
@@ -129,11 +128,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -154,6 +151,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -122,7 +122,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -145,6 +144,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti-alltypes2.c
@@ -114,5 +114,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr *sus(struct fptrarr *, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>);
 
 struct fptrarr * foo() {
  
@@ -119,11 +119,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -144,6 +142,5 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
@@ -112,5 +112,4 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: struct fptrarr *sus(struct fptrarr *x, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotoboth-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -120,7 +120,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -143,7 +142,6 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -161,5 +159,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -121,7 +121,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -144,7 +143,6 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -162,5 +160,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocallee-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -120,7 +120,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -142,7 +141,6 @@ struct fptrarr * bar() {
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -160,5 +158,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -121,7 +121,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -143,7 +142,6 @@ struct fptrarr * bar() {
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -161,5 +159,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocaller-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -120,7 +120,6 @@ struct fptrarr * foo() {
 return z; }
 //CHECK: struct fptrarr * foo() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -143,7 +142,6 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -160,5 +158,5 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
+//CHECK: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 //CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: struct fptrarr *sus(struct fptrarr *x, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>);
 
 struct fptrarr * foo() {
  
@@ -119,11 +119,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -144,7 +142,6 @@ z += 2;
 return z; }
 //CHECK: struct fptrarr * bar() {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
 //CHECK:         struct fptrarr *z = sus(x, y);
 
@@ -161,5 +158,4 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: struct fptrarr *sus(struct fptrarr *x, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotosafe-alltypes.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -117,11 +117,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -139,11 +137,9 @@ struct fptrarr * bar() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * bar() {
+//CHECK: _Ptr<struct fptrarr> bar(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -158,5 +154,4 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -118,11 +118,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -140,11 +138,9 @@ struct fptrarr * bar() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * bar() {
+//CHECK: _Ptr<struct fptrarr> bar(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
  
@@ -159,5 +155,4 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructsafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafe-alltypes.c
@@ -108,8 +108,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 
 struct fptrarr * foo() {
  
@@ -127,11 +126,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -149,8 +146,6 @@ struct fptrarr * bar() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * bar() {
+//CHECK: _Ptr<struct fptrarr> bar(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafe.c
@@ -109,8 +109,7 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
 
 struct fptrarr * foo() {
  
@@ -128,11 +127,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -150,8 +147,6 @@ struct fptrarr * bar() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * bar() {
+//CHECK: _Ptr<struct fptrarr> bar(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti-alltypes1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -119,11 +119,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -141,8 +139,6 @@ struct fptrarr * bar() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * bar() {
+//CHECK: _Ptr<struct fptrarr> bar(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti-alltypes2.c
@@ -113,5 +113,4 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptrarr * sus(struct fptrarr *, struct fptrarr *);
-//CHECK: struct fptrarr * sus(struct fptrarr *, struct fptrarr *y : itype(_Ptr<struct fptrarr>));
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *, _Ptr<struct fptrarr> y);
 
 struct fptrarr * foo() {
  
@@ -118,11 +118,9 @@ struct fptrarr * foo() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * foo() {
+//CHECK: _Ptr<struct fptrarr> foo(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
  
@@ -140,8 +138,6 @@ struct fptrarr * bar() {
         struct fptrarr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptrarr * bar() {
+//CHECK: _Ptr<struct fptrarr> bar(void) {
 //CHECK:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK:         struct fptrarr *y =  malloc(sizeof(struct fptrarr));
 //CHECK:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
@@ -111,5 +111,4 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         }
         
 return z; }
-//CHECK: struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y : itype(_Ptr<struct fptrarr>)) {
-//CHECK:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {

--- a/clang/test/CheckedCRewriter/fptrinstructboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructboth-alltypes.c
@@ -105,7 +105,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
@@ -117,7 +117,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -130,5 +129,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructboth.c
@@ -106,7 +106,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
@@ -118,7 +118,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -131,5 +130,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -113,7 +113,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -126,5 +125,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti-alltypes2.c
@@ -110,5 +110,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -112,7 +112,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -125,5 +124,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
@@ -108,5 +108,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallee-alltypes.c
@@ -105,7 +105,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
@@ -117,7 +117,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -129,5 +128,4 @@ struct fptr * bar() {
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallee.c
@@ -106,7 +106,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
@@ -118,7 +118,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -130,5 +129,4 @@ struct fptr * bar() {
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -113,7 +113,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -125,5 +124,4 @@ struct fptr * bar() {
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti-alltypes2.c
@@ -110,5 +110,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -112,7 +112,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -124,5 +123,4 @@ struct fptr * bar() {
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
@@ -108,5 +108,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcaller-alltypes.c
@@ -104,7 +104,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
 
 struct fptr * foo() {
@@ -116,7 +116,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -129,5 +128,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcaller.c
@@ -105,8 +105,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: struct fptr *sus(struct fptr *x, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>) {
 
 struct fptr * foo() {
  
@@ -115,10 +114,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -130,5 +127,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti-alltypes1.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -113,7 +113,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -126,5 +125,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti-alltypes2.c
@@ -109,5 +109,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr *sus(struct fptr *, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>);
 
 struct fptr * foo() {
  
@@ -110,10 +110,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -125,5 +123,4 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
@@ -107,5 +107,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: struct fptr *sus(struct fptr *x, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>) {

--- a/clang/test/CheckedCRewriter/fptrinstructprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotoboth-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -111,7 +111,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -124,7 +123,6 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -136,5 +134,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -112,7 +112,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -125,7 +124,6 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -137,5 +135,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocallee-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -111,7 +111,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -123,7 +122,6 @@ struct fptr * bar() {
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -135,5 +133,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -112,7 +112,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -124,7 +123,6 @@ struct fptr * bar() {
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -136,5 +134,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 z += 2;
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocaller-alltypes.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -111,7 +111,6 @@ struct fptr * foo() {
 return z; }
 //CHECK: struct fptr * foo() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -124,7 +123,6 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -135,5 +133,5 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
+//CHECK: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
 //CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: struct fptr *sus(struct fptr *x, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>);
 
 struct fptr * foo() {
  
@@ -110,10 +110,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -125,7 +123,6 @@ z += 2;
 return z; }
 //CHECK: struct fptr * bar() {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
 //CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -136,5 +133,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: struct fptr *sus(struct fptr *x, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>) {

--- a/clang/test/CheckedCRewriter/fptrinstructprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotosafe-alltypes.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -108,10 +108,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -120,10 +118,8 @@ struct fptr * bar() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * bar() {
+//CHECK: _Ptr<struct fptr> bar(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -133,5 +129,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {

--- a/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -109,10 +109,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -121,10 +119,8 @@ struct fptr * bar() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * bar() {
+//CHECK: _Ptr<struct fptr> bar(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
  
@@ -134,5 +130,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {

--- a/clang/test/CheckedCRewriter/fptrinstructsafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafe-alltypes.c
@@ -103,8 +103,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
 
 struct fptr * foo() {
  
@@ -113,10 +112,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -125,7 +122,5 @@ struct fptr * bar() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * bar() {
+//CHECK: _Ptr<struct fptr> bar(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafe.c
@@ -104,8 +104,7 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
 
 struct fptr * foo() {
  
@@ -114,10 +113,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -126,7 +123,5 @@ struct fptr * bar() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * bar() {
+//CHECK: _Ptr<struct fptr> bar(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti-alltypes1.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: _Ptr<struct fptr> sus(struct fptr *, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -110,10 +110,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -122,7 +120,5 @@ struct fptr * bar() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * bar() {
+//CHECK: _Ptr<struct fptr> bar(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti-alltypes2.c
@@ -108,5 +108,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 struct fptr * sus(struct fptr *, struct fptr *);
-//CHECK: struct fptr * sus(struct fptr *, struct fptr *y : itype(_Ptr<struct fptr>));
+//CHECK: _Ptr<struct fptr> sus(struct fptr *, _Ptr<struct fptr> y);
 
 struct fptr * foo() {
  
@@ -109,10 +109,8 @@ struct fptr * foo() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * foo() {
+//CHECK: _Ptr<struct fptr> foo(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
  
@@ -121,7 +119,5 @@ struct fptr * bar() {
         struct fptr *z = sus(x, y);
         
 return z; }
-//CHECK: struct fptr * bar() {
+//CHECK: _Ptr<struct fptr> bar(void) {
 //CHECK:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK:         struct fptr *y =  malloc(sizeof(struct fptr));
-//CHECK:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
@@ -106,5 +106,4 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         z->func = fact;
         
 return z; }
-//CHECK: struct fptr * sus(struct fptr *x, struct fptr *y : itype(_Ptr<struct fptr>)) {
-//CHECK:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {

--- a/clang/test/CheckedCRewriter/fptrsafeboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafeboth-alltypes.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -107,9 +107,8 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -127,9 +126,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -149,7 +146,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeboth.c
@@ -28,7 +28,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -108,9 +108,8 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -128,9 +127,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -150,7 +147,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti-alltypes1.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -120,9 +120,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -142,7 +140,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti-alltypes2.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -112,6 +112,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -119,9 +119,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -141,7 +139,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -110,6 +110,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafecallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallee-alltypes.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -107,9 +107,8 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -127,9 +126,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -148,7 +145,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallee.c
@@ -28,7 +28,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -108,9 +108,8 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -128,9 +127,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -149,7 +146,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti-alltypes1.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -120,9 +120,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -141,7 +139,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti-alltypes2.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -112,6 +112,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -119,9 +119,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -140,7 +138,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -110,6 +110,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafecaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafecaller-alltypes.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -106,9 +106,8 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -126,9 +125,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -148,7 +145,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafecaller.c
@@ -28,7 +28,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -107,9 +107,8 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -127,9 +126,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -149,7 +146,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti-alltypes1.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -120,9 +120,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -142,7 +140,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti-alltypes2.c
@@ -32,7 +32,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -111,6 +111,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -119,9 +119,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -141,7 +139,5 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -109,6 +109,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotoboth-alltypes.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -118,9 +118,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -140,9 +138,7 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -156,6 +152,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -119,9 +119,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -141,9 +139,7 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -157,6 +153,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocallee-alltypes.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -118,9 +118,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -139,9 +137,7 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -155,6 +151,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -119,9 +119,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -140,9 +138,7 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -156,6 +152,5 @@ int * sus(struct general *x, struct general *y) {
         
 z += 2;
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocaller-alltypes.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -118,9 +118,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -140,9 +138,7 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -155,6 +151,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -119,9 +119,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -141,9 +139,7 @@ z += 2;
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -156,6 +152,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotosafe-alltypes.c
@@ -29,7 +29,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -117,9 +117,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -138,9 +136,7 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -153,6 +149,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *x, struct general *y);
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -118,9 +118,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -139,9 +137,7 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * sus(struct general *x, struct general *y) {
@@ -154,6 +150,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafesafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafe-alltypes.c
@@ -26,7 +26,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -105,9 +105,8 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -125,9 +124,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -146,7 +143,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafe.c
@@ -27,7 +27,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -106,9 +106,8 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;
 
 int * foo() {
 
@@ -126,9 +125,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -147,7 +144,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti-alltypes1.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -119,9 +119,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -140,7 +138,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti-alltypes2.c
@@ -31,7 +31,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -110,6 +110,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
@@ -30,7 +30,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 int * sus(struct general *, struct general *);
-//CHECK: int * sus(struct general *, struct general *);
+//CHECK: int * sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 
@@ -118,9 +118,7 @@ int * foo() {
 return z; }
 //CHECK: int * foo() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);
 
 int * bar() {
@@ -139,7 +137,5 @@ int * bar() {
 return z; }
 //CHECK: int * bar() {
 //CHECK:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK:         struct general *y = malloc(sizeof(struct general));
-//CHECK:         struct general *curr = y;
-//CHECK:         _Ptr<int* (struct general *, struct general *)> sus_ptr =  sus;   
+//CHECK:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK:         int *z = sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
@@ -29,7 +29,7 @@ struct general {
     int data; 
     struct general *next;
 };
-//CHECK:     struct general *next;
+//CHECK:     _Ptr<struct general> next;
 
 
 struct warr { 
@@ -108,6 +108,5 @@ int * sus(struct general *x, struct general *y) {
         } 
         
 return z; }
-//CHECK: int * sus(struct general *x, struct general *y) {
+//CHECK: int * sus(struct general *x, _Ptr<struct general> y) {
 //CHECK:         int *z = calloc(5, sizeof(int)); 
-//CHECK:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/ptrTOptrboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrboth-alltypes.c
@@ -111,9 +111,9 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
@@ -122,10 +122,10 @@ char *** foo() {
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -133,7 +133,7 @@ char *** bar() {
         char *** z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrboth.c
@@ -112,7 +112,7 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
@@ -125,7 +125,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -136,5 +136,5 @@ z += 2;
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti-alltypes1.c
@@ -101,17 +101,17 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -119,7 +119,7 @@ char *** bar() {
         char *** z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti-alltypes2.c
@@ -116,8 +116,8 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -109,7 +109,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -120,5 +120,5 @@ z += 2;
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
@@ -114,7 +114,7 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallee-alltypes.c
@@ -111,9 +111,9 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
@@ -122,17 +122,17 @@ char *** foo() {
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallee.c
@@ -112,7 +112,7 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
@@ -125,7 +125,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -135,5 +135,5 @@ char *** bar() {
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti-alltypes1.c
@@ -101,24 +101,24 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti-alltypes2.c
@@ -116,8 +116,8 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -109,7 +109,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -119,5 +119,5 @@ char *** bar() {
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
@@ -114,7 +114,7 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcaller-alltypes.c
@@ -110,9 +110,9 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
@@ -121,10 +121,10 @@ char *** foo() {
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -132,7 +132,7 @@ char *** bar() {
         char *** z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcaller.c
@@ -111,7 +111,7 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
@@ -124,7 +124,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -135,5 +135,5 @@ z += 2;
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti-alltypes1.c
@@ -101,17 +101,17 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -119,7 +119,7 @@ char *** bar() {
         char *** z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti-alltypes2.c
@@ -115,8 +115,8 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -109,7 +109,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -120,5 +120,5 @@ z += 2;
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
@@ -113,7 +113,7 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotoboth-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotoboth-alltypes.c
@@ -99,17 +99,17 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -117,10 +117,10 @@ char *** bar() {
         char *** z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -138,8 +138,8 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -109,7 +109,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -120,7 +120,7 @@ z += 2;
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -139,7 +139,7 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocallee-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocallee-alltypes.c
@@ -99,27 +99,27 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -137,8 +137,8 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -109,7 +109,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -119,7 +119,7 @@ char *** bar() {
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -138,7 +138,7 @@ x = (char * * *) 5;
         
 z += 2;
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocaller-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocaller-alltypes.c
@@ -99,17 +99,17 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
@@ -117,10 +117,10 @@ char *** bar() {
         char *** z = sus(x, y);
 z += 2;
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -137,8 +137,8 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
@@ -100,7 +100,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -109,7 +109,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -120,7 +120,7 @@ z += 2;
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -138,7 +138,7 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotosafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotosafe-alltypes.c
@@ -98,27 +98,27 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
 x = (char * * *) 5;
@@ -135,8 +135,8 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -108,7 +108,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -118,7 +118,7 @@ char *** bar() {
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -136,7 +136,7 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrsafe-alltypes.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafe-alltypes.c
@@ -109,9 +109,9 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 
 
@@ -120,17 +120,17 @@ char *** foo() {
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafe.c
@@ -110,7 +110,7 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
@@ -123,7 +123,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -133,5 +133,5 @@ char *** bar() {
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti-alltypes1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti-alltypes1.c
@@ -100,24 +100,24 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** foo() {
+//CHECK: _Ptr<_Array_ptr<char*>> foo(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
         char * * * x = malloc(sizeof(char * *));
         char * * * y = malloc(sizeof(char * *));
         char *** z = sus(x, y);
 return z; }
-//CHECK: char *** bar() {
+//CHECK: _Ptr<_Array_ptr<char*>> bar(void) {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
-//CHECK:         char *** z = sus(x, y);
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti-alltypes2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti-alltypes2.c
@@ -114,8 +114,8 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
-//CHECK:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 
 //CHECK:                 z[i][j] = malloc(2*sizeof(char)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 //CHECK: _Ptr<int> mul2(_Ptr<int> x) { 
 
 char *** sus(char * * *, char * * *);
-//CHECK: char *** sus(char ***, char ***y : itype(_Ptr<char**>));
+//CHECK: char *** sus(char ***, _Ptr<_Ptr<_Ptr<char>>> y);
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -108,7 +108,7 @@ char *** foo() {
 return z; }
 //CHECK: char *** foo() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);
 
 char *** bar() {
@@ -118,5 +118,5 @@ char *** bar() {
 return z; }
 //CHECK: char *** bar() {
 //CHECK:         char * * * x = malloc(sizeof(char * *));
-//CHECK:         char * * * y = malloc(sizeof(char * *));
+//CHECK:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
 //CHECK:         char *** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
@@ -112,7 +112,7 @@ x = (char * * *) 5;
         }
         
 return z; }
-//CHECK: char *** sus(char ***x, char ***y : itype(_Ptr<char**>)) {
+//CHECK: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
 //CHECK:         char *ch = malloc(sizeof(char)); 
 //CHECK:         char *** z = malloc(5*sizeof(char**)); 
 //CHECK:             z[i] = malloc(5*sizeof(char *)); 


### PR DESCRIPTION
Initial fix pushed, example provided in the issue now works. 248 test failures, but I think all of them are due to this issue and are "good" errors that we like to see. Committing now for a "LGTM" before changing those tests. 
Most of the changes make sense to me. Attaching a case that looks right, but also weird to me for inspection. The following file: 
``` 
char *** sus(char *** x, char *** y) {
	x = (char ***) 5;
        char *** z = malloc(5*sizeof(char**)); 
        return z; 
}

char *** foo() {
        char * * * x = malloc(sizeof(char * *));
        char * * * y = malloc(sizeof(char * *));
        char *** z = sus(x, y);
	return z; 
}
``` 
gets converted to: 
``` 
_Ptr<_Ptr<_Ptr<char>>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
	x = (char ***) 5;
        _Ptr<_Ptr<_Ptr<char>>> z =  malloc(5*sizeof(char**)); 
        return z; 
}

_Ptr<_Ptr<_Ptr<char>>> foo(void) {
        char * * * x = malloc(sizeof(char * *));
        _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
        _Ptr<_Ptr<_Ptr<char>>> z =  sus(x, y);
	return z; 
}
```