### PR TITLE
Solver changes

### DIFF
--- a/clang/include/clang/CConv/Constraints.h
+++ b/clang/include/clang/CConv/Constraints.h
@@ -539,6 +539,7 @@ public:
   std::set<VarAtom *> resetSolution(VarAtomPred Pred, ConstAtom *CA);
   void resetFullSolution(VarSolTy InitC);
   bool checkAssignment(VarSolTy C);
+  std::set<VarAtom *> filterAtoms(VarAtomPred Pred);
 
 private:
   EnvironmentMap environment; // Solution map: Var --> Sol

--- a/clang/lib/CConv/Constraints.cpp
+++ b/clang/lib/CConv/Constraints.cpp
@@ -295,7 +295,7 @@ VarAtomPred isNonParamReturn = [](VarAtom *VA) -> bool {
 
 // Remove from S all elements that don't match the predicate P
 void filter(VarAtomPred P, std::set<VarAtom *> &S) {
-  for (auto I = S.begin(), E = S.end(); I != E; ) {
+  for (auto I = S.begin(), E = S.end(); I != E;) {
     if (!P(*I))
       I = S.erase(I);
     else
@@ -303,19 +303,37 @@ void filter(VarAtomPred P, std::set<VarAtom *> &S) {
   }
 }
 
-static std::set<VarAtom *> findBounded(ConstraintsGraph &CG, std::set<VarAtom *> *Concrete, bool Succs, bool UseConstAtoms) {
+// For the provided constraint graph, construct the set of atoms bounded in a
+// direction (defined by Succs) by an atom from the set of concrete atoms.
+// When Succs is true, the traversal flows from each node to its successor - in
+// the direction the edges are oriented. When false, the traversal is reversed.
+// To view this another way, true checks for a lower bound in the Ptyp
+// constraint graph, but an upper bound in the checked graph. UseConstAtoms
+// decides if constant atoms should be used in addition to the provided Concrete
+// atoms.
+static std::set<VarAtom *> findBounded(ConstraintsGraph &CG,
+                                       std::set<VarAtom *> *Concrete,
+                                       bool Succs, bool UseConstAtoms = true) {
   std::set<VarAtom *> Bounded;
-  std::vector<Atom *> Open;
+  std::set<Atom *> Open;
+
+  // Initialize the open set of atoms with the provided set of fixed atoms.
+  // These are the start points for a traversal of the constraint graph.
   if (Concrete != nullptr) {
-    Open.insert(Open.begin(), Concrete->begin(), Concrete->end());
+    Open.insert(Concrete->begin(), Concrete->end());
     Bounded.insert(Concrete->begin(), Concrete->end());
   }
 
+  // We often, but not always, want to consider constant atoms as concrete.
   if (UseConstAtoms) {
     auto &ConstA = CG.getAllConstAtoms();
-    Open.insert(Open.begin(), ConstA.begin(), ConstA.end());
+    Open.insert(ConstA.begin(), ConstA.end());
   }
 
+  // Traversal of the constraint graph. An atom is bounded in a direction by
+  // one of the Concrete atoms if it is reachable from one of the atoms taking
+  // only edges in that direction. The particular atom bounding it does not
+  // matter.
   while (!Open.empty()) {
     auto *Curr = *(Open.begin());
     Open.erase(Open.begin());
@@ -323,9 +341,9 @@ static std::set<VarAtom *> findBounded(ConstraintsGraph &CG, std::set<VarAtom *>
     std::set<Atom *> Neighbors;
     if (CG.getNeighbors<VarAtom>(Curr, Neighbors, Succs)) {
       for (Atom *N : Neighbors) {
-        if(VarAtom *VA = dyn_cast<VarAtom>(N)){
-          if (Bounded.find(VA) == Bounded.end()){
-            Open.push_back(VA);
+        if (VarAtom *VA = dyn_cast<VarAtom>(N)) {
+          if (Bounded.find(VA) == Bounded.end()) {
+            Open.insert(VA);
             Bounded.insert(VA);
           }
         }
@@ -354,13 +372,12 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
       else
         PtrTypCG.addConstraint(G, *this);
     }
-    // Save the implies to solve them later.
+      // Save the implies to solve them later.
     else if (Implies *Imp = dyn_cast<Implies>(C)) {
       assert(Imp->getConclusion()->constraintIsChecked() &&
-             Imp->getPremise()->constraintIsChecked());
+          Imp->getPremise()->constraintIsChecked());
       SavedImplies.insert(Imp);
-    }
-    else
+    } else
       llvm_unreachable("Bogus constraint type");
   }
 
@@ -390,7 +407,7 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
       // 1. Find return vars with a lower bound
       std::set<VarAtom *> ParamVars = env.filterAtoms(isParam);
       std::set<VarAtom *> LowerBoundedRet =
-          findBounded(PtrTypCG, &ParamVars, true, true);
+          findBounded(PtrTypCG, &ParamVars, true);
       filter(isReturn, LowerBoundedRet);
 
       // 2. Find local vars where one of the return vars is an upper bound.
@@ -401,7 +418,7 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
 
       // 3. Find local vars upper bounded by a const var.
       std::set<VarAtom *> ConstUpperBoundedLocals =
-          findBounded(PtrTypCG, nullptr, false, true);
+          findBounded(PtrTypCG, nullptr, false);
       filter(isNonParamReturn, ConstUpperBoundedLocals);
 
       // 4. Take set difference of 2 and 3 to find bounded vars that do not
@@ -422,7 +439,7 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
       // Remember which variables have a concrete lower bound. Variables without
       // a lower bound will be resolved in the final greatest solution.
       std::set<VarAtom *> LowerBounded =
-          findBounded(PtrTypCG, &rest, true, true);
+          findBounded(PtrTypCG, &rest, true);
 
       res = do_solve(PtrTypCG, Empty, env, this, true, &rest, Conflicts);
 
@@ -433,7 +450,7 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
         rest = env.resetSolution(
             [LowerBounded](VarAtom *VA) -> bool {
               return isNonParamReturn(VA) ||
-                     LowerBounded.find(VA) == LowerBounded.end();
+                  LowerBounded.find(VA) == LowerBounded.end();
             },
             getPtr());
 

--- a/clang/lib/CConv/Constraints.cpp
+++ b/clang/lib/CConv/Constraints.cpp
@@ -283,17 +283,58 @@ static bool do_solve(ConstraintsGraph &CG,
   return ok;
 }
 
-auto isNonParam =
-    [](VarAtom *VA) -> bool {
-      VarAtom::VarKind VK = VA->getVarKind();
-      return VK != VarAtom::V_Param;
-    };
+VarAtomPred isReturn = [](VarAtom *VA) -> bool {
+  return VA->getVarKind() == VarAtom::V_Return;
+};
+VarAtomPred isParam = [](VarAtom *VA) -> bool {
+  return VA->getVarKind() == VarAtom::V_Param;
+};
+VarAtomPred isNonParamReturn = [](VarAtom *VA) -> bool {
+  return !isReturn(VA) && !isParam(VA);
+};
 
-auto isNonParamReturn =
-    [](VarAtom *VA) -> bool {
-      VarAtom::VarKind VK = VA->getVarKind();
-      return VK != VarAtom::V_Param && VK != VarAtom::V_Return;
-    };
+// Remove from S all elements that don't match the predicate P
+void filter(VarAtomPred P, std::set<VarAtom *> &S) {
+  for (auto I = S.begin(), E = S.end(); I != E; ) {
+    if (!P(*I))
+      I = S.erase(I);
+    else
+      ++I;
+  }
+}
+
+static std::set<VarAtom *> findBounded(ConstraintsGraph &CG, std::set<VarAtom *> *Concrete, bool Succs, bool UseConstAtoms) {
+  std::set<VarAtom *> Bounded;
+  std::vector<Atom *> Open;
+  if (Concrete != nullptr) {
+    Open.insert(Open.begin(), Concrete->begin(), Concrete->end());
+    Bounded.insert(Concrete->begin(), Concrete->end());
+  }
+
+  if (UseConstAtoms) {
+    auto &ConstA = CG.getAllConstAtoms();
+    Open.insert(Open.begin(), ConstA.begin(), ConstA.end());
+  }
+
+  while (!Open.empty()) {
+    auto *Curr = *(Open.begin());
+    Open.erase(Open.begin());
+
+    std::set<Atom *> Neighbors;
+    if (CG.getNeighbors<VarAtom>(Curr, Neighbors, Succs)) {
+      for (Atom *N : Neighbors) {
+        if(VarAtom *VA = dyn_cast<VarAtom>(N)){
+          if (Bounded.find(VA) == Bounded.end()){
+            Open.push_back(VA);
+            Bounded.insert(VA);
+          }
+        }
+      }
+    }
+  }
+
+  return Bounded;
+}
 
 bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
   ConstraintsGraph ChkCG;
@@ -342,13 +383,60 @@ bool Constraints::graph_based_solve(ConstraintSet &Conflicts) {
 
     // Step 2: Reset all solutions but for function params, and compute the least
     if (res) {
-      std::set<VarAtom *> rest = env.resetSolution(isNonParam, getNTArr());
+
+      // We want to find all local variables with an upper bound that provide a
+      // lower bound for return variables that are not otherwise bounded.
+
+      // 1. Find return vars with a lower bound
+      std::set<VarAtom *> ParamVars = env.filterAtoms(isParam);
+      std::set<VarAtom *> LowerBoundedRet =
+          findBounded(PtrTypCG, &ParamVars, true, true);
+      filter(isReturn, LowerBoundedRet);
+
+      // 2. Find local vars where one of the return vars is an upper bound.
+      //    Conversely, these are an alternative lower bound for the return var.
+      std::set<VarAtom *> RetUpperBoundedLocals =
+          findBounded(PtrTypCG, &LowerBoundedRet, false, false);
+      filter(isNonParamReturn, RetUpperBoundedLocals);
+
+      // 3. Find local vars upper bounded by a const var.
+      std::set<VarAtom *> ConstUpperBoundedLocals =
+          findBounded(PtrTypCG, nullptr, false, true);
+      filter(isNonParamReturn, ConstUpperBoundedLocals);
+
+      // 4. Take set difference of 2 and 3 to find bounded vars that do not
+      //    effect an existing lower bound.
+      std::set<VarAtom *> Diff;
+      std::set_difference(
+          ConstUpperBoundedLocals.begin(), ConstUpperBoundedLocals.end(),
+          RetUpperBoundedLocals.begin(), RetUpperBoundedLocals.end(),
+          std::inserter(Diff, Diff.begin()));
+
+      // 5. Reset var to NTArr if not a param var and not in the previous set.
+      std::set<VarAtom *> rest = env.resetSolution(
+          [Diff](VarAtom *VA) -> bool {
+            return !(isParam(VA) || Diff.find(VA) != Diff.end());
+          },
+          getNTArr());
+
+      // Remember which variables have a concrete lower bound. Variables without
+      // a lower bound will be resolved in the final greatest solution.
+      std::set<VarAtom *> LowerBounded =
+          findBounded(PtrTypCG, &rest, true, true);
+
       res = do_solve(PtrTypCG, Empty, env, this, true, &rest, Conflicts);
 
       // Step 3: Reset local variable solutions, compute greatest
       if (res) {
         rest.clear();
-        rest = env.resetSolution(isNonParamReturn, getPtr());
+
+        rest = env.resetSolution(
+            [LowerBounded](VarAtom *VA) -> bool {
+              return isNonParamReturn(VA) ||
+                     LowerBounded.find(VA) == LowerBounded.end();
+            },
+            getPtr());
+
         res = do_solve(PtrTypCG, Empty, env, this, false, &rest,
                        Conflicts);
       }
@@ -635,6 +723,17 @@ bool ConstraintsEnv::assign(VarAtom *V, ConstAtom *C) {
     VI->second.second = C;
   }
   return true;
+}
+
+// Find VarAtoms in the environment that match a predicate.
+std::set<VarAtom *> ConstraintsEnv::filterAtoms(VarAtomPred Pred) {
+  std::set<VarAtom *> Matches;
+  for (const auto &CurrE : environment) {
+    VarAtom *VA = CurrE.first;
+    if (Pred(VA))
+      Matches.insert(VA);
+  }
+  return Matches;
 }
 
 // Reset solution of all VarAtoms that satisfy the given predicate

--- a/clang/test/CheckedCRewriter/refarrsubscript.c
+++ b/clang/test/CheckedCRewriter/refarrsubscript.c
@@ -18,8 +18,8 @@ int **bar(struct foo *p) {
 //CHECK_NOALL: struct foo { int **b; int n; };
 //CHECK_NOALL-NEXT: int ** bar(_Ptr<struct foo> p) {
 //CHECK_NOALL-NEXT:  _Ptr<int> n =  &p->n;
-//CHECK_ALL: struct foo { _Nt_array_ptr<_Ptr<int>> b; int n; };
-//CHECK_ALL-NEXT: _Nt_array_ptr<_Ptr<int>> bar(_Ptr<struct foo> p) {
+//CHECK_ALL: struct foo { _Array_ptr<_Ptr<int>> b; int n; };
+//CHECK_ALL-NEXT: _Array_ptr<_Ptr<int>> bar(_Ptr<struct foo> p) {
 //CHECK_ALL-NEXT:  _Ptr<int> n =  &p->n;
 
 struct s { int *c; };

--- a/clang/test/CheckedCRewriter/return_not_least.c
+++ b/clang/test/CheckedCRewriter/return_not_least.c
@@ -39,3 +39,38 @@ int *bar() {
   z += 2;
   return z;
 }
+
+int *baz(int *a) {
+  // CHECK: _Array_ptr<int> baz(_Array_ptr<int> a) {
+  a++;
+
+  int *b = (int*) 0;
+  // CHECK: _Array_ptr<int> b = (int*) 0;
+  a = b;
+
+  int *c = b;
+  // CHECK: _Array_ptr<int> c = b;
+
+  return c;
+}
+
+int *buz(int *a) {
+  // CHECK: _Ptr<int> buz(_Array_ptr<int> a) {
+  a++;
+
+  int *b = (int*) 0;
+  // CHECK: _Array_ptr<int> b = (int*) 0;
+  a = b;
+
+  // The current implementation does not propagate array constraint to c and d, but
+  // if this test starts failing because it does, that's probably OK.
+
+  int *c = b;
+  // CHECK: _Ptr<int>  c = b;
+
+  int *d = (int*) 0;
+  // CHECK: _Ptr<int> d = (int*) 0;
+  c = d;
+
+  return d;
+}

--- a/clang/test/CheckedCRewriter/return_not_least.c
+++ b/clang/test/CheckedCRewriter/return_not_least.c
@@ -1,0 +1,41 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+
+int *a() {
+// CHECK: _Array_ptr<int> a(void) {
+  int *a = 0;
+  // CHECK: _Array_ptr<int> a =  0;
+  return a++;
+}
+
+int *dumb(int *a){
+// CHECK: _Ptr<int> dumb(_Ptr<int> a){
+  int *b = a;
+  // CHECK: _Ptr<int> b =  a;
+  return b;
+}
+
+int *f(void) {
+// CHECK: _Array_ptr<int> f(void) {
+  int *p = (int*)0;
+  // CHECK: _Array_ptr<int> p =  (int*)0;
+  p++;
+  return p;
+}
+
+int *foo(void) {
+// CHECK: _Array_ptr<int> foo(void) {
+  int *q = f();
+  // CHECK: _Array_ptr<int> q =  f();
+  return q;
+}
+
+#define size_t int
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+
+int *bar() {
+// CHECK: _Nt_array_ptr<int> bar(void) {
+  int *z = calloc(2, sizeof(int));
+  //CHECK: _Nt_array_ptr<int> z =  calloc(2, sizeof(int));
+  z += 2;
+  return z;
+}


### PR DESCRIPTION
Changes to constraint graph solving so that the least solution is not always used for return values. The least solution is only used when the return variable has an explicit lower bound. When there is no explicit lower bound, there are two possible cases:
1. There is local variable with an upper bound that can define a lower bound for the return variable. In this case, the bounding variable is fixed (like a parameter variable) while computing the least solution.
2. There is no viable lower bound. In this case, the least solution is computed as normal, but the unbounded return variable is reset to `Ptr` and included in the final greatest solution. 

Example 1: The return value has no lower bound, so the greatest solution is used. This gives `_Ptr` rather than `_Nt_array_ptr`
```c
int *bar() {
  int *a = 0;
  return a;
}
```

```c
_Ptr<int> bar(void) {
  _Ptr<int> a =  0;
  return a;
}
```

Example 2: The return value has no direct lower bound, but `a` has an upper bound of `Arr`. This is used during the least solution. 
```c
int *foo() {
  int *a = 0;
  a++;
  return a;
}
```
```c
_Array_ptr<int> foo(void) {
  _Array_ptr<int> a =  0;
  a++;
  return a;
}
```
