### PR TITLE
Don't output bounds expr when not array type

### DIFF
--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -840,7 +840,12 @@ std::string ArrayBoundsRewriter::getBoundsString(Decl *D, bool Isitype) {
   std::string BVarString = "";
   auto &ArrBInfo = Info.getArrayBoundsInformation();
 
-  if (ArrBInfo.hasBoundsInformation(D))
+  auto CS = Info.getVariable(D, Context);
+  bool hasArr = false;
+  for (auto *CV : CS)
+    hasArr = hasArr || CV->hasArr(Info.getConstraints().getVariables());
+
+  if (hasArr && ArrBInfo.hasBoundsInformation(D))
     BVarString = ArrBInfo.getBoundsInformation(D).second;
 
   if (BVarString.length() > 0) {


### PR DESCRIPTION
Removes the incorrectly placed bounds expression on strings literals seen in #143. This doesn't do anything with the constraints on strings literals, and I'm not sure exactly what we we want to  do there.