### PR TITLE
FIx Issue #58

### DIFF
--- a/clang/lib/CConv/Utils.cpp
+++ b/clang/lib/CConv/Utils.cpp
@@ -268,11 +268,13 @@ static bool CastCheck(clang::QualType DstType,
   if (SrcType == DstType)
     return true;
 
-  const clang::Type *SrcTypePtr = SrcType.getTypePtr();
-  const clang::Type *DstTypePtr = DstType.getTypePtr();
+  const clang::Type *SrcTypePtr = SrcType.getCanonicalType().getTypePtr();
+  const clang::Type *DstTypePtr = DstType.getCanonicalType().getTypePtr();
 
-  const clang::PointerType *SrcPtrTypePtr = dyn_cast<clang::PointerType>(SrcTypePtr);
-  const clang::PointerType *DstPtrTypePtr = dyn_cast<clang::PointerType>(DstTypePtr);
+  const clang::PointerType *SrcPtrTypePtr =
+      dyn_cast<clang::PointerType>(SrcTypePtr);
+  const clang::PointerType *DstPtrTypePtr =
+      dyn_cast<clang::PointerType>(DstTypePtr);
 
   // Both are pointers? check their pointee
   if (SrcPtrTypePtr && DstPtrTypePtr) {

--- a/clang/test/CheckedCRewriter/canonical_type_cast.c
+++ b/clang/test/CheckedCRewriter/canonical_type_cast.c
@@ -1,5 +1,6 @@
 // RUN: cconv-standalone %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL" %s
 // RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL" %s
+// RUN: cconv-standalone -alltypes %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 
 // Examples from issue #58

--- a/clang/test/CheckedCRewriter/canonical_type_cast.c
+++ b/clang/test/CheckedCRewriter/canonical_type_cast.c
@@ -1,0 +1,35 @@
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL" %s
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL" %s
+
+
+// Examples from issue #58
+
+void f(int *p) {
+  int *x = (int *)p;
+  // CHECK_NOALL: _Ptr<int> x = (int *)p;
+  // CHECK_ALL: _Ptr<int> x = (int *)p;
+}
+
+void g(int p[]) {
+  int *x = (int *)p;
+  // CHECK_NOALL: int *x = (int *)p;
+  // CHECK_All: _Ptr<int> x = (int *)p;
+}
+
+// A very similar issue with function pointers
+
+int add1(int a){
+  return a + 1;
+}
+
+void h() {
+  int (*x)(int) = add1;
+  // CHECK_NOALL: _Ptr<int (int )> x = add1;
+  // CHECK_ALL: _Ptr<int (int )> x = add1;
+}
+
+void i() {
+  int (*x)(int) = (int(*)(int))add1;
+  // CHECK_NOALL: _Ptr<int (int )> x = (int(*)(int))add1;
+  // CHECK_ALL: _Ptr<int (int )> x = (int(*)(int))add1;
+}


### PR DESCRIPTION
The fix for issue #58 turned out to be fairly straightforward. `CastCheck` did not account for decayed types created by casting arrays to pointer. This also fixes explicit casts of functions to function pointer for the same reason.

The one tricky point is that
```c
void g(int p[]) {
  int *x = (int *)p;
}
```
must  rewrite to 
```c
void g(_Ptr<int> p) {
  _Ptr<int> x =  (int *)p;
}
```
Note that the `p` went from `int[]` to `_Ptr<int>`. This requires making the constraint from `p` to `ARR` a lower bound instead of an upper bound, but this can't be done for all arrays. For instance, `int a[1] = {1}` to `_Ptr<int> a = {1}`, is not allowed. To get around this, a check is added to determine if the array is an incomplete array type. The lower bound is used only in this case.

Another point is that the above example will only be converted under `-alltypes`. I think this is the expected behavior since `p` is an array type. It might make sense to work around this because the converted type is not an array. 
