### PR TITLE
Fix for iss152

### DIFF
--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -347,11 +347,12 @@ public:
       if (G->hasInit()) {
         CB.constrainLocalAssign(nullptr, G, G->getInit());
       }
-      // If the location of the previous RecordDecl and the current VarDecl are
-      // the same, this implies an inline struct as per Clang's AST, so set a
-      // flag in ProgramInfo to indicate that this variable should be
-      // constrained to wild later
-      if (lastRecordLocation == G->getBeginLoc().getRawEncoding()) {
+      // If the location of the previous RecordDecl and the current VarDecl
+      // coincide with one another, we constrain the VarDecl to be wild
+      // in order to allow the fields of the RecordDecl to be converted
+      int BeginLoc = G->getBeginLoc().getRawEncoding();
+      int EndLoc = G->getEndLoc().getRawEncoding();
+      if (lastRecordLocation >= BeginLoc && lastRecordLocation <= EndLoc) {
         std::set<ConstraintVariable *> C = Info.getVariable(G, Context);
         CB.constraintAllCVarsToWild(C, "Inline struct encountered.", nullptr);
       }

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -350,8 +350,8 @@ public:
       // If the location of the previous RecordDecl and the current VarDecl
       // coincide with one another, we constrain the VarDecl to be wild
       // in order to allow the fields of the RecordDecl to be converted
-      int BeginLoc = G->getBeginLoc().getRawEncoding();
-      int EndLoc = G->getEndLoc().getRawEncoding();
+      unsigned int BeginLoc = G->getBeginLoc().getRawEncoding();
+      unsigned int EndLoc = G->getEndLoc().getRawEncoding();
       if (lastRecordLocation >= BeginLoc && lastRecordLocation <= EndLoc) {
         std::set<ConstraintVariable *> C = Info.getVariable(G, Context);
         CB.constraintAllCVarsToWild(C, "Inline struct encountered.", nullptr);

--- a/clang/test/CheckedCRewriter/inlinestruct_difflocs.c
+++ b/clang/test/CheckedCRewriter/inlinestruct_difflocs.c
@@ -1,0 +1,21 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -output-postfix=checkedNOALL %s
+// RUN: %clang -c %S/inlinestruct_difflocs.checkedNOALL.c
+// RUN: rm %S/inlinestruct_difflocs.checkedNOALL.c
+
+int valuable;
+
+static struct foo
+{
+  const char* name;
+  int* p_valuable;
+}
+array[] =
+{
+  { "mystery", &valuable }
+}; 
+
+//CHECK_ALL: _Ptr<const char> name;
+//CHECK_NOALL: const char* name;
+//CHECK: _Ptr<int> p_valuable;


### PR DESCRIPTION
Fix for #152. (with one passing test) 

Similar to the inline struct erasure problem ( issue #31 )The way we solved inline structs before was to detect if the beginning locations were exact, but the example from #152 demonstrates that sometimes struct definitions are subsumed in `VarDecl`s. (e.g. struct definition may occur from locations `9-90` while the `VarDecl` occurs from `2-93`, so their locations aren't identical, and yet the `VarDecl` shadows the struct definition). We just need to alter the way we were checking before to instead be a range of values. The caveat here, as before, is that we sacrifice conversion of the variable in exchange for conversion of the struct fields, so unlike the clean suggested conversion from #152 , the resulting conversion is: 
```
int tunable_anonymous_enable;

static struct parseconf_bool_setting
{
  _Ptr<const char> p_setting_name;
  _Ptr<int> p_variable;
}
parseconf_bool_array[] =
{
  { "anonymous_enable", &tunable_anonymous_enable }
};
```
It's worth considering separating inline struct declarations (the way we separate multiple decls on the same line) and then special-casing anonymous structs to be made WILD. If we're after consistency among inline-structs, the current solution is probably best, but it's possible to get the ideal conversion suggested in #152 if that's what we're after. 
