### PR TITLE
Insert type arguments for allocator function

### DIFF
--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -834,7 +834,7 @@ public:
     if (CallExpr *Call = getAllocatorCall(SubExpr)) {
       // If the function call already has type arguments, we'll trust that
       // they're correct and not add anything else.
-      if(allocTypeArgProvided(Call))
+      if (allocTypeArgProvided(Call))
         return true;
 
       // If the type does not have an identifier (i.e., it's anonymous), then we
@@ -892,8 +892,7 @@ private:
         return false;
       }
       // We only handle direct calls, so there must be a DeclRefExpr.
-      assert("Callee of alloc function call is not DeclRefExpr." && false);
-      return false;
+      llvm_unreachable("Callee of alloc function call is not DeclRefExpr.");
     }
 };
 

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -837,6 +837,14 @@ public:
       if(allocTypeArgProvided(Call))
         return true;
 
+      // If the type does not have an identifier (i.e., it's anonymous), then we
+      // can't use it as a type parameter.
+      QualType PointeeType = CE->getType()->getPointeeType();
+      if (PointeeType->isRecordType() &&
+        !(PointeeType->getAsRecordDecl()->getIdentifier() ||
+          PointeeType->getAsRecordDecl()->getTypedefNameForAnonDecl()))
+        return true;
+
       // I don't like depending on the function having arguments, but I'm not
       // sure how else to figure out the correct spot to add the type parameter.
       assert("No arguments to allocator function." && Call->getNumArgs() > 0);
@@ -846,7 +854,7 @@ public:
       // CheckedC doesn't seem to care that this doesn't get the correct checked
       // type for the pointer. malloc<int*>(sizeof(int*)) is treated the same as
       // malloc<_Ptr<int>>(sizeof(int*)).
-      std::string TypeStr = CE->getType()->getPointeeType().getAsString();
+      std::string TypeStr = PointeeType.getAsString();
       Writer.InsertTextAfter(TypeParamLoc, "<" + TypeStr + ">");
     }
     return true;

--- a/clang/test/CheckedCRewriter/alloc_type_param.c
+++ b/clang/test/CheckedCRewriter/alloc_type_param.c
@@ -50,6 +50,23 @@ void baz() {
   // CHECK: void *v = malloc(sizeof(int));
 }
 
+void buz() {
+  // Anonymous structs shouldn't get a type parameter since they don't have a name.
+  struct {int a;} *b = malloc(10);
+  // CHECK: struct {int a;} *b = malloc(10);
+
+  // Inline structs work just fine as long as they've been named.
+  // Note that c isn't made checked due to limitation in how inline structs are converted.
+  // If this test fails because it's made checked, that's great.
+  struct test {int a;} *c = malloc(sizeof(struct test));
+  // CHECK: struct test {int a;} *c = malloc<struct test>(sizeof(struct test));
+
+  // typedefs are also OK.
+  typedef struct {int a;} other;
+  other *d = malloc(sizeof(other));
+  // CHECK: _Ptr<other> d = malloc<other>(sizeof(other));
+}
+
 // Don't mess with any existing type arguments.
 void fuz() {
   int *a = malloc<int>(sizeof(int));

--- a/clang/test/CheckedCRewriter/alloc_type_param.c
+++ b/clang/test/CheckedCRewriter/alloc_type_param.c
@@ -1,0 +1,51 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -output-postfix=checkedNOALL %s
+// RUN: %clang -c %S/alloc_type_param.checkedNOALL.c
+// RUN: rm %S/alloc_type_param.checkedNOALL.c
+
+typedef unsigned long size_t;
+extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+// Check basic behavior with the three alloc functions
+void foo() {
+  int *a = malloc(sizeof(int));
+  // CHECK: _Ptr<int> a = malloc<int>(sizeof(int));
+  int *b = calloc(1, sizeof(int));
+  // CHECK: _Ptr<int> b = calloc<int>(1, sizeof(int));
+  int *c = realloc(a, sizeof(int));
+  // CHECK: _Ptr<int> c = realloc<int>(a, sizeof(int));
+
+  // Explicit casts work fine also
+
+  int *d = (int*) malloc(sizeof(int));
+  // CHECK: _Ptr<int> d = (int*) malloc<int>(sizeof(int));
+  int *e = (int*) calloc(1, sizeof(int));
+  // CHECK: _Ptr<int> e = (int*) calloc<int>(1, sizeof(int));
+  int *f = (int*) realloc(d, sizeof(int));
+  // CHECK: _Ptr<int> f = (int*) realloc<int>(d, sizeof(int));
+}
+
+// Allocating pointers to pointers
+void bar() {
+  // The type parameter doesn't need to be _Ptr<int> even though it is checked
+  int **a = malloc(sizeof(int*));
+  // CHECK: _Ptr<_Ptr<int>> a = malloc<int *>(sizeof(int*));
+  *a = malloc(sizeof(int));
+  // CHECK: *a = malloc<int>(sizeof(int));
+
+  // It's also fine if the pointer is unchecked
+  int **b = malloc(sizeof(int*));
+  // CHECK: _Ptr<int*> b = malloc<int *>(sizeof(int*));
+  *b = (int*) 1;
+}
+
+// No conversion is done for void pointers, but this should just test that they
+// convert and compile without crashing. We could insert void as the type
+// parameter if there is anything to be gained from that.
+void baz() {
+  void *v = malloc(sizeof(int));
+  // CHECK: void *v = malloc(sizeof(int));
+}

--- a/clang/test/CheckedCRewriter/alloc_type_param.c
+++ b/clang/test/CheckedCRewriter/alloc_type_param.c
@@ -49,3 +49,9 @@ void baz() {
   void *v = malloc(sizeof(int));
   // CHECK: void *v = malloc(sizeof(int));
 }
+
+// Don't mess with any existing type arguments.
+void fuz() {
+  int *a = malloc<int>(sizeof(int));
+  // CHECK: _Ptr<int> a  = malloc<int>(sizeof(int));
+}

--- a/clang/test/CheckedCRewriter/allocator.c
+++ b/clang/test/CheckedCRewriter/allocator.c
@@ -25,7 +25,7 @@ void foo(void) {
   return;
 }
 //CHECK: void foo(void) {
-//CHECK-NEXT: int *a = (int *) malloc(sizeof(int));
+//CHECK-NEXT: int *a = (int *) malloc<int>(sizeof(int));
 
 typedef struct _listelt {
   struct _listelt *next;
@@ -48,4 +48,4 @@ void add_some_stuff(listhead *hd) {
   return;
 }
 //CHECK: void add_some_stuff(_Ptr<listhead>  hd) {
-//CHECK-NEXT: _Ptr<listelt>  l1 = (listelt *) malloc(sizeof(listelt));
+//CHECK-NEXT: _Ptr<listelt>  l1 = (listelt *) malloc<listelt>(sizeof(listelt));

--- a/clang/test/CheckedCRewriter/arrboth.c
+++ b/clang/test/CheckedCRewriter/arrboth.c
@@ -124,10 +124,10 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);
 
 int * foo() {
@@ -136,12 +136,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -151,10 +151,10 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti1.c
@@ -130,12 +130,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -145,10 +145,10 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti2.c
@@ -129,8 +129,8 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrcallee.c
+++ b/clang/test/CheckedCRewriter/arrcallee.c
@@ -124,10 +124,10 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);
 
 int * foo() {
@@ -136,12 +136,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -150,10 +150,10 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti1.c
@@ -130,12 +130,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -144,10 +144,10 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti2.c
@@ -129,8 +129,8 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrcaller.c
+++ b/clang/test/CheckedCRewriter/arrcaller.c
@@ -123,10 +123,10 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);
 
 int * foo() {
@@ -135,12 +135,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -150,10 +150,10 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti1.c
@@ -130,12 +130,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -145,10 +145,10 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti2.c
@@ -128,8 +128,8 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrinstructboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructboth.c
@@ -137,12 +137,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * foo() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -152,10 +152,10 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Array_ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti1.c
@@ -130,12 +130,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * foo() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -145,10 +145,10 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Array_ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallee.c
@@ -137,12 +137,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * foo() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -151,10 +151,10 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti1.c
@@ -130,12 +130,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * foo() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -144,10 +144,10 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructcaller.c
@@ -136,12 +136,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> foo(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -151,10 +151,10 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Array_ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallermulti1.c
@@ -130,12 +130,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> foo(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -145,10 +145,10 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Array_ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotoboth.c
@@ -128,12 +128,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * foo() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -143,12 +143,12 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Array_ptr<struct warr> z =  sus(x, y);
 
 struct warr * sus(struct warr * x, struct warr * y) {

--- a/clang/test/CheckedCRewriter/arrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocallee.c
@@ -128,12 +128,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * foo() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -142,12 +142,12 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * sus(struct warr * x, struct warr * y) {

--- a/clang/test/CheckedCRewriter/arrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocaller.c
@@ -128,12 +128,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> foo(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -143,12 +143,12 @@ struct warr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct warr * bar() {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         struct warr * z = sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         struct warr * y = malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         struct warr * y = malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Array_ptr<struct warr> z =  sus(x, y);
 
 struct warr * sus(struct warr * x, struct warr * y) {

--- a/clang/test/CheckedCRewriter/arrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotosafe.c
@@ -127,12 +127,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> foo(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -141,12 +141,12 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> bar(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * sus(struct warr * x, struct warr * y) {

--- a/clang/test/CheckedCRewriter/arrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafe.c
@@ -135,12 +135,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> foo(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -149,10 +149,10 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> bar(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrinstructsafemulti1.c
@@ -129,12 +129,12 @@ struct warr * foo() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> foo(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> foo(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);
 
 struct warr * bar() {
@@ -143,10 +143,10 @@ struct warr * bar() {
         struct warr * z = sus(x, y);
 return z; }
 //CHECK_NOALL: _Ptr<struct warr> bar(void) {
-//CHECK_NOALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_NOALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_NOALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_NOALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_NOALL:         _Ptr<struct warr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct warr> bar(void) {
-//CHECK_ALL:         struct warr * x = malloc(sizeof(struct warr));
-//CHECK_ALL:         _Ptr<struct warr> y =  malloc(sizeof(struct warr));
+//CHECK_ALL:         struct warr * x = malloc<struct warr>(sizeof(struct warr));
+//CHECK_ALL:         _Ptr<struct warr> y =  malloc<struct warr>(sizeof(struct warr));
 //CHECK_ALL:         _Ptr<struct warr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructboth.c
@@ -128,10 +128,10 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;
 
 struct general ** foo() {
@@ -148,13 +148,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -173,12 +173,12 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
@@ -138,13 +138,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -163,12 +163,12 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -133,8 +133,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallee.c
@@ -128,10 +128,10 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;
 
 struct general ** foo() {
@@ -148,13 +148,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -172,12 +172,12 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
@@ -138,13 +138,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -162,12 +162,12 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -133,8 +133,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructcaller.c
@@ -127,10 +127,10 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;
 
 struct general ** foo() {
@@ -147,13 +147,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -172,12 +172,12 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
@@ -138,13 +138,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -163,12 +163,12 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -132,8 +132,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotoboth.c
@@ -136,13 +136,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -161,13 +161,13 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -184,8 +184,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocallee.c
@@ -136,13 +136,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -160,13 +160,13 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -183,8 +183,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocaller.c
@@ -136,13 +136,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -161,13 +161,13 @@ struct general ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -183,8 +183,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotosafe.c
@@ -135,13 +135,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -159,13 +159,13 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -181,8 +181,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrofstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafe.c
@@ -126,10 +126,10 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;
 
 struct general ** foo() {
@@ -146,13 +146,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -170,12 +170,12 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
@@ -137,13 +137,13 @@ struct general ** foo() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** foo() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);
 
@@ -161,12 +161,12 @@ struct general ** bar() {
         struct general ** z = sus(x, y);
 return z; }
 //CHECK_NOALL: struct general ** bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         struct general ** z = sus(x, y);
 //CHECK_ALL: struct general ** bar() {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         struct general * y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         struct general * y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         struct general ** z = sus(x, y);

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -131,8 +131,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_NOALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_ALL: struct general ** sus(struct general *x, struct general *y) {
-//CHECK_ALL:         struct general **z = calloc(5, sizeof(struct general *));
+//CHECK_ALL:         struct general **z = calloc<struct general *>(5, sizeof(struct general *));
 //CHECK_ALL:         struct general *curr = y;

--- a/clang/test/CheckedCRewriter/arrprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrprotoboth.c
@@ -128,12 +128,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -143,12 +143,12 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -160,8 +160,8 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrprotocallee.c
@@ -128,12 +128,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -142,12 +142,12 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -159,8 +159,8 @@ x = (int *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrprotocaller.c
@@ -128,12 +128,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -143,12 +143,12 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -159,8 +159,8 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrprotosafe.c
@@ -127,12 +127,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -141,12 +141,12 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * sus(int * x, int * y) {
@@ -157,8 +157,8 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrsafe.c
+++ b/clang/test/CheckedCRewriter/arrsafe.c
@@ -122,10 +122,10 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);
 
 int * foo() {
@@ -134,12 +134,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -148,10 +148,10 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti1.c
@@ -129,12 +129,12 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
 int * bar() {
@@ -143,10 +143,10 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         int * x = malloc(sizeof(int));
-//CHECK_NOALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_NOALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_NOALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         int * x = malloc(sizeof(int));
-//CHECK_ALL:         _Ptr<int> y =  malloc(sizeof(int));
+//CHECK_ALL:         int * x = malloc<int>(sizeof(int));
+//CHECK_ALL:         _Ptr<int> y =  malloc<int>(sizeof(int));
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti2.c
@@ -127,8 +127,8 @@ x = (int *) 5;
         { *p = fac; }
 return z; }
 //CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int i, *p, fac;
 //CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL: _Array_ptr<int> p = ((void *)0);

--- a/clang/test/CheckedCRewriter/arrstructboth.c
+++ b/clang/test/CheckedCRewriter/arrstructboth.c
@@ -127,10 +127,10 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -147,13 +147,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -172,12 +172,12 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti1.c
@@ -138,13 +138,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -163,12 +163,12 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti2.c
@@ -132,8 +132,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/arrstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrstructcallee.c
@@ -127,10 +127,10 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -147,13 +147,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -171,12 +171,12 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
@@ -138,13 +138,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -162,12 +162,12 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
@@ -132,8 +132,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/arrstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrstructcaller.c
@@ -126,10 +126,10 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -146,13 +146,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -171,12 +171,12 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti1.c
@@ -138,13 +138,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -163,12 +163,12 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti2.c
@@ -131,8 +131,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/arrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrstructprotoboth.c
@@ -136,13 +136,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -161,13 +161,13 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -183,8 +183,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/arrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocallee.c
@@ -136,13 +136,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -160,13 +160,13 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -182,8 +182,8 @@ x = (struct general *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/arrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocaller.c
@@ -136,13 +136,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -161,13 +161,13 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -182,8 +182,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/arrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrstructprotosafe.c
@@ -135,13 +135,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -159,13 +159,13 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -180,8 +180,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/arrstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrstructsafe.c
@@ -125,10 +125,10 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -145,13 +145,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -169,12 +169,12 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti1.c
@@ -137,13 +137,13 @@ int * foo() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);
 
@@ -161,12 +161,12 @@ int * bar() {
         int * z = sus(x, y);
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         int * z = sus(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general * x = malloc(sizeof(struct general));
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general * x = malloc<struct general>(sizeof(struct general));
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/arrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti2.c
@@ -130,8 +130,8 @@ x = (struct general *) 5;
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/b13_calleestructp.c
+++ b/clang/test/CheckedCRewriter/b13_calleestructp.c
@@ -30,7 +30,7 @@ struct p sus(struct p x) {
   struct p *n = malloc(sizeof(struct p));
   return *n;
 }
-//CHECK: _Ptr<struct p> n =  malloc(sizeof(struct p));
+//CHECK: _Ptr<struct p> n =  malloc<struct p>(sizeof(struct p));
 
 struct p foo() {
   struct p x;

--- a/clang/test/CheckedCRewriter/b14_callerstructp.c
+++ b/clang/test/CheckedCRewriter/b14_callerstructp.c
@@ -30,7 +30,7 @@ struct p sus(struct p x) {
   struct p *n = malloc(sizeof(struct p));
   return *n;
 }
-//CHECK: _Ptr<struct p> n =  malloc(sizeof(struct p));
+//CHECK: _Ptr<struct p> n =  malloc<struct p>(sizeof(struct p));
 
 struct p foo() {
   struct p x;

--- a/clang/test/CheckedCRewriter/b18_bothstructp.c
+++ b/clang/test/CheckedCRewriter/b18_bothstructp.c
@@ -31,7 +31,7 @@ struct p sus(struct p x) {
   struct p *n = malloc(sizeof(struct p));
   return *n;
 }
-//CHECK: _Ptr<struct p> n =  malloc(sizeof(struct p));
+//CHECK: _Ptr<struct p> n =  malloc<struct p>(sizeof(struct p));
 
 struct p foo() {
   struct p x;

--- a/clang/test/CheckedCRewriter/b30_structprotoconflict.c
+++ b/clang/test/CheckedCRewriter/b30_structprotoconflict.c
@@ -59,4 +59,4 @@ struct r *sus(struct r *x, struct r *y) {
   return z;
 }
 //CHECK: struct r *sus(_Ptr<struct r> x, _Ptr<struct r> y) : itype(_Ptr<struct r>) {
-//CHECK: _Ptr<struct r> z =  malloc(sizeof(struct r));
+//CHECK: _Ptr<struct r> z =  malloc<struct r>(sizeof(struct r));

--- a/clang/test/CheckedCRewriter/b30_structprotoconflictbodyconvert.c
+++ b/clang/test/CheckedCRewriter/b30_structprotoconflictbodyconvert.c
@@ -57,4 +57,4 @@ struct np *sus(struct r *x, struct r *y) {
   return z;
 }
 //CHECK: struct np *sus(struct r *x : itype(_Ptr<struct r>), struct r *y : itype(_Ptr<struct r>)) : itype(_Ptr<struct np>) {
-//CHECK: _Ptr<struct np> z =  malloc(sizeof(struct np));
+//CHECK: _Ptr<struct np> z =  malloc<struct np>(sizeof(struct np));

--- a/clang/test/CheckedCRewriter/b3_onecallerunsafe.c
+++ b/clang/test/CheckedCRewriter/b3_onecallerunsafe.c
@@ -16,7 +16,7 @@ int *sus(int *x, int*y) {
   return z;
 }
 //CHECK: int *sus(int *x, _Ptr<int> y) : itype(_Ptr<int>) {
-//CHECK:   _Ptr<int> z =  malloc(sizeof(int));
+//CHECK:   _Ptr<int> z =  malloc<int>(sizeof(int));
 
 int* foo() {
   int sx = 3;

--- a/clang/test/CheckedCRewriter/b9_allsafestructp.c
+++ b/clang/test/CheckedCRewriter/b9_allsafestructp.c
@@ -29,7 +29,7 @@ struct p sus(struct p x) {
   struct p *n = malloc(sizeof(struct p));
   return *n;
 }
-//CHECK: _Ptr<struct p> n =  malloc(sizeof(struct p));
+//CHECK: _Ptr<struct p> n =  malloc<struct p>(sizeof(struct p));
 
 struct p foo() {
   struct p x;

--- a/clang/test/CheckedCRewriter/basic.c
+++ b/clang/test/CheckedCRewriter/basic.c
@@ -15,7 +15,7 @@ void basic1() {
 }
 
 //CHECK: char data[] = "abcdefghijklmnop";
-//CHECK: char *buffer = malloc(50);
+//CHECK: char *buffer = malloc<char>(50);
 //CHECK-NEXT: strcpy(buffer, data);
 
 char* basic2(int temp) {
@@ -38,8 +38,8 @@ char* basic2(int temp) {
 	}
 }
 //CHECK: char * basic2(int temp) {
-//CHECK: char *buffer = malloc(8);
-//CHECK: char *buffer = malloc(1024);
+//CHECK: char *buffer = malloc<char>(8);
+//CHECK: char *buffer = malloc<char>(1024);
 
 char* basic3(int* data, int count) {
 	while (count > 1) {
@@ -50,7 +50,7 @@ char* basic3(int* data, int count) {
 	return NULL;
 }
 //CHECK: _Ptr<char> basic3(_Ptr<int> data, int count) {
-//CHECK: _Ptr<int> temp =  malloc(sizeof(int));
+//CHECK: _Ptr<int> temp =  malloc<int>(sizeof(int));
 
 void sum_numbers(int count) {
     int n, i, sum = 0;
@@ -74,7 +74,7 @@ void sum_numbers(int count) {
     }
     free(ptr);
 }
-//CHECK: int *ptr = (int*) malloc(n * sizeof(int));
+//CHECK: int *ptr = (int*) malloc<int>(n * sizeof(int));
 
 
 void basic_calloc(int count) {
@@ -101,7 +101,7 @@ void basic_calloc(int count) {
     printf("Sum = %d", sum);
     free(ptr);
 }
-//CHECK: int *ptr = (int*) calloc(n, sizeof(int));
+//CHECK: int *ptr = (int*) calloc<int>(n, sizeof(int));
 
 void basic_realloc(int count) {
     int i , n1, n2;
@@ -126,7 +126,7 @@ void basic_realloc(int count) {
 
     free(ptr);
 }
-//CHECK: int *ptr = (int*) malloc(n1 * sizeof(int));
+//CHECK: int *ptr = (int*) malloc<int>(n1 * sizeof(int));
 
 struct student
 {
@@ -171,7 +171,7 @@ void basic_struct(int count) {
     }
 
 }
-//CHECK: struct student *pstd=(struct student*)malloc(n*sizeof(struct student));
+//CHECK: struct student *pstd=(struct student*)malloc<struct student>(n*sizeof(struct student));
 
 struct student * new_student() {
 		char name[] = "Bilbo Baggins";
@@ -183,7 +183,7 @@ struct student * new_student() {
 }
 //CHECK: _Ptr<struct student> new_student(void) {
 //CHECK-NEXT: char name[] = "Bilbo Baggins";
-//CHECK: _Ptr<struct student> new_s =  malloc(sizeof(struct student));
+//CHECK: _Ptr<struct student> new_s =  malloc<struct student>(sizeof(struct student));
 
 int main() {
 	basic1();

--- a/clang/test/CheckedCRewriter/calloc.c
+++ b/clang/test/CheckedCRewriter/calloc.c
@@ -15,5 +15,5 @@ void foo(int *w) {
     x[2] = 3; 
     func(x);
 }
-//CHECK_ALL: _Nt_array_ptr<int> x = calloc(5, sizeof(int)); 
-//CHECK_NOALL: int *x = calloc(5, sizeof(int));
+//CHECK_ALL: _Nt_array_ptr<int> x = calloc<int>(5, sizeof(int)); 
+//CHECK_NOALL: int *x = calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/fptrarrboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrboth.c
@@ -128,10 +128,10 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
@@ -146,12 +146,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -167,10 +167,10 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
@@ -136,12 +136,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -157,10 +157,10 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -133,8 +133,8 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallee.c
@@ -128,10 +128,10 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
@@ -146,12 +146,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -166,10 +166,10 @@ int ** bar() {
         
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
@@ -136,12 +136,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -156,10 +156,10 @@ int ** bar() {
         
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -133,8 +133,8 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrcaller.c
@@ -127,10 +127,10 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
@@ -145,12 +145,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -166,10 +166,10 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
@@ -136,12 +136,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -157,10 +157,10 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -132,8 +132,8 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructboth.c
@@ -132,9 +132,9 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -149,12 +149,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * foo() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -171,10 +171,10 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti1.c
@@ -137,12 +137,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * foo() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -159,10 +159,10 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructbothmulti2.c
@@ -137,6 +137,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallee.c
@@ -132,9 +132,9 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -149,12 +149,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * foo() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -170,10 +170,10 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti1.c
@@ -137,12 +137,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * foo() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -158,10 +158,10 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcalleemulti2.c
@@ -137,6 +137,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcaller.c
@@ -131,9 +131,9 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK_NOALL: struct arrfptr *sus(struct arrfptr *x, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>) {
-//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -148,12 +148,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -170,10 +170,10 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti1.c
@@ -137,12 +137,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -159,10 +159,10 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructcallermulti2.c
@@ -136,6 +136,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK_NOALL: struct arrfptr *sus(struct arrfptr *x, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>) {
-//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotoboth.c
@@ -135,12 +135,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * foo() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -157,12 +157,12 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -182,6 +182,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocallee.c
@@ -135,12 +135,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * foo() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -156,12 +156,12 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -181,6 +181,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotocaller.c
@@ -135,12 +135,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: struct arrfptr * foo() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * bar() {
@@ -157,12 +157,12 @@ struct arrfptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct arrfptr * bar() {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         struct arrfptr *z = sus(x, y); 
 //CHECK_ALL: struct arrfptr * bar() {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         struct arrfptr *z = sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -181,6 +181,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK_NOALL: struct arrfptr *sus(struct arrfptr *x, _Ptr<struct arrfptr> y) : itype(_Ptr<struct arrfptr>) {
-//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: struct arrfptr * sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         struct arrfptr *z = malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         struct arrfptr *z = malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructprotosafe.c
@@ -134,12 +134,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 
 struct arrfptr * bar() {
@@ -155,12 +155,12 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> bar(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: _Ptr<struct arrfptr> bar(void) {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 
 struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
@@ -179,6 +179,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafe.c
@@ -130,9 +130,9 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 
 struct arrfptr * foo() {
  
@@ -147,12 +147,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 
 struct arrfptr * bar() {
@@ -168,10 +168,10 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> bar(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: _Ptr<struct arrfptr> bar(void) {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         _Ptr<struct arrfptr> z =  sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti1.c
@@ -136,12 +136,12 @@ struct arrfptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: _Ptr<struct arrfptr> foo(void) {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 
 struct arrfptr * bar() {
@@ -157,10 +157,10 @@ struct arrfptr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> bar(void) {
-//CHECK_NOALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_NOALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_NOALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_NOALL:         _Ptr<struct arrfptr> z =  sus(x, y); 
 //CHECK_ALL: _Ptr<struct arrfptr> bar(void) {
-//CHECK_ALL:         struct arrfptr * x = malloc(sizeof(struct arrfptr));
-//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc(sizeof(struct arrfptr));
+//CHECK_ALL:         struct arrfptr * x = malloc<struct arrfptr>(sizeof(struct arrfptr));
+//CHECK_ALL:         _Ptr<struct arrfptr> y =   malloc<struct arrfptr>(sizeof(struct arrfptr));
 //CHECK_ALL:         _Ptr<struct arrfptr> z =  sus(x, y); 

--- a/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrinstructsafemulti2.c
@@ -135,6 +135,6 @@ struct arrfptr * sus(struct arrfptr *x, struct arrfptr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_NOALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 
 //CHECK_ALL: _Ptr<struct arrfptr> sus(struct arrfptr *x, _Ptr<struct arrfptr> y) {
-//CHECK_ALL:         _Ptr<struct arrfptr> z =  malloc(sizeof(struct arrfptr)); 
+//CHECK_ALL:         _Ptr<struct arrfptr> z =  malloc<struct arrfptr>(sizeof(struct arrfptr)); 

--- a/clang/test/CheckedCRewriter/fptrarrprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotoboth.c
@@ -134,12 +134,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -155,12 +155,12 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
@@ -176,8 +176,8 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocallee.c
@@ -134,12 +134,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -154,12 +154,12 @@ int ** bar() {
         
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
@@ -175,8 +175,8 @@ int ** sus(int *x, int *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocaller.c
@@ -134,12 +134,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -155,12 +155,12 @@ int ** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
@@ -175,8 +175,8 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotosafe.c
@@ -133,12 +133,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -153,12 +153,12 @@ int ** bar() {
         
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** sus(int *x, int *y) {
@@ -173,8 +173,8 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafe.c
@@ -126,10 +126,10 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 
 int ** foo() {
@@ -144,12 +144,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -164,10 +164,10 @@ int ** bar() {
         
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
@@ -135,12 +135,12 @@ int ** foo() {
         
 return z; }
 //CHECK_NOALL: int ** foo() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** foo() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);
 
 int ** bar() {
@@ -155,10 +155,10 @@ int ** bar() {
         
 return z; }
 //CHECK_NOALL: int ** bar() {
-//CHECK_NOALL:         int *x = malloc(sizeof(int)); 
-//CHECK_NOALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_NOALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         int *z = sus(x, y);
 //CHECK_ALL: int ** bar() {
-//CHECK_ALL:         int *x = malloc(sizeof(int)); 
-//CHECK_ALL:         int *y = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *x = malloc<int>(sizeof(int)); 
+//CHECK_ALL:         int *y = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         int *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -131,8 +131,8 @@ int ** sus(int *x, int *y) {
         
 return z; }
 //CHECK_NOALL: int ** sus(int *x, int *y) {
-//CHECK_NOALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_NOALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_NOALL:         _Ptr<int* (int *)> mul2ptr =  mul2;
 //CHECK_ALL: int ** sus(int *x, int *y) {
-//CHECK_ALL:         int **z = calloc(5, sizeof(int *)); 
+//CHECK_ALL:         int **z = calloc<int *>(5, sizeof(int *)); 
 //CHECK_ALL:         _Ptr<int* (int *)> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructboth.c
@@ -131,9 +131,9 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
  
@@ -153,15 +153,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * foo() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -184,14 +184,14 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
@@ -142,15 +142,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * foo() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -173,14 +173,14 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
@@ -136,6 +136,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallee.c
@@ -131,9 +131,9 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
  
@@ -153,15 +153,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * foo() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -183,14 +183,14 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
@@ -142,15 +142,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * foo() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -172,14 +172,14 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
@@ -136,6 +136,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcaller.c
@@ -130,9 +130,9 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK_NOALL: struct fptrarr *sus(struct fptrarr *x, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>) {
-//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
  
@@ -152,15 +152,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -183,14 +183,14 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
@@ -142,15 +142,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -173,14 +173,14 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
@@ -135,6 +135,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK_NOALL: struct fptrarr *sus(struct fptrarr *x, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>) {
-//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
@@ -140,15 +140,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * foo() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -171,15 +171,15 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -199,6 +199,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
@@ -140,15 +140,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * foo() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -170,15 +170,15 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -198,6 +198,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
@@ -140,15 +140,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -171,15 +171,15 @@ struct fptrarr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptrarr * bar() {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
@@ -198,6 +198,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK_NOALL: struct fptrarr *sus(struct fptrarr *x, _Ptr<struct fptrarr> y) : itype(_Ptr<struct fptrarr>) {
-//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: struct fptrarr * sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         struct fptrarr *z = malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         struct fptrarr *z = malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
@@ -139,15 +139,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
@@ -169,15 +169,15 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> bar(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> bar(void) {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
@@ -196,6 +196,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrarrstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafe.c
@@ -129,9 +129,9 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 
 struct fptrarr * foo() {
  
@@ -151,15 +151,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
@@ -181,14 +181,14 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> bar(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> bar(void) {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
@@ -141,15 +141,15 @@ struct fptrarr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> foo(void) {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
@@ -171,14 +171,14 @@ struct fptrarr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> bar(void) {
-//CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_NOALL:         int *yvals = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> bar(void) {
-//CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
-//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         struct fptrarr * x = malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc<struct fptrarr>(sizeof(struct fptrarr));
+//CHECK_ALL:         _Array_ptr<int> yvals: count((5 * sizeof(int))) =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
@@ -134,6 +134,6 @@ struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_NOALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 
 //CHECK_ALL: _Ptr<struct fptrarr> sus(struct fptrarr *x, _Ptr<struct fptrarr> y) {
-//CHECK_ALL:         _Ptr<struct fptrarr> z =  malloc(sizeof(struct fptrarr)); 
+//CHECK_ALL:         _Ptr<struct fptrarr> z =  malloc<struct fptrarr>(sizeof(struct fptrarr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructboth.c
@@ -125,9 +125,9 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -137,12 +137,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptr * foo() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -154,10 +154,10 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti1.c
@@ -132,12 +132,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptr * foo() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -149,10 +149,10 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructbothmulti2.c
@@ -130,6 +130,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallee.c
@@ -125,9 +125,9 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -137,12 +137,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptr * foo() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -153,10 +153,10 @@ struct fptr * bar() {
         
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti1.c
@@ -132,12 +132,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptr * foo() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -148,10 +148,10 @@ struct fptr * bar() {
         
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcalleemulti2.c
@@ -130,6 +130,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcaller.c
@@ -124,9 +124,9 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK_NOALL: struct fptr *sus(struct fptr *x, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>) {
-//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -136,12 +136,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> foo(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -153,10 +153,10 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti1.c
@@ -132,12 +132,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> foo(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -149,10 +149,10 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructcallermulti2.c
@@ -129,6 +129,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK_NOALL: struct fptr *sus(struct fptr *x, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>) {
-//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotoboth.c
@@ -130,12 +130,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptr * foo() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -147,12 +147,12 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -165,6 +165,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocallee.c
@@ -130,12 +130,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: struct fptr * foo() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -146,12 +146,12 @@ struct fptr * bar() {
         
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -164,6 +164,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotocaller.c
@@ -130,12 +130,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> foo(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: struct fptr * foo() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * bar() {
@@ -147,12 +147,12 @@ struct fptr * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: struct fptr * bar() {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         struct fptr *z = sus(x, y);
 //CHECK_ALL: struct fptr * bar() {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         struct fptr *z = sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -164,6 +164,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK_NOALL: struct fptr *sus(struct fptr *x, _Ptr<struct fptr> y) : itype(_Ptr<struct fptr>) {
-//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: struct fptr * sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         struct fptr *z = malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         struct fptr *z = malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructprotosafe.c
@@ -129,12 +129,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> foo(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptr> foo(void) {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         _Ptr<struct fptr> z =  sus(x, y);
 
 struct fptr * bar() {
@@ -145,12 +145,12 @@ struct fptr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> bar(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptr> bar(void) {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         _Ptr<struct fptr> z =  sus(x, y);
 
 struct fptr * sus(struct fptr *x, struct fptr *y) {
@@ -162,6 +162,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrinstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafe.c
@@ -123,9 +123,9 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 
 
 struct fptr * foo() {
  
@@ -135,12 +135,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> foo(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptr> foo(void) {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         _Ptr<struct fptr> z =  sus(x, y);
 
 struct fptr * bar() {
@@ -151,10 +151,10 @@ struct fptr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> bar(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptr> bar(void) {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         _Ptr<struct fptr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti1.c
@@ -131,12 +131,12 @@ struct fptr * foo() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> foo(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptr> foo(void) {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         _Ptr<struct fptr> z =  sus(x, y);
 
 struct fptr * bar() {
@@ -147,10 +147,10 @@ struct fptr * bar() {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> bar(void) {
-//CHECK_NOALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_NOALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_NOALL:         _Ptr<struct fptr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptr> bar(void) {
-//CHECK_ALL:         struct fptr * x = malloc(sizeof(struct fptr)); 
-//CHECK_ALL:         _Ptr<struct fptr> y =   malloc(sizeof(struct fptr));
+//CHECK_ALL:         struct fptr * x = malloc<struct fptr>(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> y =   malloc<struct fptr>(sizeof(struct fptr));
 //CHECK_ALL:         _Ptr<struct fptr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrinstructsafemulti2.c
@@ -128,6 +128,6 @@ struct fptr * sus(struct fptr *x, struct fptr *y) {
         
 return z; }
 //CHECK_NOALL: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_NOALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 
 //CHECK_ALL: _Ptr<struct fptr> sus(struct fptr *x, _Ptr<struct fptr> y) {
-//CHECK_ALL:         _Ptr<struct fptr> z =  malloc(sizeof(struct fptr)); 
+//CHECK_ALL:         _Ptr<struct fptr> z =  malloc<struct fptr>(sizeof(struct fptr)); 

--- a/clang/test/CheckedCRewriter/fptrsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeboth.c
@@ -128,10 +128,10 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -150,14 +150,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -179,14 +179,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
@@ -140,14 +140,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -169,14 +169,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
@@ -133,8 +133,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallee.c
@@ -128,10 +128,10 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -150,14 +150,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -178,14 +178,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
@@ -140,14 +140,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -168,14 +168,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
@@ -133,8 +133,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafecaller.c
@@ -127,10 +127,10 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -149,14 +149,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -178,14 +178,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
@@ -140,14 +140,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -169,14 +169,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
@@ -132,8 +132,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
@@ -138,14 +138,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -167,14 +167,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -192,8 +192,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
@@ -138,14 +138,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -166,14 +166,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -191,8 +191,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
@@ -138,14 +138,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -167,14 +167,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -191,8 +191,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
@@ -137,14 +137,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -165,14 +165,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -189,8 +189,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafe.c
@@ -126,10 +126,10 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;
 
 int * foo() {
@@ -148,14 +148,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -176,14 +176,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
@@ -139,14 +139,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> foo(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);
@@ -167,14 +167,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         _Ptr<struct general> curr =  y;
 //CHECK_NOALL:         _Ptr<int* (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_NOALL:         int *z = sus_ptr(x, y);
 //CHECK_ALL: _Nt_array_ptr<int> bar(void) {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         _Ptr<struct general> y =  malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         _Ptr<struct general> curr =  y;
 //CHECK_ALL:         _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
 //CHECK_ALL:         _Nt_array_ptr<int> z =  sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
@@ -131,8 +131,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         _Ptr<struct general> p =  y;
 //CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int)); 
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         _Ptr<struct general> p =  y;

--- a/clang/test/CheckedCRewriter/fptrunsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeboth.c
@@ -128,10 +128,10 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;
 
 int * foo() {
@@ -150,14 +150,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -179,14 +179,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti1.c
@@ -140,14 +140,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -169,14 +169,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafebothmulti2.c
@@ -133,8 +133,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallee.c
@@ -128,10 +128,10 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;
 
 int * foo() {
@@ -150,14 +150,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -178,14 +178,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti1.c
@@ -140,14 +140,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -168,14 +168,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecalleemulti2.c
@@ -133,8 +133,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecaller.c
@@ -127,10 +127,10 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;
 
 int * foo() {
@@ -149,14 +149,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -178,14 +178,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti1.c
@@ -140,14 +140,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -169,14 +169,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafecallermulti2.c
@@ -132,8 +132,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
@@ -138,14 +138,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -167,14 +167,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -192,8 +192,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
@@ -138,14 +138,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -166,14 +166,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -191,8 +191,8 @@ int * sus(struct general *x, struct general *y) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
@@ -138,14 +138,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -167,14 +167,14 @@ int * bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -191,8 +191,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
@@ -137,14 +137,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -165,14 +165,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -189,8 +189,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/fptrunsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafe.c
@@ -126,10 +126,10 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;
 
 int * foo() {
@@ -148,14 +148,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -176,14 +176,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti1.c
@@ -139,14 +139,14 @@ int * foo() {
         
 return z; }
 //CHECK_NOALL: int * foo() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * foo() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);
@@ -167,14 +167,14 @@ int * bar() {
         
 return z; }
 //CHECK_NOALL: int * bar() {
-//CHECK_NOALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_NOALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_NOALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_NOALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_NOALL:         struct general *curr = y;
 //CHECK_NOALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_NOALL:         int *z = (int *) sus_ptr(x, y);
 //CHECK_ALL: int * bar() {
-//CHECK_ALL:         struct general *x = malloc(sizeof(struct general)); 
-//CHECK_ALL:         struct general *y = malloc(sizeof(struct general));
+//CHECK_ALL:         struct general *x = malloc<struct general>(sizeof(struct general)); 
+//CHECK_ALL:         struct general *y = malloc<struct general>(sizeof(struct general));
 //CHECK_ALL:         struct general *curr = y;
 //CHECK_ALL:         int (*sus_ptr)(struct fptr *, struct fptr *) = sus;   
 //CHECK_ALL:         int *z = (int *) sus_ptr(x, y);

--- a/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrunsafesafemulti2.c
@@ -131,8 +131,8 @@ int * sus(struct general *x, struct general *y) {
         
 return z; }
 //CHECK_NOALL: int * sus(struct general *x, struct general *y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL:         struct general *p = y;
 //CHECK_ALL: int * sus(struct general *x, struct general *y) {
-//CHECK_ALL:         int *z = calloc(5, sizeof(int)); 
+//CHECK_ALL:         int *z = calloc<int>(5, sizeof(int)); 
 //CHECK_ALL:         struct general *p = y;

--- a/clang/test/CheckedCRewriter/graphs.c
+++ b/clang/test/CheckedCRewriter/graphs.c
@@ -230,7 +230,7 @@ struct node* createNode(int v)
 
 }
 //CHECK: struct node *createNode(int v) : itype(_Ptr<struct node>)
-//CHECK: _Ptr<struct node> newNode =  malloc(sizeof(struct node));
+//CHECK: _Ptr<struct node> newNode =  malloc<struct node>(sizeof(struct node));
 
 //Allocate memory for the entire graph structure
 
@@ -325,7 +325,7 @@ struct Stack* createStack()
 
 }
 //CHECK: _Ptr<struct Stack> createStack(void)
-//CHECK: _Ptr<struct Stack> stack = malloc(sizeof(struct Stack));
+//CHECK: _Ptr<struct Stack> stack = malloc<struct Stack>(sizeof(struct Stack));
 
 //Pushes element into stack
 

--- a/clang/test/CheckedCRewriter/graphs2.c
+++ b/clang/test/CheckedCRewriter/graphs2.c
@@ -47,5 +47,5 @@ void createGraph(struct Graph* G,int V){
 
 }
 //CHECK: void createGraph(_Ptr<struct Graph> G, int V){
-//CHECK: int ** toadd = malloc(V * sizeof(int*));
-//CHECK: int *adder = malloc(V * sizeof(int));
+//CHECK: int ** toadd = malloc<int *>(V * sizeof(int*));
+//CHECK: int *adder = malloc<int>(V * sizeof(int));

--- a/clang/test/CheckedCRewriter/linkedlist.c
+++ b/clang/test/CheckedCRewriter/linkedlist.c
@@ -61,7 +61,7 @@ Node * createnode(int data){
 
 }
 //CHECK: Node *createnode(int data) : itype(_Ptr<Node>){
-//CHECK: _Ptr<Node> newNode =  malloc(sizeof(Node));
+//CHECK: _Ptr<Node> newNode =  malloc<Node>(sizeof(Node));
 
 
 
@@ -81,7 +81,7 @@ List * makelist(){
 
 }
 //CHECK: _Ptr<List> makelist(void){
-//CHECK: _Ptr<List> list =  malloc(sizeof(List));
+//CHECK: _Ptr<List> list =  malloc<List>(sizeof(List));
 
 
 

--- a/clang/test/CheckedCRewriter/malloc_array.c
+++ b/clang/test/CheckedCRewriter/malloc_array.c
@@ -9,8 +9,8 @@ int * foo(int *x) {
 }
 void bar(void) {
   int *y = malloc(sizeof(int)*2);
-  //CHECK_NOALL: int *y = malloc(sizeof(int)*2);
-  //CHECK_ALL: int *y = malloc(sizeof(int)*2);
+  //CHECK_NOALL: int *y = malloc<int>(sizeof(int)*2);
+  //CHECK_ALL: int *y = malloc<int>(sizeof(int)*2);
   y = (int *)5;
   int *z = foo(y);
   //CHECK_NOALL: int *z = foo(y);

--- a/clang/test/CheckedCRewriter/pointerarithm.c
+++ b/clang/test/CheckedCRewriter/pointerarithm.c
@@ -16,7 +16,7 @@ int *sus(int *x, int*y) {
   return z;
 }
 //CHECK: _Array_ptr<int> sus(int *x : itype(_Array_ptr<int>), _Ptr<int> y) {
-//CHECK-NEXT:  _Array_ptr<int> z: count((sizeof(int) * 2)) =  malloc(sizeof(int)*2);
+//CHECK-NEXT:  _Array_ptr<int> z: count((sizeof(int) * 2)) =  malloc<int>(sizeof(int)*2);
 
 int* foo() {
   int sx = 3, sy = 4, *x = &sx, *y = &sy;

--- a/clang/test/CheckedCRewriter/ptrTOptrboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrboth.c
@@ -131,11 +131,11 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -143,12 +143,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -158,10 +158,10 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti1.c
@@ -129,12 +129,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -144,10 +144,10 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrbothmulti2.c
@@ -136,8 +136,8 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallee.c
@@ -131,11 +131,11 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -143,12 +143,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -157,10 +157,10 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti1.c
@@ -129,12 +129,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -143,10 +143,10 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcalleemulti2.c
@@ -136,8 +136,8 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrcaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcaller.c
@@ -130,11 +130,11 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -142,12 +142,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -157,10 +157,10 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti1.c
@@ -129,12 +129,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -144,10 +144,10 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrcallermulti2.c
@@ -135,8 +135,8 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotoboth.c
@@ -127,12 +127,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -142,12 +142,12 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -167,8 +167,8 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocallee.c
@@ -127,12 +127,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -141,12 +141,12 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -166,8 +166,8 @@ x = (char * * *) 5;
 z += 2;
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotocaller.c
@@ -127,12 +127,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -142,12 +142,12 @@ char *** bar() {
 z += 2;
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -166,8 +166,8 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Array_ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrprotosafe.c
@@ -126,12 +126,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -140,12 +140,12 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** sus(char * * * x, char * * * y) {
@@ -164,8 +164,8 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrTOptrsafe.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafe.c
@@ -129,11 +129,11 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 
 
 char *** foo() {
         char * * * x = malloc(sizeof(char * *));
@@ -141,12 +141,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -155,10 +155,10 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti1.c
@@ -128,12 +128,12 @@ char *** foo() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** foo() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> foo(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);
 
 char *** bar() {
@@ -142,10 +142,10 @@ char *** bar() {
         char *** z = sus(x, y);
 return z; }
 //CHECK_NOALL: char *** bar() {
-//CHECK_NOALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_NOALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_NOALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_NOALL:         char *** z = sus(x, y);
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> bar(void) {
-//CHECK_ALL:         char * * * x = malloc(sizeof(char * *));
-//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc(sizeof(char * *));
+//CHECK_ALL:         char * * * x = malloc<char **>(sizeof(char * *));
+//CHECK_ALL:         _Ptr<_Ptr<_Ptr<char>>> y =  malloc<char **>(sizeof(char * *));
 //CHECK_ALL:         _Ptr<_Array_ptr<char*>> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/ptrTOptrsafemulti2.c
@@ -134,8 +134,8 @@ x = (char * * *) 5;
         
 return z; }
 //CHECK_NOALL: char *** sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_NOALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_NOALL:         char *** z = malloc(5*sizeof(char**)); 
+//CHECK_NOALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_NOALL:         char *** z = malloc<char **>(5*sizeof(char**)); 
 //CHECK_ALL: _Ptr<_Array_ptr<char*>> sus(char ***x, _Ptr<_Ptr<_Ptr<char>>> y) {
-//CHECK_ALL:         char *ch = malloc(sizeof(char)); 
-//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc(5*sizeof(char**)); 
+//CHECK_ALL:         char *ch = malloc<char>(sizeof(char)); 
+//CHECK_ALL:         _Array_ptr<_Array_ptr<char*>> z: count((5 * sizeof(char **))) =  malloc<char **>(5*sizeof(char**)); 

--- a/clang/test/CheckedCRewriter/ptrptr.c
+++ b/clang/test/CheckedCRewriter/ptrptr.c
@@ -28,7 +28,7 @@ void g() {
   r = p;
   **r = 1;
 }
-// CHECK:  _Array_ptr<int> x: count((sizeof(int) * 1)) =  malloc(sizeof(int)*1);
+// CHECK:  _Array_ptr<int> x: count((sizeof(int) * 1)) =  malloc<int>(sizeof(int)*1);
 // CHECK:  int y _Checked[5];
 // CHECK:  _Ptr<_Array_ptr<int>> p =  &x;
 // CHECK:  _Ptr<_Array_ptr<int>> r =  0;

--- a/clang/test/CheckedCRewriter/realloc.c
+++ b/clang/test/CheckedCRewriter/realloc.c
@@ -15,8 +15,8 @@ void foo(int *w) {
     int *z = realloc(y, 5*sizeof(int)); 
     z[3] =  2;
 } 
-//CHECK_NOALL: int *y = malloc(2*sizeof(int)); 
-//CHECK_NOALL: int *z = realloc(y, 5*sizeof(int));
-//CHECK_ALL: _Array_ptr<int> y: count((2 * sizeof(int))) =  malloc(2*sizeof(int)); 
-//CHECK_ALL: _Array_ptr<int> z =  realloc(y, 5*sizeof(int)); 
+//CHECK_NOALL: int *y = malloc<int>(2*sizeof(int)); 
+//CHECK_NOALL: int *z = realloc<int>(y, 5*sizeof(int));
+//CHECK_ALL: _Array_ptr<int> y: count((2 * sizeof(int))) =  malloc<int>(2*sizeof(int)); 
+//CHECK_ALL: _Array_ptr<int> z =  realloc<int>(y, 5*sizeof(int)); 
 

--- a/clang/test/CheckedCRewriter/realloc_complex.c
+++ b/clang/test/CheckedCRewriter/realloc_complex.c
@@ -37,16 +37,16 @@ void foo(int *count) {
     m[1] = 5; 
     z[3] =  2;
 } 
-//CHECK_NOALL: int *a = malloc(2*sizeof(int));
-//CHECK_ALL: _Array_ptr<int> a: count((2 * sizeof(int))) =  malloc(2*sizeof(int)); 
+//CHECK_NOALL: int *a = malloc<int>(2*sizeof(int));
+//CHECK_ALL: _Array_ptr<int> a: count((2 * sizeof(int))) =  malloc<int>(2*sizeof(int)); 
 
-//CHECK: int *b = malloc(sizeof(int));
+//CHECK: int *b = malloc<int>(sizeof(int));
 
-//CHECK_ALL: _Array_ptr<int> y: count((2 * sizeof(int))) =  malloc(2*sizeof(int)); 
-//CHECK_NOALL: int *y = malloc(2*sizeof(int));
-//CHECK: int *w = malloc(sizeof(int));
-//CHECK_NOALL: int *z = realloc(y, 5*sizeof(int)); 
-//CHECK_NOALL: int *m = realloc(w, 2*sizeof(int));
-//CHECK_ALL: _Array_ptr<int> z =  realloc(y, 5*sizeof(int));
-//CHECK_ALL: _Array_ptr<int> m =  realloc(w, 2*sizeof(int)); 
+//CHECK_ALL: _Array_ptr<int> y: count((2 * sizeof(int))) =  malloc<int>(2*sizeof(int)); 
+//CHECK_NOALL: int *y = malloc<int>(2*sizeof(int));
+//CHECK: int *w = malloc<int>(sizeof(int));
+//CHECK_NOALL: int *z = realloc<int>(y, 5*sizeof(int)); 
+//CHECK_NOALL: int *m = realloc<int>(w, 2*sizeof(int));
+//CHECK_ALL: _Array_ptr<int> z =  realloc<int>(y, 5*sizeof(int));
+//CHECK_ALL: _Array_ptr<int> m =  realloc<int>(w, 2*sizeof(int)); 
 

--- a/clang/test/CheckedCRewriter/return_not_least.c
+++ b/clang/test/CheckedCRewriter/return_not_least.c
@@ -35,7 +35,7 @@ extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_
 int *bar() {
 // CHECK: _Nt_array_ptr<int> bar(void) {
   int *z = calloc(2, sizeof(int));
-  //CHECK: _Nt_array_ptr<int> z =  calloc(2, sizeof(int));
+  //CHECK: _Nt_array_ptr<int> z =  calloc<int>(2, sizeof(int));
   z += 2;
   return z;
 }

--- a/clang/test/CheckedCRewriter/safefptrargboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargboth.c
@@ -127,9 +127,9 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));
 
 int * foo() {
  

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
@@ -132,6 +132,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargcallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallee.c
@@ -127,9 +127,9 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));
 
 int * foo() {
  

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
@@ -132,6 +132,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargcaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargcaller.c
@@ -126,9 +126,9 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));
 
 int * foo() {
  

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
@@ -131,6 +131,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotoboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotoboth.c
@@ -167,6 +167,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotocallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocallee.c
@@ -166,6 +166,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
 z += 2;
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotocaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocaller.c
@@ -166,6 +166,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargprotosafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotosafe.c
@@ -164,6 +164,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/safefptrargsafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafe.c
@@ -125,9 +125,9 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));
 
 int * foo() {
  

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
@@ -130,6 +130,6 @@ int * sus(int (*x) (int), int (*y) (int)) {
         
 return z; }
 //CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_NOALL:         int *z = calloc(5, sizeof(int));
+//CHECK_NOALL:         int *z = calloc<int>(5, sizeof(int));
 //CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
-//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc(5, sizeof(int));
+//CHECK_ALL:         _Nt_array_ptr<int> z =  calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/single_ptr_calloc.c
+++ b/clang/test/CheckedCRewriter/single_ptr_calloc.c
@@ -16,6 +16,6 @@ void foo(int *w) {
     /*allocating multiple things, should only be converted when alltypes is on*/
     int *y = calloc(5, sizeof(int)); 
 }
-//CHECK: _Ptr<int> x = calloc(1, sizeof(int));
-//CHECK_ALL: _Ptr<int> y = calloc(5, sizeof(int)); 
-//CHECK_NOALL: int *y = calloc(5, sizeof(int));
+//CHECK: _Ptr<int> x = calloc<int>(1, sizeof(int));
+//CHECK_ALL: _Ptr<int> y = calloc<int>(5, sizeof(int)); 
+//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/tree.c
+++ b/clang/test/CheckedCRewriter/tree.c
@@ -28,7 +28,7 @@ struct tree *new_node(int val, unsigned int num_childs, struct tree *parent) {
 }
 
 //CHECK: _Ptr<struct tree> new_node(int val, unsigned int num_childs, _Ptr<struct tree> parent) {
-//CHECK: _Ptr<struct tree> n = malloc(sizeof(struct tree));
+//CHECK: _Ptr<struct tree> n = malloc<struct tree>(sizeof(struct tree));
 //CHECK: _Array_ptr<_Ptr<struct tree>> children: count((sizeof(struct tree *) * num_childs)) = ((void *)0);
 
 int add_child(struct tree *p, struct tree *c) {


### PR DESCRIPTION
Adds a new pass when rewriting to insert type arguments in calls to allocator functions (`malloc`, `calloc`, `realloc`). The basic assumption this uses is that these function calls will be inside a cast expression that casts `void*` to whatever type the return value is used as. The pointee type of the casts type is used as the type argument.

News tests demonstrating this are added in `alloc_type_param.c`, and existing tests have been updated to include type parameters. 