### PR TITLE
Advanced array inference based on control dependencies

### DIFF
--- a/clang/include/clang/CConv/AVarBoundsInfo.h
+++ b/clang/include/clang/CConv/AVarBoundsInfo.h
@@ -87,7 +87,8 @@ public:
   AvarBoundsInference(AVarBoundsInfo *BoundsInfo) : BI(BoundsInfo) { }
 
   // Infer bounds for the given key from the set of given ARR atoms.
-  bool inferBounds(BoundsKey K);
+  // The flag FromPB requests the inference to use potential length variables.
+  bool inferBounds(BoundsKey K, bool FromPB = false);
 private:
   bool inferPossibleBounds(BoundsKey K, ABounds *SB,
                            std::set<ABounds *> &EB);
@@ -123,6 +124,7 @@ public:
   bool removeBounds(BoundsKey L);
   bool replaceBounds(BoundsKey L, ABounds *B);
   ABounds *getBounds(BoundsKey L);
+  bool updatePotentialCountBounds(BoundsKey BK, std::set<BoundsKey> &CntBK);
 
   // Try and get BoundsKey, into R, for the given declaration. If the declaration
   // does not have a BoundsKey then return false.
@@ -184,6 +186,9 @@ private:
   AVarGraph ProgVarGraph;
   // Stats on techniques used to find length for various variables.
   AVarBoundsStats BoundsInferStats;
+  // This is the map of pointer variable bounds key and set of bounds key
+  // which can be the count bounds.
+  std::map<BoundsKey, std::set<BoundsKey>> PotentialCntBounds;
 
   // BoundsKey helper function: These functions help in getting bounds key from
   // various artifacts.
@@ -196,6 +201,11 @@ private:
   void insertVarKey(PersistentSourceLoc &PSL, BoundsKey NK);
 
   void insertProgramVar(BoundsKey NK, ProgramVar *PV);
+
+  // Perform worklist based inference on the requested array variables.
+  // The flag FromPB requests the algorithm to use potential length variables.
+  bool performWorkListInference(std::set<BoundsKey> &ArrNeededBounds,
+                                bool FromPB = false);
 
 };
 

--- a/clang/include/clang/CConv/ArrayBoundsInferenceConsumer.h
+++ b/clang/include/clang/CConv/ArrayBoundsInferenceConsumer.h
@@ -12,11 +12,15 @@
 #ifndef _ARRAYBOUNDSINFERENCECONSUMER_H
 #define _ARRAYBOUNDSINFERENCECONSUMER_H
 
+#include "clang/Analysis/CFG.h"
+#include "clang/Analysis/Analyses/Dominators.h"
+#include "clang/AST/StmtVisitor.h"
 #include "clang/AST/ASTConsumer.h"
 
 #include "ProgramInfo.h"
 
 class LocalVarABVisitor;
+class ConstraintResolver;
 
 // This class handles determining bounds of global array variables.
 // i.e., function parameters, structure fields and global variables.
@@ -56,6 +60,33 @@ private:
   std::set<ParmVarDecl *> NonLengthParameters;
   ASTContext *Context;
   ProgramInfo &Info;
+};
+
+// Statement visitor that tries to find potential length variables of arrays
+// based on the usage.
+// Example:
+// if (i < len) { ....arr[i]...}
+// Here, we detect that len is a potential length of arr.
+class LengthVarInference : public StmtVisitor<LengthVarInference> {
+public:
+  LengthVarInference(ProgramInfo &In, ASTContext *AC,
+                     FunctionDecl *F);
+
+  virtual ~LengthVarInference();
+
+  void VisitStmt(Stmt *St);
+
+  void VisitArraySubscriptExpr(ArraySubscriptExpr *ASE);
+
+private:
+  std::map<const Stmt *, CFGBlock *> StMap;
+  ProgramInfo &I;
+  ASTContext *C;
+  FunctionDecl *FD;
+  CFGBlock *CurBB;
+  ControlDependencyCalculator *CDG;
+  ConstraintResolver *CR;
+  std::unique_ptr<CFG> Cfg;
 };
 
 void HandleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I);

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -395,20 +395,6 @@ bool GlobalABVisitor::VisitFunctionDecl(FunctionDecl *FD) {
   // If we have seen the body of this function? Then try to guess the length
   // of the parameters that are arrays.
   if (FD->isThisDeclarationADefinition() && FD->hasBody()) {
-    std::unique_ptr<CFG> Cfg = CFG::buildCFG(nullptr, FD->getBody(),
-                                             Context, CFG::BuildOptions());
-
-    CFGDomTree DT(Cfg.get());
-
-    auto *RBB = DT.getRoot();
-    DT.getRootNode()->getChildren();
-
-    ControlDependencyCalculator CDG(Cfg.get());
-    CDG.getControlDependencies(RBB);
-
-
-
-
     auto &ABInfo = Info.getABoundsInfo();
     auto &ABStats = ABInfo.getBStats();
     const clang::Type *Ty = FD->getTypeSourceInfo()->getTypeLoc().getTypePtr();

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -677,6 +677,13 @@ public:
     }
   }
 
+  void VisitSwitchStmt(SwitchStmt *St) {
+    // Ignore.
+  }
+
+  void VisitSwitchCase(SwitchCase *St) {
+    // Ignore.
+  }
   void VisitBinaryOperator(BinaryOperator *BO) {
     // We care about < and >= operator.
     if (BO->getOpcode() == BO_LT || BO->getOpcode() == BO_GE) {

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/Analysis/CFG.h"
+#include "clang/Analysis/Analyses/Dominators.h"
 #include "clang/CConv/ArrayBoundsInferenceConsumer.h"
 #include "clang/CConv/ConstraintResolver.h"
 #include <sstream>
@@ -393,6 +395,20 @@ bool GlobalABVisitor::VisitFunctionDecl(FunctionDecl *FD) {
   // If we have seen the body of this function? Then try to guess the length
   // of the parameters that are arrays.
   if (FD->isThisDeclarationADefinition() && FD->hasBody()) {
+    std::unique_ptr<CFG> Cfg = CFG::buildCFG(nullptr, FD->getBody(),
+                                             Context, CFG::BuildOptions());
+
+    CFGDomTree DT(Cfg.get());
+
+    auto *RBB = DT.getRoot();
+    DT.getRootNode()->getChildren();
+
+    ControlDependencyCalculator CDG(Cfg.get());
+    CDG.getControlDependencies(RBB);
+
+
+
+
     auto &ABInfo = Info.getABoundsInfo();
     auto &ABStats = ABInfo.getBStats();
     const clang::Type *Ty = FD->getTypeSourceInfo()->getTypeLoc().getTypePtr();
@@ -611,6 +627,176 @@ void AddMainFuncHeuristic(ASTContext *C, ProgramInfo &I, FunctionDecl *FD) {
           ABounds *ArgcBounds = new CountBound(ArgcKey);
           ABInfo.replaceBounds(ArgvKey, ArgcBounds);
         }
+      }
+    }
+  }
+
+}
+
+// Given a variable I, this visitor collects all the variables that are used as
+// RHS operand of < and I >=  expression.
+// i.e., for all I < X expressions, it collects X.
+class ComparisionVisitor : public StmtVisitor<ComparisionVisitor> {
+public:
+  ComparisionVisitor(ProgramInfo &In, ASTContext *AC,
+                     BoundsKey I, std::set<BoundsKey> &PossB) : I(In),
+                                    C(AC),
+                                    IndxBKey(I), PB(PossB) {
+    CR = new ConstraintResolver(In, AC);
+  }
+  virtual ~ComparisionVisitor() {
+    if (CR != nullptr) {
+      delete (CR);
+      CR = nullptr;
+    }
+  }
+
+  void VisitStmt(Stmt *St) {
+    for (auto *Child : St->children()) {
+      if (Child) {
+        Visit(Child);
+      }
+    }
+  }
+
+  void VisitIfStmt(IfStmt *St) {
+    if (St->getCond() != nullptr) {
+      Visit(St->getCond());
+    }
+  }
+
+  void VisitWhileStmt(WhileStmt *St) {
+    if (St->getCond() != nullptr) {
+      Visit(St->getCond());
+    }
+  }
+
+  void VisitForStmt(ForStmt *St) {
+    if (St->getCond() != nullptr) {
+      Visit(St->getCond());
+    }
+  }
+
+  void VisitBinaryOperator(BinaryOperator *BO) {
+    // We care about < and >= operator.
+    if (BO->getOpcode() == BO_LT || BO->getOpcode() == BO_GE) {
+      Expr *LHS = BO->getLHS()->IgnoreParenCasts();
+      Expr *RHS = BO->getRHS()->IgnoreParenCasts();
+      auto LHSCVars = CR->getExprConstraintVars(LHS);
+      auto RHSCVars = CR->getExprConstraintVars(RHS);
+
+      if (!CR->containsValidCons(LHSCVars) &&
+          !CR->containsValidCons(RHSCVars)) {
+        BoundsKey LKey, RKey;
+        auto &ABI = I.getABoundsInfo();
+        if ((CR->resolveBoundsKey(LHSCVars, LKey) ||
+            ABI.tryGetVariable(LHS, *C, LKey)) &&
+            (CR->resolveBoundsKey(RHSCVars, RKey) ||
+             ABI.tryGetVariable(RHS, *C, RKey))) {
+          // If this the left hand side of a < comparision and the LHS is the
+          // index used in array indexing operation? Then add the RHS to the
+          // possible bounds key.
+          if (LKey == IndxBKey) {
+            PB.insert(RKey);
+          }
+        }
+      }
+    } else {
+      for (auto *Child : BO->children()) {
+        if (Child) {
+          Visit(Child);
+        }
+      }
+    }
+  }
+private:
+  ProgramInfo &I;
+  ASTContext *C;
+  // Index variable used in dereference.
+  BoundsKey IndxBKey;
+  // Possible Bounds.
+  std::set<BoundsKey> &PB;
+  // Helper objects.
+  ConstraintResolver *CR;
+};
+
+LengthVarInference::LengthVarInference(ProgramInfo &In,
+                                       ASTContext *AC,
+                                       FunctionDecl *F) : I(In),
+                                       C(AC),
+                                       FD(F),
+                                       CurBB(nullptr) {
+
+  Cfg = CFG::buildCFG(nullptr, FD->getBody(),
+                      AC, CFG::BuildOptions());
+  for (auto *CBlock : *(Cfg.get())) {
+    for (auto &CfgElem : *CBlock) {
+      if (CfgElem.getKind() == clang::CFGElement::Statement) {
+        const Stmt *TmpSt = CfgElem.castAs<CFGStmt>().getStmt();
+        StMap[TmpSt] = CBlock;
+      }
+    }
+  }
+
+  CDG = new ControlDependencyCalculator(Cfg.get());
+
+  CR = new ConstraintResolver(I, C);
+}
+
+LengthVarInference::~LengthVarInference() {
+  if (CDG != nullptr) {
+    delete (CDG);
+    CDG = nullptr;
+  }
+  if (CR != nullptr) {
+    delete (CR);
+    CR = nullptr;
+  }
+}
+
+void LengthVarInference::VisitStmt(Stmt *St) {
+  for (auto *Child : St->children()) {
+    if (Child) {
+      if (StMap.find(St) != StMap.end()) {
+        CurBB = StMap[St];
+      }
+      Visit(Child);
+    }
+  }
+}
+
+void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
+  assert (CurBB != nullptr && "Array dereference does not belong "
+                              "to any basic block");
+  // First, get the BoundsKey for the base.
+  Expr *BE = ASE->getBase()->IgnoreParenCasts();
+  auto BaseCVars = CR->getExprConstraintVars(BE);
+  // Next get the index used.
+  Expr *IdxExpr = ASE->getIdx()->IgnoreParenCasts();
+  auto IdxCVars = CR->getExprConstraintVars(IdxExpr);
+
+  // Get the bounds key of the base and index.
+  if (CR->containsValidCons(BaseCVars) &&
+      !CR->containsValidCons(IdxCVars)) {
+    BoundsKey BasePtr, IdxKey;
+    auto &ABI = I.getABoundsInfo();
+    if (CR->resolveBoundsKey(BaseCVars, BasePtr) &&
+        (CR->resolveBoundsKey(IdxCVars, IdxKey) ||
+            ABI.tryGetVariable(IdxExpr, *C, IdxKey))) {
+      std::set<BoundsKey> PossibleLens;
+      PossibleLens.clear();
+      ComparisionVisitor CV(I, C, IdxKey, PossibleLens);
+      auto &CDNodes = CDG->getControlDependencies(CurBB);
+      if (!CDNodes.empty()) {
+        // Next try to find all the nodes that the CurBB is
+        // control dependent on.
+        // For each of the control dependent node, check if we are comparing the
+        // index variable with another variable.
+        for (auto &CDGNode : CDNodes) {
+          // Collect the possible length bounds keys.
+          CV.Visit(CDGNode->getTerminatorStmt());
+        }
+        ABI.updatePotentialCountBounds(BasePtr, PossibleLens);
       }
     }
   }

--- a/clang/lib/CConv/CMakeLists.txt
+++ b/clang/lib/CConv/CMakeLists.txt
@@ -33,6 +33,7 @@ if (LLVM_BOOST_FOUND)
           Utils.cpp
           LINK_LIBS
           clangAST
+          clangAnalysis
           clangBasic
           clangDriver
           clangFrontend

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -407,6 +407,8 @@ public:
         Stmt *Body = D->getBody();
         FunctionVisitor FV = FunctionVisitor(Context, Info, D);
         FV.TraverseStmt(Body);
+        LengthVarInference LVI(Info, Context, D);
+        LVI.Visit(Body);
       }
     }
 

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -407,8 +407,11 @@ public:
         Stmt *Body = D->getBody();
         FunctionVisitor FV = FunctionVisitor(Context, Info, D);
         FV.TraverseStmt(Body);
-        LengthVarInference LVI(Info, Context, D);
-        LVI.Visit(Body);
+        if (AllTypes) {
+          // Only do this, if all types is enabled.
+          LengthVarInference LVI(Info, Context, D);
+          LVI.Visit(Body);
+        }
       }
     }
 

--- a/clang/test/CheckedCRewriter/arrboundsadvanced.c
+++ b/clang/test/CheckedCRewriter/arrboundsadvanced.c
@@ -1,0 +1,65 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines %s
+
+
+/*
+Advanced array-bounds inference (based on control-dependencies).
+*/
+
+struct foo {
+    void *data;
+};
+//CHECK:     void *data;
+struct foo1 {
+    int *x;
+    // This is to make sure that length heuristic will not
+    // kick in
+    unsigned x_len;
+    unsigned ml;    
+};
+//CHECK:     _Array_ptr<int> x : count(ml);
+struct foo **FL;
+int *intarr;
+//CHECK: _Array_ptr<_Ptr<struct foo>> FL : count(FooLen) = ((void *)0);
+//CHECK: _Array_ptr<int> intarr = ((void *)0);
+unsigned FooLenD;
+unsigned FooLen;
+void intcopy(int *arr, int *ptr, int len) {
+    int i;
+    for (i=0; i<len; i++) {
+        // This will make len the length of arr and ptr.
+        arr[i] = ptr[i];
+    }
+}
+//CHECK: void intcopy(_Array_ptr<int> arr : count(len), _Array_ptr<int> ptr : count(len), int len) {
+
+void setdata(struct foo **G, unsigned dlen, struct foo *d, unsigned idx) {
+    if (idx >= dlen) {
+        return;
+    }
+    if (idx >= FooLenD) {
+        // This is not a control-dependent node.
+        printf("Default length more");
+    }
+    // This will make dlen the length of G
+    G[idx] = d;
+}
+//CHECK: void setdata(_Array_ptr<_Ptr<struct foo>> G : count(dlen), unsigned int dlen, _Ptr<struct foo> d, unsigned int idx) {
+
+int main(int argc, char **argv) {
+    char *PN = argv[0];
+    unsigned i = 3, n;
+    struct foo1 po;
+    setdata(FL, FooLen, 0, 0);
+    n = po.ml;
+    if ( i < n && i < FooLenD && i < FooLen) {
+        // This will make ml the length of X
+        po.x[i] = 0;
+        // This will not make FooLenD or FooLen the size of intarr
+        // because we don't know which one is the right length.
+        intarr[i] = 0;
+    }
+    return 0;
+}
+//CHECK: int main(int argc, _Array_ptr<_Ptr<char>> argv : count(argc)) {
+//CHECK:    _Ptr<char> PN =  argv[0];
+//CHECK:    struct foo1 po = {};

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti2.c
@@ -59,7 +59,7 @@ struct fptrarr {
 //CHECK_NOALL:     char *name;
 //CHECK_NOALL:     _Ptr<int (int )> mapper;
 
-//CHECK_ALL:     _Array_ptr<int> values; 
+//CHECK_ALL:     _Array_ptr<int> values : count(5); 
 //CHECK_ALL:     char *name;
 //CHECK_ALL:     _Ptr<int (int )> mapper;
 

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti2.c
@@ -59,7 +59,7 @@ struct fptrarr {
 //CHECK_NOALL:     char *name;
 //CHECK_NOALL:     _Ptr<int (int )> mapper;
 
-//CHECK_ALL:     _Array_ptr<int> values; 
+//CHECK_ALL:     _Array_ptr<int> values : count(5); 
 //CHECK_ALL:     char *name;
 //CHECK_ALL:     _Ptr<int (int )> mapper;
 

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti2.c
@@ -59,7 +59,7 @@ struct fptrarr {
 //CHECK_NOALL:     char *name;
 //CHECK_NOALL:     _Ptr<int (int )> mapper;
 
-//CHECK_ALL:     _Array_ptr<int> values; 
+//CHECK_ALL:     _Array_ptr<int> values : count(5); 
 //CHECK_ALL:     char *name;
 //CHECK_ALL:     _Ptr<int (int )> mapper;
 

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti2.c
@@ -58,7 +58,7 @@ struct fptrarr {
 //CHECK_NOALL:     char *name;
 //CHECK_NOALL:     _Ptr<int (int )> mapper;
 
-//CHECK_ALL:     _Array_ptr<int> values; 
+//CHECK_ALL:     _Array_ptr<int> values : count(5); 
 //CHECK_ALL:     char *name;
 //CHECK_ALL:     _Ptr<int (int )> mapper;
 


### PR DESCRIPTION
# Checkings based inference
This pull requests add the following feature to array bounds inference mechansim:
Consider the following example:
```
int foo(int *a, int *b, unsigned l) {
    unsigned i = 0;
    for (i=0; i<l; i++) {
        a[i] = b[i];
    }
}
```
From the above code, it is obvious that the length of `a` and `b` should be `l`. 

Consider the following a bit more complex example:
```
struct f {
    int *a;
    unsigned l;
};
void clear(struct f *b, int idx) {
   unsigned n = b->l;
    if (idx >= n) {
        return;
    }
    b->a[idx] = 0;
}
```
Here, we can see that the length of the `f`'s struct member `a` is `l`. 


We can capture these facts by using control dependencies. Specifically, for each array indexing operation, i.e., `arr[i]`, we find all the statements that the indexing statement is **control dependent on**. 
Then, for each of the control dependent nodes, we check if there is any relational comparison of the form `i < X` or `i >= X`, then we consider `X` (or any assignments of `X` to the variables of the same scope as `arr`) to be the size of `arr`.

## Code Changes:

The class `LengthVarInference` performs the inference as mentioned above. 
Specifically, given a `FunctionDecl`, first, it computes the `CDG` (Control dependence graph) of the function. Then, it finds all the array indexing operations in `VisitArraySubscriptExpr` and for each of the indexing operations, it checks if index variable `IdxExpr` is checked by using `CDG`, if yes, it stores the variables that it is compared against using `ComparisionVisitor`.