### PR TITLE
Remove unneeded casts

### DIFF
--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -77,6 +77,9 @@ private:
   std::set<ConstraintVariable *>
       getAllSubExprConstraintVars(std::vector<Expr *> &Exprs);
   std::set<ConstraintVariable *> getBaseVarPVConstraint(DeclRefExpr *Decl);
+  std::set<ConstraintVariable *>
+      getPersistentConstraints(clang::Expr *E,
+                               std::set<ConstraintVariable *> &Vars);
 };
 
 #endif // _CONSTRAINTRESOLVER_H

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -56,12 +56,11 @@ public:
   // For each pointer type in the declaration of D, add a variable to the 
   // constraint system for that pointer type.
   void addVariable(clang::DeclaratorDecl *D, clang::ASTContext *astContext);
-  void addCompoundLiteral(CompoundLiteralExpr *CLE, ASTContext *AstContext);
-
+  std::set<ConstraintVariable *>
+      &getPersistentConstraintVars(Expr *E, ASTContext *AstContext);
   // Get constraint variable for the provided Decl
   std::set<ConstraintVariable *> getVariable(clang::Decl *D,
                                              clang::ASTContext *C);
-  std::set<ConstraintVariable *> getCompoundLiteral(CompoundLiteralExpr *CLE, ASTContext *C);
 
   // Retrieve a function's constraints by decl, or by name; nullptr if not found
   std::set<FVConstraint *> *getFuncConstraints(FunctionDecl *D, ASTContext *C);

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -528,12 +528,16 @@ std::set<ConstraintVariable *>
   return std::set<ConstraintVariable *>();
 }
 
+// Get the set of constraint variables for an expression that will persist
+// between the constraint generation and rewriting pass. If the expression
+// already has a set of persistent constraints, this set is returned. Otherwise,
+// the set provided in the arguments is stored persistent and returned. This is
+// required for correct cast insertion.
 std::set<ConstraintVariable *> ConstraintResolver::getPersistentConstraints(
-    clang::Expr *E,
-    std::set<ConstraintVariable *> &Vars) {
+    clang::Expr *E, std::set<ConstraintVariable *> &Vars) {
   std::set<ConstraintVariable *>
       &Persist = Info.getPersistentConstraintVars(E, Context);
-  if(Persist.empty())
+  if (Persist.empty())
     Persist.insert(Vars.begin(), Vars.end());
   return Persist;
 }

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -788,7 +788,8 @@ public:
     // When an compound literal was visited in constraint generation, a
     // constraint variable for it was stored in program info.  There should be
     // either zero or one of these.
-    std::set<ConstraintVariable *> CVSingleton = Info.getCompoundLiteral(CLE, Context);
+    std::set<ConstraintVariable *>
+        CVSingleton = Info.getPersistentConstraintVars(CLE, Context);
     if (CVSingleton.empty())
       return true;
     ConstraintVariable *CV = getOnly(CVSingleton);

--- a/clang/test/CheckedCRewriter/fptrarrstructboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructboth.c
@@ -156,13 +156,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -187,11 +185,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructbothmulti1.c
@@ -145,13 +145,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -176,11 +174,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallee.c
@@ -156,13 +156,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -186,11 +184,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcalleemulti1.c
@@ -145,13 +145,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -175,11 +173,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcaller.c
@@ -155,13 +155,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -186,11 +184,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructcallermulti1.c
@@ -145,13 +145,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -176,11 +174,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotoboth.c
@@ -143,13 +143,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -174,13 +172,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocallee.c
@@ -143,13 +143,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -173,13 +171,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotocaller.c
@@ -143,13 +143,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: struct fptrarr * foo() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * bar() {
@@ -174,13 +172,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         struct fptrarr *z = sus(x, y);
 //CHECK_ALL: struct fptrarr * bar() {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         struct fptrarr *z = sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructprotosafe.c
@@ -142,13 +142,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> foo(void) {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
 struct fptrarr * bar() {
@@ -172,13 +170,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> bar(void) {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
 struct fptrarr * sus(struct fptrarr *x, struct fptrarr *y) {

--- a/clang/test/CheckedCRewriter/fptrarrstructsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafe.c
@@ -154,13 +154,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> foo(void) {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int));
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
 struct fptrarr * bar() {
@@ -184,11 +182,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> bar(void) {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrstructsafemulti1.c
@@ -144,13 +144,11 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> foo(void) {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 
 struct fptrarr * bar() {
@@ -174,11 +172,9 @@ return z; }
 //CHECK_NOALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_NOALL:         int *yvals = calloc(5, sizeof(int)); 
-//CHECK_NOALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_NOALL:         _Ptr<struct fptrarr> z =  sus(x, y);
 //CHECK_ALL: _Ptr<struct fptrarr> bar(void) {
 //CHECK_ALL:         struct fptrarr * x = malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Ptr<struct fptrarr> y =   malloc(sizeof(struct fptrarr));
 //CHECK_ALL:         _Array_ptr<int> yvals : count(5) =  calloc(5, sizeof(int)); 
-//CHECK_ALL:         strcpy(y->name, ((const char *)"Example")); 
 //CHECK_ALL:         _Ptr<struct fptrarr> z =  sus(x, y);

--- a/clang/test/CheckedCRewriter/no_casts.c
+++ b/clang/test/CheckedCRewriter/no_casts.c
@@ -1,0 +1,18 @@
+// RUN: cconv-standalone %s | count 0
+
+void foo(char *a);
+void bar(int *a);
+void baz(int a[1]);
+
+int *wild();
+
+void test() {
+  foo("test");
+
+  int x;
+  bar(&x);
+
+  baz((int[1]){1});
+
+  bar(wild());
+}


### PR DESCRIPTION
Unneeded casts were being inserted on function calls where the both the parameter and argument were `WILD` (#134). The cause of this was that the cast insertion visitor was not using the solved types for arguments. Since the initial type for all variables is `PTR`, arguments were always treated as checked variables so a cast was inserted. This PR fixes that by storing constraint variables constructed during `getExprConstraintVar` in the `Variables` map in `ProgramInfo`.

In addition to the string literal case demonstrated in the referenced issue, this fix applies to function calls, address-of operations, and compound literals. All of the following used to insert casts, but are now not rewritten.

```c
void foo(char *a);
void bar(int *a);
void baz(int a[1]);

int *wild();

void test() {
  foo("test");

  int x;
  bar(&x);

  baz((int[1]){1});

  bar(wild());
}
```