### PR TITLE
Add support for volatile and restrict qualifiers 

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -172,7 +172,8 @@ class PointerVariableConstraint : public ConstraintVariable {
 public:
   enum Qualification {
       ConstQualification,
-      StaticQualification
+      VolatileQualification,
+      RestrictQualification
   };
 
   static PointerVariableConstraint *getWildPVConstraint(Constraints &CS);
@@ -184,7 +185,7 @@ private:
   std::string BaseType;
   CAtoms vars;
   FunctionVariableConstraint *FV;
-  std::map<uint32_t, Qualification> QualMap;
+  std::map<uint32_t, std::set<Qualification>> QualMap;
   enum OriginalArrType {
       O_Pointer,
       O_SizedArray,
@@ -205,6 +206,7 @@ private:
   // Get the qualifier string (e.g., const, etc) for the provided
   // pointer type into the provided string stream (ss).
   void getQualString(uint32_t TypeIdx, std::ostringstream &Ss);
+  void insertQualType(uint32_t TypeIdx, QualType &QTy);
   // This function tries to emit an array size for the variable.
   // and returns true if the variable is an array and a size is emitted.
   bool emitArraySize(std::ostringstream &Pss, uint32_t TypeIdx, bool &EmitName,

--- a/clang/test/CheckedCRewriter/qualifiers.c
+++ b/clang/test/CheckedCRewriter/qualifiers.c
@@ -1,0 +1,54 @@
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checkedALL %s %S/qualifiers.c
+// RUN: cconv-standalone -base-dir=%S -output-postfix=checkedNOALL %s %S/qualifiers.c
+// RUN: %clang -c %S/qualifiers.checkedNOALL.c %S/qualifiers.checkedNOALL.c
+// RUN: FileCheck -match-full-lines --input-file %S/qualifiers.checkedNOALL.c %s
+// RUN: FileCheck -match-full-lines --input-file %S/qualifiers.checkedALL.c %s
+// RUN: rm %S/qualifiers.checkedALL.c %S/qualifiers.checkedNOALL.c
+
+void consts() {
+  const int a;
+  const int *b;
+  int * const c;
+  int * const * d;
+  int ** const e ;
+  int * const * const f;
+}
+//CHECK: const int a;
+//CHECK: _Ptr<const int> b = ((void *)0);
+//CHECK: const _Ptr<int> c = ((void *)0);
+//CHECK: _Ptr<const _Ptr<int>> d = ((void *)0);
+//CHECK: const _Ptr<_Ptr<int>> e = ((void *)0) ;
+//CHECK: const _Ptr<const _Ptr<int>> f = ((void *)0);
+
+void volatiles() {
+  volatile int a;
+  volatile int *b;
+  int * volatile c;
+  int * volatile * d;
+  int ** volatile e ;
+  int * volatile * volatile f;
+}
+//CHECK: volatile int a;
+//CHECK: _Ptr<volatile int> b = ((void *)0);
+//CHECK: volatile _Ptr<int> c = ((void *)0);
+//CHECK: _Ptr<volatile _Ptr<int>> d = ((void *)0);
+//CHECK: volatile _Ptr<_Ptr<int>> e = ((void *)0) ;
+//CHECK: volatile _Ptr<volatile _Ptr<int>> f = ((void *)0);
+
+void restricts() {
+  int * restrict c;
+  int * restrict * d;
+  int ** restrict e ;
+  int * restrict * restrict f;
+}
+//CHECK: restrict _Ptr<int> c = ((void *)0);
+//CHECK: _Ptr<restrict _Ptr<int>> d = ((void *)0);
+//CHECK: restrict _Ptr<_Ptr<int>> e = ((void *)0) ;
+//CHECK: restrict _Ptr<restrict _Ptr<int>> f = ((void *)0);
+
+void mixed() {
+  int * const volatile restrict  a;
+  const volatile int * const * volatile const * restrict b;
+}
+//CHECK: const volatile restrict _Ptr<int> a = ((void *)0);
+//CHECK: restrict _Ptr<const volatile _Ptr<const _Ptr<const volatile int>>> b = ((void *)0);


### PR DESCRIPTION
Fix for #162 by preserving these qualifiers in the same way that `const` is preserved. 