### PR TITLE
Check arguments to generic functions

### DIFF
--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -361,11 +361,14 @@ private:
   // type variable is used.
   const TypeVariableType *getTypeVariableType(ParmVarDecl *ParmDecl){
     // This makes a lot of assumptions about how the AST will look.
-    if(InteropTypeExpr *PTy = ParmDecl->getInteropTypeExpr())
-      if (const clang::Type *T = PTy->getType().getTypePtr())
-        if (const auto *PtrTy =
-            dyn_cast_or_null<TypedefType>(T->getPointeeType().getTypePtr()))
-          return dyn_cast<TypeVariableType>(PtrTy->desugar());
+    if (auto *ITy = ParmDecl->getInteropTypeExpr()){
+      const auto *Ty = ITy->getType().getTypePtr();
+      if (Ty && Ty->isPointerType()) {
+        auto *PtrTy = Ty->getPointeeType().getTypePtr();
+        if (auto *TypdefTy = dyn_cast_or_null<TypedefType>(PtrTy))
+          return dyn_cast<TypeVariableType>(TypdefTy->desugar());
+      }
+    }
     return nullptr;
   }
 

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -175,7 +175,7 @@ public:
         // and for each arg to the function ...
         if (FVConstraint *TargetFV = dyn_cast<FVConstraint>(TmpC)) {
           std::set<const TypeVariableType *> InstantiableTypes;
-          if(TFD != nullptr)
+          if (TFD != nullptr)
             getInstantiableTypeParams(E, TFD, InstantiableTypes);
 
           unsigned i = 0;
@@ -187,9 +187,9 @@ public:
                 ArgumentConstraints = CB.getExprConstraintVars(ignoreCast(A));
               else
                 ArgumentConstraints = CB.getExprConstraintVars(A);
-            } else {
+            } else
               ArgumentConstraints = CB.getExprConstraintVars(A);
-            }
+
             // constrain the arg CV to the param CV
             if (i < TargetFV->numParams()) {
               std::set<ConstraintVariable *> ParameterDC =
@@ -390,7 +390,7 @@ private:
     unsigned int I = 0;
     for (auto *const A : CE->arguments()) {
       // This can happen with varargs
-      if(I >= FD->getNumParams())
+      if (I >= FD->getNumParams())
         break;
       if (const auto *Ty = getTypeVariableType(FD->getParamDecl(I)))
         TypeVarClasses[Ty].insert(ignoreCast(A)->getType().getTypePtr());
@@ -418,7 +418,7 @@ private:
   }
 
   Expr *ignoreCast(Expr *E){
-    if(auto *ImpCast = dyn_cast<ImplicitCastExpr>(E))
+    if (auto *ImpCast = dyn_cast<ImplicitCastExpr>(E))
       return ImpCast->getSubExpr();
     return E;
   }

--- a/clang/test/CheckedCRewriter/type_params.c
+++ b/clang/test/CheckedCRewriter/type_params.c
@@ -1,0 +1,71 @@
+// RUN: cconv-standalone -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -addcr -output-postfix=checkedNOALL %s
+// RUN: %clang -c %S/type_params.checkedNOALL.c
+// RUN: rm %S/type_params.checkedNOALL.c
+
+// General demonstration
+_Itype_for_any(T) void *test_single(void *a : itype(_Ptr<T>), void *b : itype(_Ptr<T>)) : itype(_Ptr<T>);
+
+void t0(int *a, int *b){
+//CHECK: void t0(_Ptr<int> a, _Ptr<int> b){
+  test_single(a, b);
+}
+
+void t1(int *a, int *b){
+//CHECK: void t1(int *a, _Ptr<int> b){
+  float c;
+  test_single(a, &c);
+}
+
+_Itype_for_any(T,U) void *test_double(void *a : itype(_Ptr<T>), void *b : itype(_Ptr<T>), void *c : itype(_Ptr<U>), void *d : itype(_Ptr<U>)) : itype(_Ptr<T>);
+
+void t2(int *a, int *b, float *c, float *d) {
+//CHECK: void t2(_Ptr<int> a, _Ptr<int> b, _Ptr<float> c, _Ptr<float> d) {
+  test_double(a, b, c, d);
+}
+
+void t3(int *a, int *b, float *c, float *d) {
+//CHECK: void t3(int *a, int *b, float *c, float *d) {
+  test_double(a, c, b, d);
+}
+
+void t4(int *a, int *b, float *c, float *d) {
+//CHECK: void t4(int *a, _Ptr<int> b, _Ptr<float> c, _Ptr<float> d) {
+  float e;
+  test_double(a, &e, c, d);
+}
+
+void t5(int *a, int *b, float *c, float *d) {
+//CHECK: void t5(_Ptr<int> a, _Ptr<int> b, float *c, _Ptr<float> d) {
+  int e;
+  test_double(a, b, c, &e);
+}
+
+_Itype_for_any(T) void *test_many(void *a : itype(_Ptr<T>), void *b : itype(_Ptr<T>), void *c : itype(_Ptr<T>), void *d : itype(_Ptr<T>), void *e : itype(_Ptr<T>)) : itype(_Ptr<T>);
+
+void t6(int *a, int *b, int *c, int *d, int *e) {
+//CHECK: void t6(_Ptr<int> a, _Ptr<int> b, _Ptr<int> c, _Ptr<int> d, _Ptr<int> e) {
+  test_many(a, b, c, d, e);
+}
+
+void t7(int *a, int *b, int *c, int *d, int *e) {
+// void t7(int *a, int *b, _Ptr<int> c, int *d, int *e) {
+  float f;
+  test_many(a, b, &f, d, e);
+}
+
+// Example issue 153
+
+typedef unsigned long size_t;
+_Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+_Itype_for_any(T) void *memcpy(void * restrict dest : itype(restrict _Array_ptr<T>) byte_count(n),
+             const void * restrict src : itype(restrict _Array_ptr<const T>) byte_count(n),
+             size_t n) : itype(_Array_ptr<T>) byte_count(n);
+
+void foo() {
+    int *p = malloc(2*sizeof(int));
+    //CHECK_ALL: _Array_ptr<int> p =  malloc<int>(2*sizeof(int));
+    int p2;
+    memcpy(p, &p2, sizeof(int));
+}

--- a/clang/test/CheckedCRewriter/type_params.c
+++ b/clang/test/CheckedCRewriter/type_params.c
@@ -50,7 +50,7 @@ void t6(int *a, int *b, int *c, int *d, int *e) {
 }
 
 void t7(int *a, int *b, int *c, int *d, int *e) {
-// void t7(int *a, int *b, _Ptr<int> c, int *d, int *e) {
+//CHECK: void t7(int *a, int *b, _Ptr<int> c, int *d, int *e) {
   float f;
   test_many(a, b, &f, d, e);
 }


### PR DESCRIPTION
This pull requests adds code support having checked pointers in the arguments for generic functions fixing issue #153.

 When generating constraints for function call expression, this checks if the function being called has a generic interface. If it does, a map is created taking each type parameter to the set of types that are used to instantiate that parameter. The set of types for each parameter is examined, and it if all elements of the set are compatible, then the type parameter can be instantiated. This mean that we can remove the cast to `void *` around the arguments, allowing `getExprConstraintVars` to find non-wild constraint variables.

The current implementation requires that all types used in a single type parameter are equal. This is probably too restrictive. Let me know if you have ideas about how we can determine if a set of types can be used in a single type parameter.

This pull request does not insert type arguments on the function calls. I'm working a separate (large) PR for this, but I think the changes in this one are self contained enough to be reviewed and merged independently. 