### PR TITLE
Fix for issue 182/183 - The Sequel

### DIFF
--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -675,7 +675,9 @@ bool TypeRewritingVisitor::VisitFunctionDecl(FunctionDecl *FD) {
     s = s + ")";
   } else {
     s = s + "void)";
-    if (!FD->getType()->isFunctionProtoType())
+    QualType ReturnTy = FD->getReturnType();
+    QualType Ty = FD->getType();
+    if (!Ty->isFunctionProtoType() && ReturnTy->isPointerType())
       DidAny = true;
   }
 

--- a/clang/test/CheckedCRewriter/basic_inter_field.c
+++ b/clang/test/CheckedCRewriter/basic_inter_field.c
@@ -36,7 +36,7 @@ int main() {
   return 0;
 }
 
-//CHECK: int main(void) {
+//CHECK: int main() {
 //CHECK-NEXT: int a;
 //CHECK-NEXT: _Ptr<int> b =  0;
 

--- a/clang/test/CheckedCRewriter/basic_inter_field_arr.c
+++ b/clang/test/CheckedCRewriter/basic_inter_field_arr.c
@@ -34,7 +34,7 @@ int main() {
   b = func(&a, wil);
   return 0;
 }
-//CHECK: int main(void) {
+//CHECK: int main() {
 //CHECK-NEXT: int a;
 //CHECK-NEXT: _Ptr<int> b =  0;
 //CHECK-NEXT: char *wil = 0;

--- a/clang/test/CheckedCRewriter/basic_inter_field_ntarr.c
+++ b/clang/test/CheckedCRewriter/basic_inter_field_ntarr.c
@@ -36,7 +36,7 @@ int main() {
   b = func(&a, wil);
   return 0;
 }
-//CHECK: int main(void) {
+//CHECK: int main() {
 //CHECK-NEXT: int a;
 //CHECK-NEXT: _Ptr<int> b =  0;
 //CHECK-NEXT: _Nt_array_ptr<char> wil =  0;

--- a/clang/test/CheckedCRewriter/basic_inter_ntarr.c
+++ b/clang/test/CheckedCRewriter/basic_inter_ntarr.c
@@ -64,7 +64,7 @@ int main() {
   funcdecl(ap1, bp1, cp1);
   return 0;
 }
-//CHECK: int main(void) {
+//CHECK: int main() {
 //CHECK-NEXT: int a, b, c;
 //CHECK-NEXT: int *ap =  0;
 //CHECK-NEXT: int *bp = 0;

--- a/clang/test/CheckedCRewriter/basic_local_ntarr.c
+++ b/clang/test/CheckedCRewriter/basic_local_ntarr.c
@@ -25,7 +25,7 @@ int main() {
   return 0;
 }
 
-//CHECK: int main(void) {
+//CHECK: int main() {
 //CHECK-NEXT: _Nt_array_ptr<char> a =  0;
 //CHECK-NEXT: _Ptr<char> c =  0;
 //CHECK-NEXT: int *d = 0;

--- a/clang/test/CheckedCRewriter/basic_return_itype.c
+++ b/clang/test/CheckedCRewriter/basic_return_itype.c
@@ -55,7 +55,7 @@ int main() {
   bp1 = funcdecl(ap1, bp1, cp1);
   return 0;
 }
-//CHECK: int main(void) {
+//CHECK: int main() {
 //CHECK-NEXT: int a, b, c;
 //CHECK-NEXT: _Ptr<int> ap =  0;
 //CHECK-NEXT: int *bp = 0;

--- a/clang/test/CheckedCRewriter/no_casts.c
+++ b/clang/test/CheckedCRewriter/no_casts.c
@@ -1,4 +1,4 @@
-// RUN: cconv-standalone %s | FileCheck -match-full-lines %s
+// RUN: cconv-standalone %s | count 0
 
 void foo(char *a);
 void bar(int *a);
@@ -16,4 +16,3 @@ void test() {
 
   bar(wild());
 }
-//CHECK: void test(void) {


### PR DESCRIPTION
Changed rewriting so that we only insert `void` for nullary functions when their return types are pointer types. 
Closes #182 
Closes #183 