### PR TITLE
Fix for issue 190

### DIFF
--- a/clang/include/clang/CConv/TypeVariableAnalysis.h
+++ b/clang/include/clang/CConv/TypeVariableAnalysis.h
@@ -20,8 +20,9 @@ class TypeVariableEntry {
 public:
   // Note: does not initialize TyVarType!
   TypeVariableEntry() :
-      IsConsistent(false) {}
-  TypeVariableEntry(QualType Ty, std::set<ConstraintVariable *> &CVs) {
+      IsConsistent(false), TypeParamConsVar(nullptr) {}
+  TypeVariableEntry(QualType Ty, std::set<ConstraintVariable *> &CVs) :
+      TypeParamConsVar(nullptr) {
     // We'll need a name to provide the type arguments during rewriting, so no
     // anonymous types are allowed.
     if (isTypeAnonymous(Ty->getPointeeType())) {

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -552,7 +552,6 @@ CVarSet
         // retrieve the last "thing" returned by the block
         Stmt *Res = SE->getSubStmt()->getStmtExprResult();
         if(Expr *ESE = dyn_cast<Expr>(Res)) {
-          ESE = ESE->IgnoreParens();
           return getExprConstraintVars(ESE);
         }
       } else {

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -547,6 +547,14 @@ CVarSet
         T = {P};
 
         Ret = T;
+      } else if (StmtExpr *SE = dyn_cast<StmtExpr>(E)) {
+        CVarSet T;
+        // retrieve the last "thing" returned by the block
+        Stmt *Res = SE->getSubStmt()->getStmtExprResult();
+        if(Expr *ESE = dyn_cast<Expr>(Res)) {
+          ESE = ESE->IgnoreParens();
+          return getExprConstraintVars(ESE);
+        }
       } else {
         if (Verbose) {
           llvm::errs() << "WARNING! Initialization expression ignored: ";

--- a/clang/test/CheckedCRewriter/stmtExpr.c
+++ b/clang/test/CheckedCRewriter/stmtExpr.c
@@ -1,0 +1,23 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null - 
+
+typedef unsigned long size_t;
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+void foo2(int *x) { 
+    int *p;
+    //CHECK_ALL: _Array_ptr<int> p : count(3) = ((void *)0);
+    //CHECK_NOALL: int *p;
+    p = ({int *q = malloc(3*sizeof(int)); q[2] = 1; q;});
+    //CHECK_ALL: p = ({_Array_ptr<int> q : count(3) =  malloc<int>(3*sizeof(int)); q[2] = 1; q;});
+    //CHECK_NOALL: p = ({int *q = malloc<int>(3*sizeof(int)); q[2] = 1; q;});
+    p[1] = 3;
+} 
+
+/*ideally, q would also be marked as checked, but when the decl and init are on the same, the rewriter fails*/
+void foo() {
+  int *p = ({int *q = malloc(3*sizeof(int)); q[2] = 1; q;});
+  //CHECK_ALL: _Array_ptr<int> p : count(3) =  ({int *q = malloc<int>(3*sizeof(int)); q[2] = 1; q;});
+  p[1] = 3;
+}

--- a/clang/test/CheckedCRewriter/stmtExprA.c
+++ b/clang/test/CheckedCRewriter/stmtExprA.c
@@ -14,10 +14,3 @@ void foo2(int *x) {
     //CHECK_NOALL: p = ({int *q = malloc<int>(3*sizeof(int)); q[2] = 1; q;});
     p[1] = 3;
 } 
-
-/*ideally, q would also be marked as checked, but when the decl and init are on the same, the rewriter fails*/
-void foo() {
-  int *p = ({int *q = malloc(3*sizeof(int)); q[2] = 1; q;});
-  //CHECK_ALL: _Array_ptr<int> p : count(3) =  ({int *q = malloc<int>(3*sizeof(int)); q[2] = 1; q;});
-  p[1] = 3;
-}

--- a/clang/test/CheckedCRewriter/stmtExprBUG.c
+++ b/clang/test/CheckedCRewriter/stmtExprBUG.c
@@ -1,0 +1,21 @@
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null - 
+
+typedef unsigned long size_t;
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+/*right now, even though our solving correctly identifies q ought to be checked 
+  the rewriter fails to rewrite q to be checked so it appears WILD*/
+void foo() {
+  int *p = ({int *q = malloc(3*sizeof(int)); q[2] = 1; q;});
+  //CHECK_ALL: _Array_ptr<int> p : count(3) =  ({_Array_ptr<int> q : count(3) = malloc<int>(3*sizeof(int)); q[2] = 1; q;});
+  //CHECK_NOALL: int *p = ({int *q = malloc(3*sizeof(int)); q[2] = 1; q;});
+  p[1] = 3;
+} 
+
+void bar() { 
+  int *p = ({int *q = malloc(sizeof(int)); *q = 7; q;});
+  //CHECK: _Ptr<int> p =  ({_Ptr<int> q = malloc(sizeof(int)); *q = 7; q;});
+  *p = 4;
+}


### PR DESCRIPTION
Closes #190 
This provides a fix for the inference of statement expressions and consistently creates a flow between the outer variable and variables declared within the statement expression.  
Was on branch iss190, but solved merge conflicts with unnecessary visitors. 
Includes support for fixing an initialization issue that caused undefined behavior, courtesy of @jackastner 
Also added one passing test. 