### PR TITLE
199 Calloc Fix

### DIFF
--- a/clang/test/CheckedCRewriter/arrofstructboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructboth.c
@@ -27,7 +27,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -95,13 +96,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 
@@ -112,14 +116,17 @@ z += 2;
 return z; }
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -127,18 +134,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -146,6 +157,7 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
@@ -33,7 +33,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -101,17 +102,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *, struct general *);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -119,18 +124,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -138,6 +147,7 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -33,7 +33,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -101,13 +102,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/arrofstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallee.c
@@ -27,7 +27,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -95,13 +96,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 
@@ -112,14 +116,17 @@ z += 2;
 return z; }
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -127,18 +134,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -146,5 +157,6 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
@@ -33,7 +33,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -101,17 +102,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *, struct general *);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -119,18 +124,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -138,5 +147,6 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -33,7 +33,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -101,13 +102,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/arrofstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructcaller.c
@@ -27,7 +27,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -95,13 +96,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 
@@ -111,14 +115,17 @@ x = (struct general *) 5;
 return z; }
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -126,18 +133,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -145,6 +156,7 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
@@ -33,7 +33,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -101,17 +102,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *, struct general *);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -119,18 +124,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -138,6 +147,7 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -33,7 +33,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -101,13 +102,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/arrofstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotoboth.c
@@ -30,7 +30,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -98,17 +99,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -116,18 +121,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -135,18 +144,22 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/arrofstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocallee.c
@@ -30,7 +30,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -98,17 +99,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -116,18 +121,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -135,17 +144,21 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/arrofstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocaller.c
@@ -30,7 +30,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -98,17 +99,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -116,18 +121,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -135,18 +144,22 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/arrofstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotosafe.c
@@ -29,7 +29,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -97,17 +98,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -115,18 +120,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -134,17 +143,21 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/arrofstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafe.c
@@ -26,7 +26,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -94,13 +95,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 
@@ -110,14 +114,17 @@ x = (struct general *) 5;
 return z; }
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -125,18 +132,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -144,5 +155,6 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
@@ -32,7 +32,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -100,17 +101,21 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK: struct general ** sus(struct general *, struct general *);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
-	//CHECK: struct general ** foo(void) {
+	//CHECK_NOALL: struct general ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -118,18 +123,22 @@ struct general ** foo() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
-	//CHECK: struct general ** bar(void) {
+	//CHECK_NOALL: struct general ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
-	//CHECK: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_NOALL: struct general * y = malloc<struct general>(sizeof(struct general));
+	//CHECK_ALL: _Ptr<struct general> y =  malloc<struct general>(sizeof(struct general));
         
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 1; i < 5; i++, curr = curr->next) { 
             curr->data = i;
@@ -137,5 +146,6 @@ struct general ** bar() {
             curr->next->data = i+1;
         }
         struct general ** z = sus(x, y);
-	//CHECK: struct general ** z = sus(x, y);
+	//CHECK_NOALL: struct general ** z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -32,7 +32,8 @@ extern _Unchecked char *strcpy(char * restrict dest, const char * restrict src :
 struct general { 
     int data; 
     struct general *next;
-	//CHECK: struct general *next;
+	//CHECK_NOALL: struct general *next;
+	//CHECK_ALL: _Ptr<struct general> next;
 };
 
 struct warr { 
@@ -100,13 +101,16 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
-	//CHECK: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
+	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
-	//CHECK: struct general *curr = y;
+	//CHECK_NOALL: struct general *curr = y;
+	//CHECK_ALL: _Ptr<struct general> curr =  y;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = curr; 

--- a/clang/test/CheckedCRewriter/calloc.c
+++ b/clang/test/CheckedCRewriter/calloc.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 
-#define size_t int
+typedef unsigned long size_t;
 extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
 
 void func(int *x : itype(_Nt_array_ptr<int>));

--- a/clang/test/CheckedCRewriter/fptrarrboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrboth.c
@@ -89,20 +89,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);
@@ -112,34 +116,40 @@ z += 2;
 return z; }
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
@@ -95,43 +95,51 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *, int *);
+	//CHECK_NOALL: int ** sus(int *, int *);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -95,20 +95,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/fptrarrcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallee.c
@@ -89,20 +89,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);
@@ -112,33 +116,39 @@ z += 2;
 return z; }
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
@@ -95,42 +95,50 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *, int *);
+	//CHECK_NOALL: int ** sus(int *, int *);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -95,20 +95,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/fptrarrcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrcaller.c
@@ -89,20 +89,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);
@@ -111,34 +115,40 @@ int ** sus(int *x, int *y) {
 return z; }
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
@@ -95,43 +95,51 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *, int *);
+	//CHECK_NOALL: int ** sus(int *, int *);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -95,20 +95,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/fptrarrprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotoboth.c
@@ -92,56 +92,67 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/fptrarrprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocallee.c
@@ -92,55 +92,66 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/fptrarrprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocaller.c
@@ -92,56 +92,67 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/fptrarrprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotosafe.c
@@ -91,55 +91,66 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/fptrarrsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafe.c
@@ -88,20 +88,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);
@@ -110,33 +114,39 @@ int ** sus(int *x, int *y) {
 return z; }
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
@@ -94,42 +94,50 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK: int ** sus(int *, int *);
+	//CHECK_NOALL: int ** sus(int *, int *);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y);
 
 int ** foo() {
-	//CHECK: int ** foo(void) {
+	//CHECK_NOALL: int ** foo(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
-	//CHECK: int ** bar(void) {
+	//CHECK_NOALL: int ** bar(void) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
         int *y = calloc(5, sizeof(int)); 
-	//CHECK: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_NOALL: int *y = calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> y : count(5) =  calloc<int>(5, sizeof(int)); 
         int i;
         for(i = 0; i < 5; i++) { 
             y[i] = i+1;
         } 
         int **z = sus(x, y);
-	//CHECK: int **z = sus(x, y);
+	//CHECK_NOALL: int **z = sus(x, y);
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -94,20 +94,24 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK: int * mul2(int *x) { 
+	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *x, int *y) {
-	//CHECK: int ** sus(int *x, int *y) {
+	//CHECK_NOALL: int ** sus(int *x, int *y) {
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
-	//CHECK: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
+	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
-	//CHECK: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = mul2ptr(&y[i]);

--- a/clang/test/CheckedCRewriter/realloc.c
+++ b/clang/test/CheckedCRewriter/realloc.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 
-#define size_t int
+typedef unsigned long size_t;
 extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
 

--- a/clang/test/CheckedCRewriter/realloc_complex.c
+++ b/clang/test/CheckedCRewriter/realloc_complex.c
@@ -7,7 +7,7 @@
 /* multiple complex realloc calls                         */
 /**********************************************************/
 
-#define size_t int
+typedef unsigned long size_t;
 extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 extern _Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
 

--- a/clang/test/CheckedCRewriter/return_not_least.c
+++ b/clang/test/CheckedCRewriter/return_not_least.c
@@ -36,7 +36,7 @@ int *foo(void) {
   return q;
 }
 
-#define size_t int
+typedef unsigned long size_t;
 extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
 
 int *bar() {

--- a/clang/test/CheckedCRewriter/single_ptr_calloc.c
+++ b/clang/test/CheckedCRewriter/single_ptr_calloc.c
@@ -3,7 +3,7 @@
 // RUN: cconv-standalone %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 
-#define size_t int
+typedef unsigned long size_t;
 extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
 
 void foo(int *w) { 


### PR DESCRIPTION
The fix to this specific issue was just looking at the correct argument index when searching for a `sizeof` expression in calls to `calloc`.  

I would have liked to remove this check for `sizeof`, as it should not be required with the recent type argument insertion code. It looks like a different bug exists in the type argument code that makes this change substantially more complicated so, this is a quicker fix for the problem with `calloc`.

Some of the generated tests are still failing even after they have been regenerated with the script. 
The tests `fptrarrbothmulti2.c`, `fptrarrcalleemulti2.c`, `fptrarrcallermulti2.c`, and  `fptrarrsafemulti2` all insert a `count(5)` bound of the `sus` function that isn't in the expected output. This bound seems legit to me, so maybe it's a bug in the test generation script (@sroy4899) ?

