### PR TITLE
Fix free

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -242,6 +242,12 @@ private:
   // to be wild.
   bool IsGeneric;
 
+  // Empty array pointers are represented the same as standard pointers. This
+  // lets pointers be passed to functions expecting a zero width array. This
+  // flag is used to discriminate between standard pointer and zero width array
+  // pointers.
+  bool IsZeroWidthArray;
+
 public:
   // Constructor for when we know a CVars and a type string.
   PointerVariableConstraint(CAtoms V, std::string T, std::string Name,

--- a/clang/include/clang/CConv/Utils.h
+++ b/clang/include/clang/CConv/Utils.h
@@ -134,7 +134,7 @@ unsigned int getParameterIndex(clang::ParmVarDecl *PV, clang::FunctionDecl *FD);
 // returned.
 bool evaluateToInt(clang::Expr *E, const clang::ASTContext &C, int &Result);
 
-// Check if the bounds expression BE is zero width. Array with zero width bounds
+// Check if the bounds expression BE is zero width. Arrays with zero width bounds
 // can be treated as pointers.
 bool isZeroBoundsExpr(clang::BoundsExpr *BE, const clang::ASTContext &C);
 #endif

--- a/clang/include/clang/CConv/Utils.h
+++ b/clang/include/clang/CConv/Utils.h
@@ -128,4 +128,13 @@ bool isTypeAnonymous(const clang::Type *T);
 
 // Find the index of parameter PV in the parameter list of function FD.
 unsigned int getParameterIndex(clang::ParmVarDecl *PV, clang::FunctionDecl *FD);
+
+// If E can be evaluated to a constant integer, the result is stored in Result,
+// and true is returned. Otherwise, Result is not modified and, false is
+// returned.
+bool evaluateToInt(clang::Expr *E, const clang::ASTContext &C, int &Result);
+
+// Check if the bounds expression BE is zero width. Array with zero width bounds
+// can be treated as pointers.
+bool isZeroBoundsExpr(clang::BoundsExpr *BE, const clang::ASTContext &C);
 #endif

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -129,11 +129,8 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
     if (!getSizeOfArg(CE->getArg(1), ArgTy))
       return nullptr;
     // Check if first argument to calloc is 1
-    Expr *E = CE->getArg(0);
-    Expr::EvalResult ER;
-    E->EvaluateAsInt(ER, *Context,
-                     clang::Expr::SE_NoSideEffects, false);
-    if (ER.Val.isInt() && ER.Val.getInt().getExtValue() == 1)
+    int Result;
+    if (evaluateToInt(CE->getArg(0), *Context, Result) && Result == 1)
       return CS.getPtr();
     else
       return CS.getNTArr();

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -304,7 +304,7 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT,
 
   // In CheckedC, a pointer can be freely converted to a size 0 array pointer,
   // but our constraint system does not allow this. To enable converting calls
-  // functions with similar to free, size zero array pointers are made PTR
+  // to functions with types similar to free, size 0 array pointers are made PTR
   // instead of ARR.
   if (D && D->hasBoundsExpr() && !vars.empty() && vars[0] == CS.getArr())
     if (BoundsExpr *BE = D->getBoundsExpr())

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -104,6 +104,7 @@ PointerVariableConstraint::
   }
   this->Parent = Ot;
   this->IsGeneric = Ot->IsGeneric;
+  this->IsZeroWidthArray = Ot->IsZeroWidthArray;
   // We need not initialize other members.
 }
 
@@ -308,8 +309,11 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT,
   // instead of ARR.
   if (D && D->hasBoundsExpr() && !vars.empty() && vars[0] == CS.getArr())
     if (BoundsExpr *BE = D->getBoundsExpr())
-      if (isZeroBoundsExpr(BE, C))
+      if (isZeroBoundsExpr(BE, C)) {
+        IsZeroWidthArray = true;
         vars[0] = CS.getPtr();
+      } else
+        IsZeroWidthArray = false;
 
   // If, after boiling off the pointer-ness from this type, we hit a
   // function, then create a base-level FVConstraint that we carry
@@ -1080,13 +1084,24 @@ bool PointerVariableConstraint::
       if (IsGeneric || PV->IsGeneric || vars.size() == OthCVars.size()) {
         Ret = true;
 
-        // First compare Vars to see if they are same.
         CAtoms::iterator I = vars.begin();
         CAtoms::iterator J = OthCVars.begin();
-        while (I != vars.end() && J != OthCVars.end()) {
-          ConstAtom *IA = CS.getAssignment(*I);
-          ConstAtom *JA = CS.getAssignment(*J);
-          if (!(IA == CS.getPtr() && JA != CS.getWild()) && IA != JA) {
+        // Special handling for zero width arrays so they can compare equal to
+        // ARR or PTR.
+        if (IsZeroWidthArray) {
+          assert(I != vars.end() && "Zero width array cannot be base type.");
+          assert("Zero width arrays should be encoded as PTR."
+                     && CS.getAssignment(*I) == CS.getPtr());
+          ConstAtom *JAtom = CS.getAssignment(*J);
+          // Zero width array can compare as either ARR or PTR
+          if (JAtom != CS.getArr() && JAtom != CS.getPtr())
+            Ret = false;
+          ++I;
+          ++J;
+        }
+        // Compare Vars to see if they are same.
+        while (Ret && I != vars.end() && J != OthCVars.end()) {
+          if (CS.getAssignment(*I) != CS.getAssignment(*J)) {
             Ret = false;
             break;
           }

--- a/clang/test/CheckedCRewriter/allocator.c
+++ b/clang/test/CheckedCRewriter/allocator.c
@@ -25,7 +25,7 @@ void foo(void) {
   return;
 }
 //CHECK: void foo(void) {
-//CHECK-NEXT: int *a = (int *) malloc<int>(sizeof(int));
+//CHECK-NEXT: _Ptr<int> a = (_Ptr<int> ) malloc<int>(sizeof(int));
 
 typedef struct _listelt {
   struct _listelt *next;

--- a/clang/test/CheckedCRewriter/free.c
+++ b/clang/test/CheckedCRewriter/free.c
@@ -1,0 +1,43 @@
+// RUN: cconv-standalone -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+
+typedef unsigned long size_t;
+_Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+_Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+
+int *test() {
+// CHECK_NOALL: int * test(void) {
+// CHECK_ALL: _Array_ptr<int> test(void) {
+  int *a = malloc(sizeof(int));
+  // CHECK: _Ptr<int> a = malloc<int>(sizeof(int));
+  free(a);
+  // CHECK: free<int>(a);
+
+  int *b = malloc(5*sizeof(int));
+  // CHECK_NOALL: int *b = malloc<int>(5*sizeof(int));
+  // CHECK_ALL: _Array_ptr<int> b : count(5) =  malloc<int>(5*sizeof(int));
+  free(b);
+  // CHECK: free<int>(b);
+  return b;
+}
+
+_Itype_for_any(T) void my_free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
+
+int *test2() {
+// CHECK_NOALL: int * test2(void) {
+// CHECK_ALL:_Array_ptr<int> test2(void) {
+  int *a = malloc(sizeof(int));
+  // CHECK: _Ptr<int> a = malloc<int>(sizeof(int));
+  my_free(a);
+  // CHECK: my_free<int>(a);
+
+  int *b = malloc(5*sizeof(int));
+  // CHECK_NOALL: int *b = malloc<int>(5*sizeof(int));
+  // CHECK_ALL: _Array_ptr<int> b : count(5) =  malloc<int>(5*sizeof(int));
+  my_free(b);
+  // CHECK: my_free<int>(b);
+
+  return b;
+}

--- a/clang/test/CheckedCRewriter/hash.c
+++ b/clang/test/CheckedCRewriter/hash.c
@@ -168,8 +168,7 @@ hash_free_entry(struct hash* p_hash, void* p_key)
   {
     p_node->p_next->p_prev = p_node->p_prev;
   }
-  //FIX soon:
-  //  free(p_node);
+  free(p_node);
 }
 
 struct hash_node**


### PR DESCRIPTION
Checked function expecting zero length array bounds are now  treated the same as functions expecting pointers. This lets functions with signatures like `free` be used on checked pointers without forcing the pointer to either be `WILD` or `ARR`. 