### PR TITLE
Constrain calloc to ARR instead of NT_ARR

### DIFF
--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -135,8 +135,12 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
                      clang::Expr::SE_NoSideEffects, false);
     if (ER.Val.isInt() && ER.Val.getInt().getExtValue() == 1)
       return CS.getPtr();
-    else
-      return CS.getNTArr();
+    else {
+      // While calloc can be thought of as returning NT_ARR because it
+      // initializes the allocated memory to zero, its type in the checked
+      // header file is ARR so, we cannot safely return NT_ARR here.
+      return CS.getArr();
+    }
   }
 
   ConstAtom *Ret = CS.getPtr();

--- a/clang/test/CheckedCRewriter/arrboth.c
+++ b/clang/test/CheckedCRewriter/arrboth.c
@@ -96,12 +96,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;
@@ -113,25 +113,25 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti1.c
@@ -102,29 +102,29 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrbothmulti2.c
@@ -102,12 +102,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrcallee.c
+++ b/clang/test/CheckedCRewriter/arrcallee.c
@@ -96,12 +96,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;
@@ -113,24 +113,24 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti1.c
@@ -102,28 +102,28 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrcalleemulti2.c
@@ -102,12 +102,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrcaller.c
+++ b/clang/test/CheckedCRewriter/arrcaller.c
@@ -96,12 +96,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;
@@ -112,25 +112,25 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti1.c
@@ -102,29 +102,29 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrcallermulti2.c
@@ -102,12 +102,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrofstructboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructboth.c
@@ -97,12 +97,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;
@@ -117,7 +117,7 @@ return z; }
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -135,12 +135,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -158,6 +158,6 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti1.c
@@ -103,11 +103,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -125,12 +125,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -148,6 +148,6 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -103,12 +103,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrofstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallee.c
@@ -97,12 +97,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;
@@ -117,7 +117,7 @@ return z; }
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -135,12 +135,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -158,5 +158,5 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti1.c
@@ -103,11 +103,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -125,12 +125,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -148,5 +148,5 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -103,12 +103,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrofstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructcaller.c
@@ -97,12 +97,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;
@@ -116,7 +116,7 @@ return z; }
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -134,12 +134,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -157,6 +157,6 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti1.c
@@ -103,11 +103,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -125,12 +125,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -148,6 +148,6 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -103,12 +103,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrofstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotoboth.c
@@ -100,11 +100,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -122,12 +122,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -145,18 +145,18 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocallee.c
@@ -100,11 +100,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -122,12 +122,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -145,17 +145,17 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrofstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocaller.c
@@ -100,11 +100,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -122,12 +122,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -145,18 +145,18 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 z += 2;
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrofstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotosafe.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -121,12 +121,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -144,17 +144,17 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrofstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafe.c
@@ -96,12 +96,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;
@@ -115,7 +115,7 @@ return z; }
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -133,12 +133,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -156,5 +156,5 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general *, struct general *);
 	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *, _Ptr<struct general> y);
 
 struct general ** foo() {
 	//CHECK_NOALL: struct general ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -124,12 +124,12 @@ struct general ** foo() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }
 
 struct general ** bar() {
 	//CHECK_NOALL: struct general ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -147,5 +147,5 @@ struct general ** bar() {
         }
         struct general ** z = sus(x, y);
 	//CHECK_NOALL: struct general ** z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -102,12 +102,12 @@ int *mul2(int *x) {
 
 struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 
         struct general **z = calloc(5, sizeof(struct general *));
 	//CHECK_NOALL: struct general **z = calloc<struct general *>(5, sizeof(struct general *));
-	//CHECK_ALL: _Nt_array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
+	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> z : count(5) =  calloc<_Ptr<struct general>>(5, sizeof(struct general *));
         struct general *curr = y;
 	//CHECK_NOALL: struct general *curr = y;
 	//CHECK_ALL: _Ptr<struct general> curr =  y;

--- a/clang/test/CheckedCRewriter/arrprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrprotoboth.c
@@ -99,41 +99,41 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrprotocallee.c
@@ -99,40 +99,40 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrprotocaller.c
@@ -99,41 +99,41 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrprotosafe.c
@@ -98,40 +98,40 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrsafe.c
+++ b/clang/test/CheckedCRewriter/arrsafe.c
@@ -95,12 +95,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;
@@ -111,24 +111,24 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti1.c
@@ -101,28 +101,28 @@ int *mul2(int *x) {
 
 int * sus(int *, int *);
 	//CHECK_NOALL: int * sus(int *, _Ptr<int> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *, _Ptr<int> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int *, _Ptr<int> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         int * x = malloc(sizeof(int));
 	//CHECK: int * x = malloc<int>(sizeof(int));
         int * y = malloc(sizeof(int));
 	//CHECK: _Ptr<int> y =  malloc<int>(sizeof(int));
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrsafemulti2.c
@@ -101,12 +101,12 @@ int *mul2(int *x) {
 
 int * sus(int * x, int * y) {
 	//CHECK_NOALL: int * sus(int *x, _Ptr<int> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int *x, _Ptr<int> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int *x, _Ptr<int> y) {
 x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         int i, fac;
         int *p;
 	//CHECK_NOALL: int *p;

--- a/clang/test/CheckedCRewriter/arrstructboth.c
+++ b/clang/test/CheckedCRewriter/arrstructboth.c
@@ -96,12 +96,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -114,7 +114,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -130,12 +130,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -151,6 +151,6 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructbothmulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -122,12 +122,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -143,6 +143,6 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructbothmulti2.c
@@ -102,12 +102,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrstructcallee.c
@@ -96,12 +96,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -114,7 +114,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -130,12 +130,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -151,5 +151,5 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -122,12 +122,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -143,5 +143,5 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcalleemulti2.c
@@ -102,12 +102,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrstructcaller.c
@@ -96,12 +96,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -113,7 +113,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -129,12 +129,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -150,6 +150,6 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructcallermulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -122,12 +122,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -143,6 +143,6 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructcallermulti2.c
@@ -102,12 +102,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrstructprotoboth.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -119,12 +119,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -140,18 +140,18 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocallee.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -119,12 +119,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -140,17 +140,17 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrstructprotocaller.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -119,12 +119,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -140,18 +140,18 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 z += 2;
 return z; }
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrstructprotosafe.c
@@ -98,11 +98,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -118,12 +118,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -139,17 +139,17 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/arrstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrstructsafe.c
@@ -95,12 +95,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -112,7 +112,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -128,12 +128,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -149,5 +149,5 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructsafemulti1.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti1.c
@@ -101,11 +101,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -121,12 +121,12 @@ int * foo() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
         struct general * x = malloc(sizeof(struct general));
 	//CHECK: struct general * x = malloc<struct general>(sizeof(struct general));
         struct general * y = malloc(sizeof(struct general));
@@ -142,5 +142,5 @@ int * bar() {
         }
         int * z = sus(x, y);
 	//CHECK_NOALL: int * z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
 return z; }

--- a/clang/test/CheckedCRewriter/arrstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrstructsafemulti2.c
@@ -101,12 +101,12 @@ int *mul2(int *x) {
 
 int * sus(struct general * x, struct general * y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/calloc.c
+++ b/clang/test/CheckedCRewriter/calloc.c
@@ -6,12 +6,12 @@
 typedef unsigned long size_t;
 extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
 
-void func(int *x : itype(_Nt_array_ptr<int>));
+void func(int *x : itype(_Array_ptr<int>));
 
 void foo(int *w) { 
     int *x = calloc(5, sizeof(int));
     x[2] = 3; 
     func(x);
 }
-//CHECK_ALL: _Nt_array_ptr<int> x : count(5) =  calloc<int>(5, sizeof(int)); 
+//CHECK_ALL: _Array_ptr<int> x : count(5) =  calloc<int>(5, sizeof(int)); 
 //CHECK_NOALL: int *x = calloc<int>(5, sizeof(int));

--- a/clang/test/CheckedCRewriter/fptrarrboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrboth.c
@@ -97,13 +97,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
@@ -117,7 +117,7 @@ return z; }
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -130,13 +130,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -149,7 +149,7 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
@@ -103,11 +103,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *, int *);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -120,13 +120,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -139,7 +139,7 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -103,13 +103,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallee.c
@@ -97,13 +97,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
@@ -117,7 +117,7 @@ return z; }
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -130,13 +130,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -149,6 +149,6 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
@@ -103,11 +103,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *, int *);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -120,13 +120,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -139,6 +139,6 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -103,13 +103,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrcaller.c
@@ -97,13 +97,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
@@ -116,7 +116,7 @@ return z; }
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -129,13 +129,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -148,7 +148,7 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
@@ -103,11 +103,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *, int *);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -120,13 +120,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -139,7 +139,7 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -103,13 +103,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotoboth.c
@@ -100,11 +100,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *x, int *y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -117,13 +117,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -136,20 +136,20 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocallee.c
@@ -100,11 +100,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *x, int *y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -117,13 +117,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -136,19 +136,19 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocaller.c
@@ -100,11 +100,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *x, int *y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -117,13 +117,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -136,20 +136,20 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 z += 2;
 return z; }
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotosafe.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *x, int *y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -116,13 +116,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -135,19 +135,19 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrarrsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafe.c
@@ -96,13 +96,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;
@@ -115,7 +115,7 @@ return z; }
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -128,13 +128,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -147,6 +147,6 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int ** sus(int *, int *);
 	//CHECK_NOALL: int ** sus(int *, int *);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *, _Array_ptr<int> y : count(5));
 
 int ** foo() {
 	//CHECK_NOALL: int ** foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> foo(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> foo(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -119,13 +119,13 @@ int ** foo() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }
 
 int ** bar() {
 	//CHECK_NOALL: int ** bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> bar(void) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> bar(void) {
 
         int *x = malloc(sizeof(int)); 
 	//CHECK: int *x = malloc<int>(sizeof(int)); 
@@ -138,6 +138,6 @@ int ** bar() {
         } 
         int **z = sus(x, y);
 	//CHECK_NOALL: int **z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -102,13 +102,13 @@ int *mul2(int *x) {
 
 int ** sus(int *x, int *y) {
 	//CHECK_NOALL: int ** sus(int *x, int *y) {
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5)) {
 
         x = (int *) 5;
 	//CHECK: x = (int *) 5;
         int **z = calloc(5, sizeof(int *)); 
 	//CHECK_NOALL: int **z = calloc<int *>(5, sizeof(int *)); 
-	//CHECK_ALL: _Nt_array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
+	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> z : count(5) =  calloc<_Array_ptr<int>>(5, sizeof(int *)); 
         int * (*mul2ptr) (int *) = mul2;
 	//CHECK_NOALL: _Ptr<int * (int *)> mul2ptr =  mul2;
 	//CHECK_ALL: _Ptr<_Array_ptr<int> (_Array_ptr<int> )> mul2ptr =  mul2;

--- a/clang/test/CheckedCRewriter/fptrsafeboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeboth.c
@@ -96,13 +96,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -115,7 +115,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -131,16 +131,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -156,10 +156,10 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -122,16 +122,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -147,10 +147,10 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafebothmulti2.c
@@ -102,13 +102,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafecallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallee.c
@@ -96,13 +96,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -115,7 +115,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -131,16 +131,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -156,9 +156,9 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -122,16 +122,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -147,9 +147,9 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecalleemulti2.c
@@ -102,13 +102,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafecaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafecaller.c
@@ -96,13 +96,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -114,7 +114,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -130,16 +130,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -155,10 +155,10 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -122,16 +122,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -147,10 +147,10 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafecallermulti2.c
@@ -102,13 +102,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotoboth.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -119,16 +119,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -144,23 +144,23 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 z += 2;
 return z; }
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocallee.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -119,16 +119,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -144,22 +144,22 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotocaller.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -119,16 +119,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -144,23 +144,23 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 z += 2;
 return z; }
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafeprotosafe.c
@@ -98,11 +98,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -118,16 +118,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -143,22 +143,22 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/fptrsafesafe.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafe.c
@@ -95,13 +95,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;
@@ -113,7 +113,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -129,16 +129,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -154,9 +154,9 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti1.c
@@ -101,11 +101,11 @@ int *mul2(int *x) {
 
 int * sus(struct general *, struct general *);
 	//CHECK_NOALL: int * sus(struct general *, _Ptr<struct general> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *, _Ptr<struct general> y);
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *, _Ptr<struct general> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -121,16 +121,16 @@ int * foo() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
 
         struct general *x = malloc(sizeof(struct general)); 
 	//CHECK: struct general *x = malloc<struct general>(sizeof(struct general)); 
@@ -146,9 +146,9 @@ int * bar() {
         }
         int * (*sus_ptr)(struct general *, struct general *) = sus;   
 	//CHECK_NOALL: _Ptr<int * (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
-	//CHECK_ALL: _Ptr<_Nt_array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
+	//CHECK_ALL: _Ptr<_Array_ptr<int> (struct general *, _Ptr<struct general> )> sus_ptr =  sus;   
         int *z = sus_ptr(x, y);
 	//CHECK_NOALL: int *z = sus_ptr(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus_ptr(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus_ptr(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrsafesafemulti2.c
@@ -101,13 +101,13 @@ int *mul2(int *x) {
 
 int * sus(struct general *x, struct general *y) {
 	//CHECK_NOALL: int * sus(struct general *x, _Ptr<struct general> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(struct general *x, _Ptr<struct general> y) {
 
         x = (struct general *) 5;
 	//CHECK: x = (struct general *) 5;
         int *z = calloc(5, sizeof(int)); 
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int)); 
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int)); 
         struct general *p = y;
 	//CHECK: _Ptr<struct general> p =  y;
         int i;

--- a/clang/test/CheckedCRewriter/return_not_least.c
+++ b/clang/test/CheckedCRewriter/return_not_least.c
@@ -40,10 +40,10 @@ typedef unsigned long size_t;
 extern _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
 
 int *bar() {
-// CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+// CHECK_ALL: _Array_ptr<int> bar(void) {
 // CHECK_NOALL: int * bar(void) {
   int *z = calloc(2, sizeof(int));
-  //CHECK_ALL: _Nt_array_ptr<int> z : count(2) =  calloc<int>(2, sizeof(int));
+  //CHECK_ALL: _Array_ptr<int> z : count(2) =  calloc<int>(2, sizeof(int));
   z += 2;
   return z;
 }

--- a/clang/test/CheckedCRewriter/safefptrargboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargboth.c
@@ -96,13 +96,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);
@@ -113,7 +113,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -121,13 +121,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -135,7 +135,7 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -114,13 +114,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -128,7 +128,7 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargbothmulti2.c
@@ -102,13 +102,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);

--- a/clang/test/CheckedCRewriter/safefptrargcallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallee.c
@@ -96,13 +96,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);
@@ -113,7 +113,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -121,13 +121,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -135,6 +135,6 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -114,13 +114,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -128,6 +128,6 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcalleemulti2.c
@@ -102,13 +102,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);

--- a/clang/test/CheckedCRewriter/safefptrargcaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargcaller.c
@@ -96,13 +96,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);
@@ -112,7 +112,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -120,13 +120,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -134,7 +134,7 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti1.c
@@ -102,11 +102,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -114,13 +114,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -128,7 +128,7 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 z += 2;
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargcallermulti2.c
@@ -102,13 +102,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);

--- a/clang/test/CheckedCRewriter/safefptrargprotoboth.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotoboth.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -111,13 +111,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -125,20 +125,20 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 z += 2;
 return z; }
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);

--- a/clang/test/CheckedCRewriter/safefptrargprotocallee.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocallee.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -111,13 +111,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -125,19 +125,19 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);

--- a/clang/test/CheckedCRewriter/safefptrargprotocaller.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotocaller.c
@@ -99,11 +99,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -111,13 +111,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -125,20 +125,20 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 z += 2;
 return z; }
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);

--- a/clang/test/CheckedCRewriter/safefptrargprotosafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargprotosafe.c
@@ -98,11 +98,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -110,13 +110,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -124,19 +124,19 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);

--- a/clang/test/CheckedCRewriter/safefptrargsafe.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafe.c
@@ -95,13 +95,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);
@@ -111,7 +111,7 @@ return z; }
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -119,13 +119,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -133,6 +133,6 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti1.c
@@ -101,11 +101,11 @@ int *mul2(int *x) {
 
 int * sus(int (*) (int), int (*) (int));
 	//CHECK_NOALL: int * sus(int (*)(int), _Ptr<int (int )> y);
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
+	//CHECK_ALL: _Array_ptr<int> sus(int (*)(int), _Ptr<int (int )> y);
 
 int * foo() {
 	//CHECK_NOALL: int * foo(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> foo(void) {
+	//CHECK_ALL: _Array_ptr<int> foo(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -113,13 +113,13 @@ int * foo() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }
 
 int * bar() {
 	//CHECK_NOALL: int * bar(void) {
-	//CHECK_ALL: _Nt_array_ptr<int> bar(void) {
+	//CHECK_ALL: _Array_ptr<int> bar(void) {
  
         int (*x)(int) = add1; 
 	//CHECK: int (*x)(int) = add1; 
@@ -127,6 +127,6 @@ int * bar() {
 	//CHECK: _Ptr<int (int )> y =  sub1; 
         int *z = sus(x, y);
 	//CHECK_NOALL: int *z = sus(x, y);
-	//CHECK_ALL: _Nt_array_ptr<int> z =  sus(x, y);
+	//CHECK_ALL: _Array_ptr<int> z =  sus(x, y);
         
 return z; }

--- a/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
+++ b/clang/test/CheckedCRewriter/safefptrargsafemulti2.c
@@ -101,13 +101,13 @@ int *mul2(int *x) {
 
 int * sus(int (*x) (int), int (*y) (int)) {
 	//CHECK_NOALL: int * sus(int (*x)(int), _Ptr<int (int )> y) {
-	//CHECK_ALL: _Nt_array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
+	//CHECK_ALL: _Array_ptr<int> sus(int (*x)(int), _Ptr<int (int )> y) {
  
         x = (int (*) (int)) 5;
 	//CHECK: x = (int (*) (int)) 5;
         int *z = calloc(5, sizeof(int));
 	//CHECK_NOALL: int *z = calloc<int>(5, sizeof(int));
-	//CHECK_ALL: _Nt_array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
+	//CHECK_ALL: _Array_ptr<int> z : count(5) =  calloc<int>(5, sizeof(int));
         int i;
         for(i = 0; i < 5; i++) { 
             z[i] = y(i);


### PR DESCRIPTION
Very small change in the source, but lots of `_Nt_array_ptr` in the tests are now `_Array_ptr`. 