### PR TITLE
Fix issue 220

### DIFF
--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -34,8 +34,6 @@
 #include <thread>
 #ifdef INTERACTIVECCCONV
 #include "clang/CConv/CConv.h"
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #endif
 
 namespace clang {
@@ -472,8 +470,14 @@ int main(int argc, char *argv[]) {
   CcOptions.EnableAllTypes = AllTypes;
   CcOptions.DisableCCTypeChecker = OptDiableCCTypeChecker;
   std::string Malloc = OptMalloc.getValue();
-  if (!Malloc.empty())
-    boost::split(CcOptions.AllocatorFunctions, Malloc, boost::is_any_of(","));
+  if (!Malloc.empty()) {
+    char *as_chr = strdup(Malloc.c_str());
+    char *tok = strtok(as_chr, ",");
+    while (tok != nullptr) {
+      CcOptions.AllocatorFunctions.push_back(tok);
+      tok = strtok(nullptr, ",");
+    }
+  }
   else
     CcOptions.AllocatorFunctions = {};
 

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -34,6 +34,8 @@
 #include <thread>
 #ifdef INTERACTIVECCCONV
 #include "clang/CConv/CConv.h"
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 #endif
 
 namespace clang {
@@ -306,6 +308,12 @@ static llvm::cl::opt<std::string>
                                  "STDOUT"),
                   llvm::cl::init("-"), llvm::cl::cat(ConvertCategory));
 
+static llvm::cl::opt<std::string>
+    Malloc("use-malloc",
+                     llvm::cl::desc("Allows for the usage of user-specified "
+                              "versions of function allocators"),
+                     llvm::cl::init(""), llvm::cl::cat(ConvertCategory));
+
 static llvm::cl::opt<std::string> ConstraintOutputJson(
     "constraint-output",
     llvm::cl::desc("Path to the file where all the analysis "
@@ -463,6 +471,11 @@ int main(int argc, char *argv[]) {
   CcOptions.AddCheckedRegions = AddCheckedRegions;
   CcOptions.EnableAllTypes = AllTypes;
   CcOptions.DisableCCTypeChecker = OptDiableCCTypeChecker;
+  std::string Malloc = OptMalloc.getValue();
+  if (!Malloc.empty())
+    boost::split(CcOptions.AllocatorFunctions, Malloc, boost::is_any_of(","));
+  else
+    CcOptions.AllocatorFunctions = {};
 
   CConvInterface CCInterface(CcOptions,
                              OptionsParser.getSourcePathList(),

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -471,12 +471,16 @@ int main(int argc, char *argv[]) {
   CcOptions.DisableCCTypeChecker = OptDiableCCTypeChecker;
   std::string Malloc = OptMalloc.getValue();
   if (!Malloc.empty()) {
-    char *as_chr = strdup(Malloc.c_str());
-    char *tok = strtok(as_chr, ",");
-    while (tok != nullptr) {
-      CcOptions.AllocatorFunctions.push_back(tok);
-      tok = strtok(nullptr, ",");
+    std::string delimiter = ",";
+    size_t pos = 0;
+    std::string token;
+    while ((pos = Malloc.find(delimiter)) != std::string::npos) {
+      token = Malloc.substr(0, pos);
+      CcOptions.AllocatorFunctions.push_back(token);
+      Malloc.erase(0, pos + delimiter.length());
     }
+    token = Malloc;
+    CcOptions.AllocatorFunctions.push_back(token);
   }
   else
     CcOptions.AllocatorFunctions = {};

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -307,7 +307,7 @@ static llvm::cl::opt<std::string>
                   llvm::cl::init("-"), llvm::cl::cat(ConvertCategory));
 
 static llvm::cl::opt<std::string>
-    Malloc("use-malloc",
+    OptMalloc("use-malloc",
                      llvm::cl::desc("Allows for the usage of user-specified "
                               "versions of function allocators"),
                      llvm::cl::init(""), llvm::cl::cat(ConvertCategory));

--- a/clang/include/clang/CConv/CCGlobalOptions.h
+++ b/clang/include/clang/CConv/CCGlobalOptions.h
@@ -24,6 +24,7 @@ extern bool ConsiderAllocUnsafe;
 extern bool AllTypes;
 extern bool NewSolver;
 extern std::string BaseDir;
+extern std::string Malloc;
 extern bool AddCheckedRegions;
 
 #endif //_CCGLOBALOPTIONS_H

--- a/clang/include/clang/CConv/CCGlobalOptions.h
+++ b/clang/include/clang/CConv/CCGlobalOptions.h
@@ -14,6 +14,7 @@
 #define _CCGLOBALOPTIONS_H
 
 #include "llvm/Support/CommandLine.h"
+#include <set>
 
 extern bool Verbose;
 extern bool DumpIntermediate;
@@ -24,7 +25,7 @@ extern bool ConsiderAllocUnsafe;
 extern bool AllTypes;
 extern bool NewSolver;
 extern std::string BaseDir;
-extern std::string Malloc;
+extern std::set<std::string> FunctionAllocs;
 extern bool AddCheckedRegions;
 
 #endif //_CCGLOBALOPTIONS_H

--- a/clang/include/clang/CConv/CCGlobalOptions.h
+++ b/clang/include/clang/CConv/CCGlobalOptions.h
@@ -14,7 +14,6 @@
 #define _CCGLOBALOPTIONS_H
 
 #include "llvm/Support/CommandLine.h"
-#include <set>
 
 extern bool Verbose;
 extern bool DumpIntermediate;
@@ -25,7 +24,7 @@ extern bool ConsiderAllocUnsafe;
 extern bool AllTypes;
 extern bool NewSolver;
 extern std::string BaseDir;
-extern std::set<std::string> FunctionAllocs;
+extern std::vector<std::string> AllocatorFunctions;
 extern bool AddCheckedRegions;
 
 #endif //_CCGLOBALOPTIONS_H

--- a/clang/include/clang/CConv/CConv.h
+++ b/clang/include/clang/CConv/CConv.h
@@ -38,7 +38,7 @@ struct CConvertOptions {
 
   std::string WildPtrInfoJson;
 
-  std::set<std::string> FunctionAllocs;
+  std::vector<std::string> AllocatorFunctions;
 
   bool HandleVARARGS;
 

--- a/clang/include/clang/CConv/CConv.h
+++ b/clang/include/clang/CConv/CConv.h
@@ -38,7 +38,7 @@ struct CConvertOptions {
 
   std::string WildPtrInfoJson;
 
-  std::string Malloc;
+  std::set<std::string> FunctionAllocs;
 
   bool HandleVARARGS;
 

--- a/clang/include/clang/CConv/CConv.h
+++ b/clang/include/clang/CConv/CConv.h
@@ -38,6 +38,8 @@ struct CConvertOptions {
 
   std::string WildPtrInfoJson;
 
+  std::string Malloc;
+
   bool HandleVARARGS;
 
   bool EnablePropThruIType;

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -14,6 +14,7 @@
 #include "clang/Analysis/Analyses/Dominators.h"
 #include "clang/CConv/ArrayBoundsInferenceConsumer.h"
 #include "clang/CConv/ConstraintResolver.h"
+#include "clang/CConv/CCGlobalOptions.h"
 #include <sstream>
 
 static std::set<std::string> LengthVarNamesPrefixes = {"len", "count",
@@ -145,7 +146,6 @@ static bool needArrayBounds(Decl *D, ProgramInfo &Info, ASTContext *C,
 // Map that contains association of allocator functions and indexes of
 // parameters that correspond to the size of the object being assigned.
 static std::map<std::string, std::set<unsigned>> AllocatorSizeAssoc = {
-                                                {"malloc", {0}},
                                                 {"calloc", {0, 1}}};
 
 
@@ -878,6 +878,7 @@ void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
 
 void HandleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I) {
   // Run array bounds
+  AllocatorSizeAssoc[Malloc] = {0};
   GlobalABVisitor GlobABV(C, I);
   TranslationUnitDecl *TUD = C->getTranslationUnitDecl();
   LocalVarABVisitor LFV = LocalVarABVisitor(C, I);

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -879,7 +879,7 @@ void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
 
 void HandleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I) {
   // Run array bounds
-  for (auto FuncName : FunctionAllocs) {
+  for (auto FuncName : AllocatorFunctions) {
     AllocatorSizeAssoc[FuncName] = {0};
   }
   GlobalABVisitor GlobABV(C, I);

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -146,6 +146,7 @@ static bool needArrayBounds(Decl *D, ProgramInfo &Info, ASTContext *C,
 // Map that contains association of allocator functions and indexes of
 // parameters that correspond to the size of the object being assigned.
 static std::map<std::string, std::set<unsigned>> AllocatorSizeAssoc = {
+                                                {"malloc", {0}},
                                                 {"calloc", {0, 1}}};
 
 
@@ -878,7 +879,9 @@ void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
 
 void HandleArrayVariablesBoundsDetection(ASTContext *C, ProgramInfo &I) {
   // Run array bounds
-  AllocatorSizeAssoc[Malloc] = {0};
+  for (auto FuncName : FunctionAllocs) {
+    AllocatorSizeAssoc[FuncName] = {0};
+  }
   GlobalABVisitor GlobABV(C, I);
   TranslationUnitDecl *TUD = C->getTranslationUnitDecl();
   LocalVarABVisitor LFV = LocalVarABVisitor(C, I);

--- a/clang/lib/CConv/CConv.cpp
+++ b/clang/lib/CConv/CConv.cpp
@@ -41,6 +41,7 @@ bool Verbose;
 std::string OutputPostfix;
 std::string ConstraintOutputJson;
 std::string Malloc;
+std::set<std::string> FunctionAllocs;
 bool DumpStats;
 bool HandleVARARGS;
 bool EnablePropThruIType;
@@ -174,7 +175,6 @@ CConvInterface::CConvInterface(const struct CConvertOptions &CCopt,
   DumpIntermediate = CCopt.DumpIntermediate;
   Verbose = CCopt.Verbose;
   OutputPostfix = CCopt.OutputPostfix;
-  Malloc = CCopt.Malloc;
   ConstraintOutputJson = CCopt.ConstraintOutputJson;
   StatsOutputJson = CCopt.StatsOutputJson;
   WildPtrInfoJson = CCopt.WildPtrInfoJson;
@@ -185,6 +185,7 @@ CConvInterface::CConvInterface(const struct CConvertOptions &CCopt,
   AllTypes = CCopt.EnableAllTypes;
   AddCheckedRegions = CCopt.AddCheckedRegions;
   DisableCCTypeChecker = CCopt.DisableCCTypeChecker;
+  FunctionAllocs = CCopt.FunctionAllocs;
 
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();

--- a/clang/lib/CConv/CConv.cpp
+++ b/clang/lib/CConv/CConv.cpp
@@ -40,7 +40,6 @@ bool DumpIntermediate;
 bool Verbose;
 std::string OutputPostfix;
 std::string ConstraintOutputJson;
-std::string Malloc;
 std::vector<std::string> AllocatorFunctions;
 bool DumpStats;
 bool HandleVARARGS;

--- a/clang/lib/CConv/CConv.cpp
+++ b/clang/lib/CConv/CConv.cpp
@@ -41,7 +41,7 @@ bool Verbose;
 std::string OutputPostfix;
 std::string ConstraintOutputJson;
 std::string Malloc;
-std::set<std::string> FunctionAllocs;
+std::vector<std::string> AllocatorFunctions;
 bool DumpStats;
 bool HandleVARARGS;
 bool EnablePropThruIType;
@@ -185,7 +185,7 @@ CConvInterface::CConvInterface(const struct CConvertOptions &CCopt,
   AllTypes = CCopt.EnableAllTypes;
   AddCheckedRegions = CCopt.AddCheckedRegions;
   DisableCCTypeChecker = CCopt.DisableCCTypeChecker;
-  FunctionAllocs = CCopt.FunctionAllocs;
+  AllocatorFunctions = CCopt.AllocatorFunctions;
 
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();

--- a/clang/lib/CConv/CConv.cpp
+++ b/clang/lib/CConv/CConv.cpp
@@ -40,6 +40,7 @@ bool DumpIntermediate;
 bool Verbose;
 std::string OutputPostfix;
 std::string ConstraintOutputJson;
+std::string Malloc;
 bool DumpStats;
 bool HandleVARARGS;
 bool EnablePropThruIType;
@@ -173,6 +174,7 @@ CConvInterface::CConvInterface(const struct CConvertOptions &CCopt,
   DumpIntermediate = CCopt.DumpIntermediate;
   Verbose = CCopt.Verbose;
   OutputPostfix = CCopt.OutputPostfix;
+  Malloc = CCopt.Malloc;
   ConstraintOutputJson = CCopt.ConstraintOutputJson;
   StatsOutputJson = CCopt.StatsOutputJson;
   WildPtrInfoJson = CCopt.WildPtrInfoJson;

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -142,7 +142,7 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
 
   ConstAtom *Ret = CS.getPtr();
   Expr *E;
-  if (FuncName.compare("malloc") == 0)
+  if (FuncName.compare(Malloc) == 0)
     E = CE->getArg(0);
   else {
     assert(FuncName.compare("realloc") == 0);
@@ -444,7 +444,8 @@ CVarSet
           }
         } else if (DeclaratorDecl *FD = dyn_cast<DeclaratorDecl>(D)) {
           /* Allocator call */
-          if (isFunctionAllocator(FD->getName())) {
+          if (isFunctionAllocator(FD->getName())
+              || FD->getName().compare(Malloc) == 0) {
             bool didInsert = false;
             if (CE->getNumArgs() > 0) {
               QualType ArgTy;

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -142,7 +142,8 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
 
   ConstAtom *Ret = CS.getPtr();
   Expr *E;
-  if (FunctionAllocs.find(FuncName) != FunctionAllocs.end()
+  if (std::find(AllocatorFunctions.begin(), AllocatorFunctions.end(),
+                FuncName) != AllocatorFunctions.end()
       || FuncName.compare("malloc") == 0)
     E = CE->getArg(0);
   else {

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -142,7 +142,8 @@ static ConstAtom *analyzeAllocExpr(CallExpr *CE, Constraints &CS,
 
   ConstAtom *Ret = CS.getPtr();
   Expr *E;
-  if (FuncName.compare(Malloc) == 0)
+  if (FunctionAllocs.find(FuncName) != FunctionAllocs.end()
+      || FuncName.compare("malloc") == 0)
     E = CE->getArg(0);
   else {
     assert(FuncName.compare("realloc") == 0);
@@ -444,8 +445,7 @@ CVarSet
           }
         } else if (DeclaratorDecl *FD = dyn_cast<DeclaratorDecl>(D)) {
           /* Allocator call */
-          if (isFunctionAllocator(FD->getName())
-              || FD->getName().compare(Malloc) == 0) {
+          if (isFunctionAllocator(FD->getName())) {
             bool didInsert = false;
             if (CE->getNumArgs() > 0) {
               QualType ArgTy;

--- a/clang/lib/CConv/Utils.cpp
+++ b/clang/lib/CConv/Utils.cpp
@@ -162,9 +162,10 @@ bool functionHasVarArgs(clang::FunctionDecl *FD) {
 }
 
 bool isFunctionAllocator(std::string FuncName) {
-  return llvm::StringSwitch<bool>(FuncName)
-    .Cases("malloc", "calloc", "realloc", true)
-    .Default(false);
+  return FunctionAllocs.find(FuncName) != FunctionAllocs.end() ||
+         llvm::StringSwitch<bool>(FuncName)
+             .Cases("malloc", "calloc", "realloc", true)
+             .Default(false);
 }
 
 float getTimeSpentInSeconds(clock_t StartTime) {

--- a/clang/lib/CConv/Utils.cpp
+++ b/clang/lib/CConv/Utils.cpp
@@ -162,8 +162,9 @@ bool functionHasVarArgs(clang::FunctionDecl *FD) {
 }
 
 bool isFunctionAllocator(std::string FuncName) {
-  return FunctionAllocs.find(FuncName) != FunctionAllocs.end() ||
-         llvm::StringSwitch<bool>(FuncName)
+  return std::find(AllocatorFunctions.begin(), AllocatorFunctions.end(),
+                   FuncName) != AllocatorFunctions.end()
+         || llvm::StringSwitch<bool>(FuncName)
              .Cases("malloc", "calloc", "realloc", true)
              .Default(false);
 }

--- a/clang/test/CheckedCRewriter/user_malloc.c
+++ b/clang/test/CheckedCRewriter/user_malloc.c
@@ -7,8 +7,7 @@ extern _Itype_for_any(T) void *my_malloc(size_t size) : itype(_Array_ptr<T>) byt
 
 int * foo(void) {
   int *p = my_malloc(sizeof(int));
-  //CHECK_ALL: _Array_ptr<int> p =  my_malloc<int>(sizeof(int));
-  //CHECK_NOALL: int *p = my_malloc<int>(sizeof(int));
+  //CHECK: _Ptr<int> p =  my_malloc<int>(sizeof(int));
   *p = 1;
   int *q = my_malloc(sizeof(int)*5);
   //CHECK_ALL: _Array_ptr<int> q : count(5) =  my_malloc<int>(sizeof(int)*5); 

--- a/clang/test/CheckedCRewriter/user_malloc.c
+++ b/clang/test/CheckedCRewriter/user_malloc.c
@@ -1,9 +1,11 @@
-// RUN: cconv-standalone -alltypes -use-malloc=my_malloc %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
-// RUN: cconv-standalone -use-malloc=my_malloc %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
-// RUN: cconv-standalone -use-malloc=my_malloc %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: cconv-standalone -alltypes -use-malloc=my_malloc,your_malloc %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone -use-malloc=my_malloc,your_malloc %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -use-malloc=my_malloc,your_malloc %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
 
 typedef unsigned long size_t;
 extern _Itype_for_any(T) void *my_malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *your_malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 
 int * foo(void) {
   int *p = my_malloc(sizeof(int));
@@ -12,6 +14,14 @@ int * foo(void) {
   int *q = my_malloc(sizeof(int)*5);
   //CHECK_ALL: _Array_ptr<int> q : count(5) =  my_malloc<int>(sizeof(int)*5); 
   //CHECK_NOALL: int *q = my_malloc<int>(sizeof(int)*5);
+  int *w = your_malloc(sizeof(int)*3); 
+  //CHECK_ALL: _Array_ptr<int> w : count(3) =  your_malloc<int>(sizeof(int)*3); 
+  //CHECK_NOALL: int *w = your_malloc<int>(sizeof(int)*3);  
+  int *x = malloc(sizeof(int)*2); 
+  //CHECK_ALL: _Array_ptr<int> x : count(2) =  malloc<int>(sizeof(int)*2);
+  //CHECK_NOALL: int *x = malloc<int>(sizeof(int)*2); 
+  w[1] = 0; 
+  x[1] = 9;
   q[2] = 3;
   return p;
 }

--- a/clang/test/CheckedCRewriter/user_malloc.c
+++ b/clang/test/CheckedCRewriter/user_malloc.c
@@ -1,0 +1,18 @@
+// RUN: cconv-standalone -alltypes -use-malloc=my_malloc %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone -use-malloc=my_malloc %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -use-malloc=my_malloc %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+
+typedef unsigned long size_t;
+extern _Itype_for_any(T) void *my_malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+int * foo(void) {
+  int *p = my_malloc(sizeof(int));
+  //CHECK_ALL: _Array_ptr<int> p =  my_malloc<int>(sizeof(int));
+  //CHECK_NOALL: int *p = my_malloc<int>(sizeof(int));
+  *p = 1;
+  int *q = my_malloc(sizeof(int)*5);
+  //CHECK_ALL: _Array_ptr<int> q : count(5) =  my_malloc<int>(sizeof(int)*5); 
+  //CHECK_NOALL: int *q = my_malloc<int>(sizeof(int)*5);
+  q[2] = 3;
+  return p;
+}

--- a/clang/tools/cconv-standalone/CConvStandalone.cpp
+++ b/clang/tools/cconv-standalone/CConvStandalone.cpp
@@ -134,12 +134,16 @@ int main(int argc, const char **argv) {
   //Add user specified function allocators
   std::string Malloc = OptMalloc.getValue();
   if (!Malloc.empty()) {
-    char *as_chr = strdup(Malloc.c_str());
-    char *tok = strtok(as_chr, ",");
-    while (tok != nullptr) {
-      CcOptions.AllocatorFunctions.push_back(tok);
-      tok = strtok(nullptr, ",");
+    std::string delimiter = ",";
+    size_t pos = 0;
+    std::string token;
+    while ((pos = Malloc.find(delimiter)) != std::string::npos) {
+      token = Malloc.substr(0, pos);
+      CcOptions.AllocatorFunctions.push_back(token);
+      Malloc.erase(0, pos + delimiter.length());
     }
+    token = Malloc;
+    CcOptions.AllocatorFunctions.push_back(token);
   }
   else
     CcOptions.AllocatorFunctions = {};

--- a/clang/tools/cconv-standalone/CConvStandalone.cpp
+++ b/clang/tools/cconv-standalone/CConvStandalone.cpp
@@ -14,6 +14,8 @@
 #include "llvm/Support/TargetSelect.h"
 
 #include "clang/CConv/CConv.h"
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 using namespace clang::driver;
 using namespace clang::tooling;
@@ -133,16 +135,10 @@ int main(int argc, const char **argv) {
   CcOptions.DisableCCTypeChecker = OptDiableCCTypeChecker;
   //Add user specified function allocators
   std::string Malloc = OptMalloc.getValue();
-  std::string delimiter = ",";
-  size_t pos = 0;
-  std::string token;
-  while ((pos = Malloc.find(delimiter)) != std::string::npos) {
-    token = Malloc.substr(0, pos);
-    CcOptions.FunctionAllocs.insert(token);
-    Malloc.erase(0, pos + delimiter.length());
-  }
-  token = Malloc;
-  CcOptions.FunctionAllocs.insert(token);
+  if (!Malloc.empty())
+    boost::split(CcOptions.AllocatorFunctions, Malloc, boost::is_any_of(","));
+  else
+    CcOptions.AllocatorFunctions = {};
 
   // Create CConv Interface.
   CConvInterface CCInterface(CcOptions,

--- a/clang/tools/cconv-standalone/CConvStandalone.cpp
+++ b/clang/tools/cconv-standalone/CConvStandalone.cpp
@@ -14,8 +14,6 @@
 #include "llvm/Support/TargetSelect.h"
 
 #include "clang/CConv/CConv.h"
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 
 using namespace clang::driver;
 using namespace clang::tooling;
@@ -135,8 +133,14 @@ int main(int argc, const char **argv) {
   CcOptions.DisableCCTypeChecker = OptDiableCCTypeChecker;
   //Add user specified function allocators
   std::string Malloc = OptMalloc.getValue();
-  if (!Malloc.empty())
-    boost::split(CcOptions.AllocatorFunctions, Malloc, boost::is_any_of(","));
+  if (!Malloc.empty()) {
+    char *as_chr = strdup(Malloc.c_str());
+    char *tok = strtok(as_chr, ",");
+    while (tok != nullptr) {
+      CcOptions.AllocatorFunctions.push_back(tok);
+      tok = strtok(nullptr, ",");
+    }
+  }
   else
     CcOptions.AllocatorFunctions = {};
 

--- a/clang/tools/cconv-standalone/CConvStandalone.cpp
+++ b/clang/tools/cconv-standalone/CConvStandalone.cpp
@@ -40,6 +40,12 @@ static cl::opt<std::string>
                   cl::init("-"), cl::cat(ConvertCategory));
 
 static cl::opt<std::string>
+    OptMalloc("use-malloc",
+                     cl::desc("Allows for the usage of a user-specified "
+                              "version of malloc"),
+                     cl::init("malloc"), cl::cat(ConvertCategory));
+
+static cl::opt<std::string>
     OptConstraintOutputJson("constraint-output",
                          cl::desc("Path to the file where all the analysis "
                                   "information will be dumped as json"),
@@ -117,6 +123,7 @@ int main(int argc, const char **argv) {
   CcOptions.HandleVARARGS = OptHandleVARARGS;
   CcOptions.DumpStats = OptDumpStats;
   CcOptions.OutputPostfix = OptOutputPostfix.getValue();
+  CcOptions.Malloc = OptMalloc.getValue();
   CcOptions.Verbose = OptVerbose;
   CcOptions.DumpIntermediate = OptDumpIntermediate;
   CcOptions.ConstraintOutputJson = OptConstraintOutputJson.getValue();

--- a/clang/tools/cconv-standalone/CConvStandalone.cpp
+++ b/clang/tools/cconv-standalone/CConvStandalone.cpp
@@ -41,9 +41,9 @@ static cl::opt<std::string>
 
 static cl::opt<std::string>
     OptMalloc("use-malloc",
-                     cl::desc("Allows for the usage of a user-specified "
-                              "version of malloc"),
-                     cl::init("malloc"), cl::cat(ConvertCategory));
+                     cl::desc("Allows for the usage of user-specified "
+                              "versions of function allocators"),
+                     cl::init(""), cl::cat(ConvertCategory));
 
 static cl::opt<std::string>
     OptConstraintOutputJson("constraint-output",
@@ -123,7 +123,6 @@ int main(int argc, const char **argv) {
   CcOptions.HandleVARARGS = OptHandleVARARGS;
   CcOptions.DumpStats = OptDumpStats;
   CcOptions.OutputPostfix = OptOutputPostfix.getValue();
-  CcOptions.Malloc = OptMalloc.getValue();
   CcOptions.Verbose = OptVerbose;
   CcOptions.DumpIntermediate = OptDumpIntermediate;
   CcOptions.ConstraintOutputJson = OptConstraintOutputJson.getValue();
@@ -132,6 +131,18 @@ int main(int argc, const char **argv) {
   CcOptions.AddCheckedRegions = OptAddCheckedRegions;
   CcOptions.EnableAllTypes = OptAllTypes;
   CcOptions.DisableCCTypeChecker = OptDiableCCTypeChecker;
+  //Add user specified function allocators
+  std::string Malloc = OptMalloc.getValue();
+  std::string delimiter = ",";
+  size_t pos = 0;
+  std::string token;
+  while ((pos = Malloc.find(delimiter)) != std::string::npos) {
+    token = Malloc.substr(0, pos);
+    CcOptions.FunctionAllocs.insert(token);
+    Malloc.erase(0, pos + delimiter.length());
+  }
+  token = Malloc;
+  CcOptions.FunctionAllocs.insert(token);
 
   // Create CConv Interface.
   CConvInterface CCInterface(CcOptions,


### PR DESCRIPTION
Fix for #220 
Allows the usage of a commandline flag `-use-malloc=<>` in order to treat custom allocator functions the same as malloc (the default is malloc). 
Added a passing test to highlight this issue.
This fix was slightly tricky, but mostly straightforward, so we can also discuss adding a config file for the more general purpose stopgap fix @mwhicks1 suggested in a followup to the issue. 