### PR TITLE
Avoid rewritting functions with an existing checked type

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -115,6 +115,13 @@ public:
   // have a binding in E other than top. E should be the EnvironmentMap that
   // results from running unification on the set of constraints and the
   // environment.
+  bool isChecked(EnvironmentMap &E);
+
+  // Returns true if this constraint variable has a different checked type after
+  // running unification. Note that if the constraint variable had a checked
+  // type in the input program, it will have the same checked type after solving
+  // so, the type will not have changed. To test if the type is checked, use
+  // isChecked instead.
   virtual bool anyChanges(EnvironmentMap &E) = 0;
 
   // Here, AIdx is the pointer level which needs to be checked.
@@ -442,18 +449,7 @@ public:
     return true;
   }
 
-  bool getIsOriginallyChecked() override {
-    for (const auto &R : returnVars)
-      if (R->getIsOriginallyChecked())
-        return true;
-
-    for (const auto &PS : paramVars)
-      for (const auto &P : PS)
-        if (P->getIsOriginallyChecked())
-          return true;
-
-    return false;
-  }
+  bool getIsOriginallyChecked() override;
 
   virtual ~FunctionVariableConstraint() {};
 };

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -110,7 +110,7 @@ bool CastPlacementVisitor::needCasting(ConstraintVariable *Src,
                                        ConstraintVariable *Dst,
                                        IsChecked Dinfo) {
   auto &E = Info.getConstraints().getVariables();
-  auto SrcChecked = Src->anyChanges(E);
+  auto SrcChecked = Src->isChecked(E);
   // Check if the src is a checked type.
   if (SrcChecked) {
     // Check if Dst is an itype, if yes then
@@ -120,7 +120,7 @@ bool CastPlacementVisitor::needCasting(ConstraintVariable *Src,
     }
 
     // Is Dst Wild?
-    if (!Dst->anyChanges(E) || Dinfo == WILD) {
+    if (!Dst->isChecked(E) || Dinfo == WILD) {
       return true;
     }
 

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -105,6 +105,7 @@ PointerVariableConstraint::
   this->Parent = Ot;
   this->IsGeneric = Ot->IsGeneric;
   this->IsZeroWidthArray = Ot->IsZeroWidthArray;
+  this->OriginallyChecked = Ot->OriginallyChecked;
   // We need not initialize other members.
 }
 
@@ -206,6 +207,7 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT,
   bool VarCreated = false;
   bool IsArr = false;
   bool IsIncompleteArr = false;
+  OriginallyChecked = false;
   uint32_t TypeIdx = 0;
   std::string Npre = inFunc ? ((*inFunc)+":") : "";
   VarAtom::VarKind VK =
@@ -223,6 +225,7 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT,
     }
 
     if (Ty->isCheckedPointerType()) {
+      OriginallyChecked = true;
       ConstAtom *CAtom = nullptr;
       if (Ty->isCheckedPointerNtArrayType()) {
         // This is an NT array type.
@@ -973,7 +976,7 @@ void PointerVariableConstraint::constrainOuterTo(Constraints &CS, ConstAtom *C,
 
 bool PointerVariableConstraint::anyArgumentIsWild(EnvironmentMap &E) {
   for (auto *ArgVal : argumentConstraints) {
-    if (!(ArgVal->anyChanges(E))) {
+    if (!ArgVal->anyChanges(E)) {
       return true;
     }
   }

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -460,15 +460,10 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   if (!Defnc->hasBody())
     return true;
 
-  // If a function had a checked type in the input program, we don't want to
-  // mess with the existing type.
-  if (Defnc->getIsOriginallyChecked())
-    return true;
-
   // DidAny tracks if we have made any changes to this function declaration.
   // If no changes are made, then there is no need to rewrite anything, and the
   // declaration is not added to RewriteThese.
-  bool DidAny = Defnc->numParams() > 0;
+  bool DidAny = false;
 
   // Get rewritten parameter variable declarations
   vector<string> ParmStrs;
@@ -479,6 +474,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
     if (isAValidPVConstraint(Defn) && Defn->anyChanges(CS.getVariables())) {
       // This means Defn has a checked type, so we should rewrite to use this
       // type with an itype if applicable.
+      DidAny = true;
 
       if (Defn->hasItype() || !Defn->anyArgumentIsWild(CS.getVariables())) {
         // If the definition already has itype or there are no WILD arguments.
@@ -540,8 +536,6 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
     ReturnVar = Defn->getOriginalTy() + " ";
     // If this there is already a bounds safe interface, keep using it.
     ItypeStr = getExistingIType(Defn);
-    if (!ItypeStr.empty())
-      DidAny = true;
   }
 
   // Combine parameter and return variables rewritings into a single rewriting

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -460,6 +460,11 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   if (!Defnc->hasBody())
     return true;
 
+  // If a function had a checked type in the input program, we don't want to
+  // mess with the existing type.
+  if (Defnc->getIsOriginallyChecked())
+    return true;
+
   // DidAny tracks if we have made any changes to this function declaration.
   // If no changes are made, then there is no need to rewrite anything, and the
   // declaration is not added to RewriteThese.

--- a/clang/lib/CConv/StructInit.cpp
+++ b/clang/lib/CConv/StructInit.cpp
@@ -28,7 +28,7 @@ bool StructVariableInitializer::VariableNeedsInitializer(VarDecl *VD) {
         CVarSet FieldConsVars = I.getVariable(D, Context);
         for (auto *CV : FieldConsVars) {
           PVConstraint *PV = dyn_cast<PVConstraint>(CV);
-          if (PV && PV->anyChanges(I.getConstraints().getVariables())) {
+          if (PV && PV->isChecked(I.getConstraints().getVariables())) {
             // Ok this contains a pointer that is checked. Store it.
             RecordsWithCPointers.insert(Definition);
             return true;

--- a/clang/test/CheckedCRewriter/3d-allocation.c
+++ b/clang/test/CheckedCRewriter/3d-allocation.c
@@ -36,7 +36,7 @@ int ***malloc3d(int y, int x, int z) {
 	return t;
 
 }
-//CHECK: int *** malloc3d(int y, int x, int z) {
+//CHECK: int ***malloc3d(int y, int x, int z) {
 //CHECK: int ***t;
 
 

--- a/clang/test/CheckedCRewriter/arrinstructboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructboth.c
@@ -95,7 +95,7 @@ int *mul2(int *x) {
 }
 
 struct warr * sus(struct warr * x, struct warr * y) {
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y) {
+	//CHECK_NOALL: struct warr * sus(struct warr * x, struct warr * y) {
 	//CHECK_ALL: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
 x = (struct warr *) 5;
 	//CHECK: x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructbothmulti2.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 }
 
 struct warr * sus(struct warr * x, struct warr * y) {
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y) {
+	//CHECK_NOALL: struct warr * sus(struct warr * x, struct warr * y) {
 	//CHECK_ALL: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
 x = (struct warr *) 5;
 	//CHECK: x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructcallee.c
@@ -95,7 +95,7 @@ int *mul2(int *x) {
 }
 
 struct warr * sus(struct warr * x, struct warr * y) {
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y) {
+	//CHECK_NOALL: struct warr * sus(struct warr * x, struct warr * y) {
 	//CHECK_ALL: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
 x = (struct warr *) 5;
 	//CHECK: x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrinstructcalleemulti2.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 }
 
 struct warr * sus(struct warr * x, struct warr * y) {
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y) {
+	//CHECK_NOALL: struct warr * sus(struct warr * x, struct warr * y) {
 	//CHECK_ALL: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
 x = (struct warr *) 5;
 	//CHECK: x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotoboth.c
@@ -98,7 +98,7 @@ int *mul2(int *x) {
 }
 
 struct warr * sus(struct warr *, struct warr *);
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y);
+	//CHECK_NOALL: struct warr * sus(struct warr *, struct warr *);
 	//CHECK_ALL: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
 
 struct warr * foo() {
@@ -127,7 +127,7 @@ z += 2;
 return z; }
 
 struct warr * sus(struct warr * x, struct warr * y) {
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y) {
+	//CHECK_NOALL: struct warr * sus(struct warr * x, struct warr * y) {
 	//CHECK_ALL: _Array_ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
 x = (struct warr *) 5;
 	//CHECK: x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrinstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrinstructprotocallee.c
@@ -98,7 +98,7 @@ int *mul2(int *x) {
 }
 
 struct warr * sus(struct warr *, struct warr *);
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y);
+	//CHECK_NOALL: struct warr * sus(struct warr *, struct warr *);
 	//CHECK_ALL: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>));
 
 struct warr * foo() {
@@ -126,7 +126,7 @@ struct warr * bar() {
 return z; }
 
 struct warr * sus(struct warr * x, struct warr * y) {
-	//CHECK_NOALL: struct warr * sus(struct warr *x, struct warr *y) {
+	//CHECK_NOALL: struct warr * sus(struct warr * x, struct warr * y) {
 	//CHECK_ALL: _Ptr<struct warr> sus(struct warr *x, struct warr *y : itype(_Array_ptr<struct warr>)) {
 x = (struct warr *) 5;
 	//CHECK: x = (struct warr *) 5;

--- a/clang/test/CheckedCRewriter/arrofstructboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructboth.c
@@ -96,7 +96,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructbothmulti2.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructcallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallee.c
@@ -96,7 +96,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcalleemulti2.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructcaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructcaller.c
@@ -96,7 +96,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructcallermulti2.c
@@ -102,7 +102,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructprotoboth.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotoboth.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
@@ -150,7 +150,7 @@ z += 2;
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructprotocallee.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocallee.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
@@ -149,7 +149,7 @@ struct general ** bar() {
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructprotocaller.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotocaller.c
@@ -99,7 +99,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
@@ -150,7 +150,7 @@ z += 2;
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructprotosafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructprotosafe.c
@@ -98,7 +98,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general *, struct general *);
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y);
+	//CHECK_NOALL: struct general ** sus(struct general *, struct general *);
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y);
 
 struct general ** foo() {
@@ -148,7 +148,7 @@ struct general ** bar() {
 return z; }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructsafe.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafe.c
@@ -95,7 +95,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
+++ b/clang/test/CheckedCRewriter/arrofstructsafemulti2.c
@@ -101,7 +101,7 @@ int *mul2(int *x) {
 }
 
 struct general ** sus(struct general * x, struct general * y) {
-	//CHECK_NOALL: struct general ** sus(struct general *x, struct general *y) {
+	//CHECK_NOALL: struct general ** sus(struct general * x, struct general * y) {
 	//CHECK_ALL: _Array_ptr<_Ptr<struct general>> sus(struct general *x, _Ptr<struct general> y) {
 x = (struct general *) 5; 
 	//CHECK: x = (struct general *) 5; 

--- a/clang/test/CheckedCRewriter/b11_calleestructnp.c
+++ b/clang/test/CheckedCRewriter/b11_calleestructnp.c
@@ -32,7 +32,7 @@ struct r {
 
 
 struct np *sus(struct p x, struct p y) {
-	//CHECK: struct np * sus(struct p x, struct p y) {
+	//CHECK: struct np *sus(struct p x, struct p y) {
   struct np *z = malloc(sizeof(struct np));
 	//CHECK: struct np *z = malloc<struct np>(sizeof(struct np));
   z->x = 1;

--- a/clang/test/CheckedCRewriter/b12_callerstructnp.c
+++ b/clang/test/CheckedCRewriter/b12_callerstructnp.c
@@ -33,7 +33,7 @@ struct r {
 
 struct np *sus(struct p x, struct p y) {
 	//CHECK_NOALL: struct np *sus(struct p x, struct p y) : itype(_Ptr<struct np>) {
-	//CHECK_ALL: struct np * sus(struct p x, struct p y) {
+	//CHECK_ALL: struct np *sus(struct p x, struct p y) {
   struct np *z = malloc(sizeof(struct np));
 	//CHECK_NOALL: _Ptr<struct np> z =  malloc<struct np>(sizeof(struct np));
 	//CHECK_ALL:   struct np *z = malloc<struct np>(sizeof(struct np));

--- a/clang/test/CheckedCRewriter/b17_bothstructnp.c
+++ b/clang/test/CheckedCRewriter/b17_bothstructnp.c
@@ -32,7 +32,7 @@ struct r {
 
 
 struct np *sus(struct p x, struct p y) {
-	//CHECK: struct np * sus(struct p x, struct p y) {
+	//CHECK: struct np *sus(struct p x, struct p y) {
   struct np *z = malloc(sizeof(struct np));
 	//CHECK: struct np *z = malloc<struct np>(sizeof(struct np));
   z->x = 1;

--- a/clang/test/CheckedCRewriter/basic.c
+++ b/clang/test/CheckedCRewriter/basic.c
@@ -54,7 +54,7 @@ char* basic2(int temp) {
 		return 0;
 	}
 }
-//CHECK: char * basic2(int temp) {
+//CHECK: char* basic2(int temp) {
 //CHECK_ALL: char data _Nt_checked[17] =  "abcdefghijklmnop";
 //CHECK_ALL: char data2 _Nt_checked[65] =  "abcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmnop";
 //CHECK: char *buffer = malloc<char>(8);

--- a/clang/test/CheckedCRewriter/bounds_interface.c
+++ b/clang/test/CheckedCRewriter/bounds_interface.c
@@ -19,7 +19,7 @@ void foo(int *p : itype(_Ptr<int>)) {
 	*p = 0;
 	return;
 }
-//CHECK: void foo(int * p : itype(_Ptr<int>)) {
+//CHECK: void foo(int *p : itype(_Ptr<int>)) {
 
 int foo2(int *j) {
 	int *a = baz();

--- a/clang/test/CheckedCRewriter/dont_rewrite.c
+++ b/clang/test/CheckedCRewriter/dont_rewrite.c
@@ -14,6 +14,15 @@ _Itype_for_any(T) void vsf_sysutil_memclr(void* p_dest : itype(_Array_ptr<T>) by
   memset(p_dest, '\0', size);
 }
 
-// included just so output is procduced
-int *a;
 
+int *foo( _Ptr<int> q) {
+// CHECK: _Ptr<int> foo(_Ptr<int> q) _Checked {
+  return q;
+}
+void bar(void) {
+// CHECK: void bar(void) _Checked {
+  int *x = 0;
+  // CHECK: _Ptr<int> x = 0;
+  int *y = foo(x);
+  // CHECK: _Ptr<int> y = foo(x);
+}

--- a/clang/test/CheckedCRewriter/dont_rewrite.c
+++ b/clang/test/CheckedCRewriter/dont_rewrite.c
@@ -1,0 +1,19 @@
+// RUN: cconv-standalone -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+
+typedef unsigned long size_t;
+
+extern void *memset(void * dest : byte_count(n),
+             int c,
+             size_t n) : bounds(dest, (_Array_ptr<char>)dest + n);
+
+// don't mess with this
+_Itype_for_any(T) void vsf_sysutil_memclr(void* p_dest : itype(_Array_ptr<T>) byte_count(size), unsigned int size) {
+// CHECK: _Itype_for_any(T) void vsf_sysutil_memclr(void* p_dest : itype(_Array_ptr<T>) byte_count(size), unsigned int size) {
+  memset(p_dest, '\0', size);
+}
+
+// included just so output is procduced
+int *a;
+

--- a/clang/test/CheckedCRewriter/fptrarrboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrboth.c
@@ -89,7 +89,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti1.c
@@ -95,7 +95,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrbothmulti2.c
@@ -95,7 +95,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrcallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallee.c
@@ -89,7 +89,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti1.c
@@ -95,7 +95,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcalleemulti2.c
@@ -95,7 +95,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrcaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrcaller.c
@@ -89,7 +89,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti1.c
@@ -95,7 +95,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrcallermulti2.c
@@ -95,7 +95,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotoboth.c
@@ -92,14 +92,14 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *, int *);
 	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {

--- a/clang/test/CheckedCRewriter/fptrarrprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocallee.c
@@ -92,14 +92,14 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *, int *);
 	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {

--- a/clang/test/CheckedCRewriter/fptrarrprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotocaller.c
@@ -92,14 +92,14 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *, int *);
 	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {

--- a/clang/test/CheckedCRewriter/fptrarrprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrprotosafe.c
@@ -91,14 +91,14 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;
 }
 
 int ** sus(int *, int *);
-	//CHECK_NOALL: int ** sus(int *x, int *y);
+	//CHECK_NOALL: int ** sus(int *, int *);
 	//CHECK_ALL: _Array_ptr<_Array_ptr<int>> sus(int *x, _Array_ptr<int> y : count(5));
 
 int ** foo() {

--- a/clang/test/CheckedCRewriter/fptrarrsafe.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafe.c
@@ -88,7 +88,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti1.c
@@ -94,7 +94,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
+++ b/clang/test/CheckedCRewriter/fptrarrsafemulti2.c
@@ -94,7 +94,7 @@ int zerohuh(int n) {
 }
 
 int *mul2(int *x) { 
-	//CHECK_NOALL: int * mul2(int *x) { 
+	//CHECK_NOALL: int *mul2(int *x) { 
 	//CHECK_ALL: _Array_ptr<int> mul2(_Array_ptr<int> x) { 
     *x *= 2; 
     return x;

--- a/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotoboth.c
@@ -98,7 +98,7 @@ int *mul2(int *x) {
 }
 
 int * sus(struct general *, struct general *);
-	//CHECK: int * sus(struct general *x, struct general *y);
+	//CHECK: int * sus(struct general *, struct general *);
 
 int * foo() {
 	//CHECK: int * foo(void) {

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocallee.c
@@ -98,7 +98,7 @@ int *mul2(int *x) {
 }
 
 int * sus(struct general *, struct general *);
-	//CHECK: int * sus(struct general *x, struct general *y);
+	//CHECK: int * sus(struct general *, struct general *);
 
 int * foo() {
 	//CHECK: int * foo(void) {

--- a/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotocaller.c
@@ -98,7 +98,7 @@ int *mul2(int *x) {
 }
 
 int * sus(struct general *, struct general *);
-	//CHECK: int * sus(struct general *x, struct general *y);
+	//CHECK: int * sus(struct general *, struct general *);
 
 int * foo() {
 	//CHECK: int * foo(void) {

--- a/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
+++ b/clang/test/CheckedCRewriter/fptrunsafeprotosafe.c
@@ -97,7 +97,7 @@ int *mul2(int *x) {
 }
 
 int * sus(struct general *, struct general *);
-	//CHECK: int * sus(struct general *x, struct general *y);
+	//CHECK: int * sus(struct general *, struct general *);
 
 int * foo() {
 	//CHECK: int * foo(void) {

--- a/clang/test/CheckedCRewriter/i3.c
+++ b/clang/test/CheckedCRewriter/i3.c
@@ -7,3 +7,5 @@ static int * f(int *x) {
   return x;
 }
 //CHECK: static int * f(int *x) {
+// force output
+int *p;

--- a/clang/test/CheckedCRewriter/linkedlist.c
+++ b/clang/test/CheckedCRewriter/linkedlist.c
@@ -22,7 +22,7 @@ void destroy(List * list);
 //CHECK-NEXT: void delete(int data, _Ptr<List> list);
 //CHECK-NEXT: void display(_Ptr<List> list);
 //CHECK-NEXT: void reverse(_Ptr<List> list);
-//CHECK-NEXT: void destroy(List *list);
+//CHECK-NEXT: void destroy(List * list);
 
 
 struct node {
@@ -214,6 +214,6 @@ void destroy(List * list){
 
   free(list);
 }
-//CHECK: void destroy(List *list){
+//CHECK: void destroy(List * list){
 //CHECK: Node * current = list->head;
 //CHECK: Node * next = current;

--- a/clang/test/CheckedCRewriter/placements.c
+++ b/clang/test/CheckedCRewriter/placements.c
@@ -31,7 +31,7 @@ void foo2(_Ptr<int> a) {
 void bar(int *a : itype(_Ptr<int>) ) {
   *a = 0;
 }
-//CHECK: void bar(int * a : itype(_Ptr<int>)) {
+//CHECK: void bar(int *a : itype(_Ptr<int>) ) {
 
 extern int* baz(void) : itype(_Ptr<int>);
 //CHECK: extern int*  baz(void) : itype(_Ptr<int>);

--- a/clang/test/CheckedCRewriter/placements.c
+++ b/clang/test/CheckedCRewriter/placements.c
@@ -35,3 +35,6 @@ void bar(int *a : itype(_Ptr<int>) ) {
 
 extern int* baz(void) : itype(_Ptr<int>);
 //CHECK: extern int*  baz(void) : itype(_Ptr<int>);
+
+// force output
+int *p;

--- a/clang/test/CheckedCRewriter/return_not_least.c
+++ b/clang/test/CheckedCRewriter/return_not_least.c
@@ -50,7 +50,7 @@ int *bar() {
 
 int *baz(int *a) {
   // CHECK_ALL: _Array_ptr<int> baz(_Array_ptr<int> a) {
-  // CHECK_NOALL: int * baz(int *a) {
+  // CHECK_NOALL: int *baz(int *a) {
   a++;
 
   int *b = (int*) 0;
@@ -65,7 +65,7 @@ int *baz(int *a) {
 
 int *buz(int *a) {
   // CHECK_ALL: _Ptr<int> buz(_Array_ptr<int> a) { 
-  // CHECK_NOALL: int * buz(int *a) {
+  // CHECK_NOALL: int *buz(int *a) {
   a++;
 
   int *b = (int*) 0;

--- a/clang/test/CheckedCRewriter/valist.c
+++ b/clang/test/CheckedCRewriter/valist.c
@@ -11,7 +11,7 @@ extern const char *luaO_pushvfstring (lua_State *L, const char *fmt, va_list arg
 const char *lua_pushfstring (lua_State *L, const char *fmt, ...) {
   const char *ret;
   va_list argp;
-//CHECK: const char * lua_pushfstring(lua_State *L, const char *fmt, ...) {
+//CHECK: const char *lua_pushfstring (lua_State *L, const char *fmt, ...) {
 //CHECK-NEXT:  const char *ret;
 //CHECK-NEXT:  va_list argp;
   lua_lock(L);
@@ -22,3 +22,5 @@ const char *lua_pushfstring (lua_State *L, const char *fmt, ...) {
   lua_unlock(L);
   return ret;
 }
+//force output
+int *p;


### PR DESCRIPTION
Adds a field to keep track of constraint variables that had checked type in the input program. When rewriting function declarations, we skip any function declarations for which the return or any of the parameters have a checked type in the original program.

There may be other places we want to avoid rewriting if the type is already checked, but this works well enough for the specific example in issue #216. 