### PR TITLE
Type argument insertion bug fix

### DIFF
--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -341,6 +341,11 @@ public:
 
   ConstraintVariable *getCopy(Constraints &CS);
 
+  // Retrieve the atom at the specified index. This function includes special
+  // handling for generic constraint variables to create deeper pointers as
+  // they are needed.
+  Atom *getAtom(unsigned int AtomIdx, Constraints &CS);
+
   virtual ~PointerVariableConstraint() {};
 };
 

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -145,6 +145,8 @@ public:
   // Sometimes, constraint variables can be produced that are empty. This
   // tests for the existence of those constraint variables.
   virtual bool isEmpty(void) const = 0;
+
+  virtual bool getIsOriginallyChecked() = 0;
 };
 
 typedef std::set<ConstraintVariable *> CVarSet;
@@ -248,6 +250,12 @@ private:
   // pointers.
   bool IsZeroWidthArray;
 
+  // Was this variable a checked pointer in the input program?
+  // This is important for two reasons: (1) externs that are checked should be
+  // kept that way during solving, (2) nothing that was originally checked
+  // should be modified during rewriting.
+  bool OriginallyChecked;
+
 public:
   // Constructor for when we know a CVars and a type string.
   PointerVariableConstraint(CAtoms V, std::string T, std::string Name,
@@ -273,6 +281,8 @@ public:
   std::string getBoundsStr() { return BoundsAnnotationStr; }
 
   bool getIsGeneric(){ return IsGeneric; }
+
+  bool getIsOriginallyChecked(){ return OriginallyChecked; }
 
   bool solutionEqualTo(Constraints &CS, ConstraintVariable *CV);
 
@@ -428,6 +438,19 @@ public:
           return false;
 
     return true;
+  }
+
+  bool getIsOriginallyChecked() {
+    for (const auto &R : returnVars)
+      if (R->getIsOriginallyChecked())
+        return true;
+
+    for (const auto &PS : paramVars)
+      for (const auto &P : PS)
+        if (P->getIsOriginallyChecked())
+          return true;
+
+    return false;
   }
 
   virtual ~FunctionVariableConstraint() {};

--- a/clang/include/clang/CConv/TypeVariableAnalysis.h
+++ b/clang/include/clang/CConv/TypeVariableAnalysis.h
@@ -25,13 +25,9 @@ public:
       TypeParamConsVar(nullptr) {
     // We'll need a name to provide the type arguments during rewriting, so no
     // anonymous types are allowed.
-    if (isTypeAnonymous(Ty->getPointeeOrArrayElementType())) {
-      IsConsistent = false;
-    } else {
-      IsConsistent = true;
-      TyVarType = Ty;
-      ArgConsVars = CVs;
-    }
+    IsConsistent = !isTypeAnonymous(Ty->getPointeeOrArrayElementType());
+    TyVarType = Ty;
+    ArgConsVars = CVs;
   }
 
   bool getIsConsistent() const;

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -206,6 +206,7 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT,
   bool VarCreated = false;
   bool IsArr = false;
   bool IsIncompleteArr = false;
+  OriginallyChecked = false;
   uint32_t TypeIdx = 0;
   std::string Npre = inFunc ? ((*inFunc)+":") : "";
   VarAtom::VarKind VK =
@@ -223,6 +224,7 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT,
     }
 
     if (Ty->isCheckedPointerType()) {
+      OriginallyChecked = true;
       ConstAtom *CAtom = nullptr;
       if (Ty->isCheckedPointerNtArrayType()) {
         // This is an NT array type.

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -422,8 +422,10 @@ bool ProgramInfo::link() {
       assert(FuncDeclFVIterator != ExternalFunctionFVCons.end());
       const std::set<FVConstraint *> &Gs = (*FuncDeclFVIterator).second;
 
-      for (const auto GIterator : Gs) {
-        auto *G = GIterator;
+      // If there was a checked type on a variable in the input program, it
+      // should stay that way. Otherwise, we shouldn't be adding a checked type
+      // to an extern function.
+      for (auto *const G : Gs) {
         for (const auto &R : G->getReturnVars()) {
           if (R->getIsOriginallyChecked())
             continue;

--- a/clang/test/CheckedCRewriter/3d-allocation.c
+++ b/clang/test/CheckedCRewriter/3d-allocation.c
@@ -8,24 +8,31 @@
 extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
 
 int ***malloc3d(int y, int x, int z) {
+//CHECK_ALL: _Array_ptr<_Array_ptr<_Array_ptr<int>>> malloc3d(int y, int x, int z) {
+//CHECK_NOALL: int ***malloc3d(int y, int x, int z) {
 
 	int i, j;
 
 	int ***t;
+	//CHECK_ALL:_Array_ptr<_Array_ptr<_Array_ptr<int>>> t : count(y) = ((void *)0);
+        //CHECK_NOALL: int ***t;
 
 
 
 	t = malloc(y * sizeof(int *));
+	//CHECK_ALL: t = malloc<_Array_ptr<_Array_ptr<int>>>(y * sizeof(int *));
 
 
 
 	for (i = 0; i < y; ++i) {
 
 		t[i] = malloc(x * sizeof(int *));
+		//CHECK_ALL: t[i] = malloc<_Array_ptr<int>>(x * sizeof(int *));
 
 		for (j = 0; j < x; ++j) {
 
 			t[i][j] = malloc(z * sizeof(int));
+			//CHECK_ALL: t[i][j] = malloc<int>(z * sizeof(int));
 
 		}
 
@@ -36,9 +43,6 @@ int ***malloc3d(int y, int x, int z) {
 	return t;
 
 }
-//CHECK: int ***malloc3d(int y, int x, int z) {
-//CHECK: int ***t;
-
 
 int main(void) {
 
@@ -53,6 +57,9 @@ int main(void) {
 
 
 	int ***t2 = malloc3d(y, x, z);
+
+	//CHECK_ALL: _Array_ptr<_Array_ptr<_Array_ptr<int>>> t2 =  malloc3d(y, x, z);
+        //CHECK_NOALL: int ***t2 = malloc3d(y, x, z);
 
 	for (i = 0; i < y; ++i) {
 
@@ -75,4 +82,3 @@ int main(void) {
 	return 0;
 
 }
-//CHECK: int ***t2 = malloc3d(y, x, z);

--- a/clang/test/CheckedCRewriter/type_params.c
+++ b/clang/test/CheckedCRewriter/type_params.c
@@ -92,3 +92,39 @@ void arrs() {
   memcpy(p, q, 10*sizeof(int));
   // CHECK: memcpy<int>(p, q, 10*sizeof(int));
 }
+
+_Itype_for_any(T) void *test1(void * t : itype(_Ptr<T>)) : itype(_Ptr<T>);
+_Itype_for_any(T) void *test2(void) : itype(_Ptr<T>);
+
+void f0() {
+  int **a = test2();
+  // CHECK: _Ptr<int *> a =  test2<int *>();
+  *a = (int*)1;
+}
+
+void f1(int **a, float **b) {
+// CHECK: void f1(_Ptr<_Ptr<int>> a, _Ptr<_Ptr<float>> b) {
+  int **c = test1(a);
+  float **d = test1(b);
+  // CHECK: _Ptr<_Ptr<int>> c =  test1<_Ptr<int>>(a);
+  // CHECK: _Ptr<_Ptr<float>> d =  test1<_Ptr<float>>(b);
+}
+
+void f2(int **a, int **c) {
+// CHECK: void f2(_Ptr<_Ptr<int>> a, int **c) {
+  int **b = test1(a);
+  // CHECK: _Ptr<_Ptr<int>> b =  test1<_Ptr<int>>(a);
+  int *d = test1(c);
+  // CHECK: int *d = test1(c);
+}
+
+void deep(int ****v, int ****w, int ****x, int ****y, int ****z) {
+  // CHECK: void deep(_Ptr<_Ptr<_Ptr<int *>>> v, _Ptr<_Ptr<_Ptr<int *>>> w, _Ptr<_Ptr<_Ptr<int *>>> x, _Ptr<_Ptr<_Ptr<int *>>> y, _Ptr<_Ptr<_Ptr<int *>>> z) {
+  int ****u = test_many(v, w, x, y, z);
+  // CHECK: _Ptr<_Ptr<_Ptr<int *>>> u =  test_many<_Ptr<_Ptr<int *>>>(v, w, x, y, z);
+  ***w = (int*) 1;
+
+  int ******a = malloc(sizeof(int*****));
+  // CHECK: _Ptr<_Ptr<_Ptr<_Ptr<int **>>>> a =  malloc<_Ptr<_Ptr<_Ptr<int **>>>>(sizeof(int*****));
+  ****a = (int**) 1;
+}


### PR DESCRIPTION
Fixes 2 bugs (#213) in type argument insertion demonstrated by the test case below. In the first function, the type parameter was instantiated to `_Ptr<int>` even though `a` is used unsafely. In the second function, the local variable is rewritten to `_Ptr<int>` even though the type parameter could not be instantiated. 

```c
_Itype_for_any(T) void *test1(void) : itype(_Ptr<T>);
_Itype_for_any(T) void *test2(void * t : itype(_Ptr<T>)) : itype(_Ptr<T>);

void f0() {
  int **a = test2();
  // CHECK: _Ptr<int *> a =  test2<int *>();
  *a = (int*)1;
}

void f1(int **a) {
// CHECK: void f1( int **a) {
  int *b = test1(a);
  // CHECK: int *b = test1(a);
}
```

A big part of this fix was modifiy constraint generation on function calls so that  the constraint graph for this function

```c
_Itype_for_any(T) void *test(void * t : itype(_Ptr<T>)) : itype(_Ptr<T>);

void make(int **a) {
 int *b = test(a);
}
``` 

![](https://user-images.githubusercontent.com/7480329/89800798-40fb1800-dafd-11ea-96be-ae06745134c0.png)

instead looks like 

![implication_constraints_graph dot](https://user-images.githubusercontent.com/7480329/90179754-efac8c00-dd7b-11ea-89fa-94d66d084f6d.png)

so that the wild constraint can reach  `b`. 


