### PR TITLE
Check for explicit void type arguments

### DIFF
--- a/clang/include/clang/CConv/TypeVariableAnalysis.h
+++ b/clang/include/clang/CConv/TypeVariableAnalysis.h
@@ -25,7 +25,8 @@ public:
       TypeParamConsVar(nullptr) {
     // We'll need a name to provide the type arguments during rewriting, so no
     // anonymous types are allowed.
-    IsConsistent = !isTypeAnonymous(Ty->getPointeeOrArrayElementType());
+    IsConsistent = (Ty->isPointerType() || Ty->isArrayType()) &&
+                   !isTypeAnonymous(Ty->getPointeeOrArrayElementType());
     TyVarType = Ty;
     ArgConsVars = CVs;
   }

--- a/clang/test/CheckedCRewriter/type_params.c
+++ b/clang/test/CheckedCRewriter/type_params.c
@@ -128,3 +128,25 @@ void deep(int ****v, int ****w, int ****x, int ****y, int ****z) {
   // CHECK: _Ptr<_Ptr<_Ptr<_Ptr<int **>>>> a =  malloc<_Ptr<_Ptr<_Ptr<int **>>>>(sizeof(int*****));
   ****a = (int**) 1;
 }
+
+// Issue #233. Void type paramters were not being detect hy typeArgsProvidedCheck
+
+_Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
+
+// void provided
+void *example0(void * ptr, unsigned int size) {
+// CHECK: void *example0(void * ptr, unsigned int size) {
+    void *ret;
+    ret = realloc<void>(ptr, size);
+    // CHECK: ret = realloc<void>(ptr, size);
+    return ret;
+}
+
+// nothing provided
+void *example1(void * ptr, unsigned int size) {
+// CHECK: void *example1(void * ptr, unsigned int size) {
+    void *ret;
+    ret = realloc(ptr, size);
+    // CHECK: ret = realloc<void>(ptr, size);
+    return ret;
+}

--- a/clang/test/CheckedCRewriter/type_params.c
+++ b/clang/test/CheckedCRewriter/type_params.c
@@ -67,6 +67,13 @@ void t7(int *a, int *b, int *c, int *d, int *e) {
   //CHECK: test_many(a, b, &f, d, e);
 }
 
+void unsafe(int *a) {
+// CHECK: void unsafe(int *a) {
+  int b = 0;
+  test_single(a, b);
+  // CHECK: test_single(a, b);
+}
+
 // Example issue 153
 
 typedef unsigned long size_t;


### PR DESCRIPTION
This turned out to be a quicker fix than I was expecting it to be. 