### PR TITLE
Avoid inserting redundant casts on itype arguments on successive invocations 

### DIFF
--- a/clang/include/clang/CConv/CastPlacement.h
+++ b/clang/include/clang/CConv/CastPlacement.h
@@ -12,40 +12,23 @@
 #ifndef _CASTPLACEMENT_H
 #define _CASTPLACEMENT_H
 #include "clang/CConv/ConstraintResolver.h"
-#include "clang/CConv/RewriteUtils.h"
-#include "clang/CConv/Utils.h"
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/CConv/ArrayBoundsInferenceConsumer.h"
-#include "clang/CConv/CCGlobalOptions.h"
-#include "clang/CConv/MappingVisitor.h"
-#include "llvm/Support/raw_ostream.h"
-#include "clang/Tooling/Refactoring/SourceCode.h"
-#include <sstream>
 
-using namespace clang;
+class CastPlacementVisitor : public RecursiveASTVisitor<CastPlacementVisitor> {
+public:
+  explicit CastPlacementVisitor(ASTContext *C, ProgramInfo &I, Rewriter &R)
+      : Context(C), Info(I), Writer(R), CR(Info, Context) {}
 
-class CastPlacementVisitor :
-  public RecursiveASTVisitor<CastPlacementVisitor> { 
-    public:
-      explicit CastPlacementVisitor(ASTContext *C, ProgramInfo &I, Rewriter &R)
-        : Context(C), Info(I), Writer(R), CR(Info, Context)
-      {}
+  bool VisitCallExpr(CallExpr* C);
+private:
+  ASTContext* Context;
+  ProgramInfo& Info;
+  Rewriter& Writer;
+  ConstraintResolver CR;
 
-      bool VisitCallExpr(CallExpr* C);
-
-    private:
-
-      bool needCasting(ConstraintVariable*, ConstraintVariable*, IsChecked);
-      std::string getCastString(ConstraintVariable *Src, 
-                                ConstraintVariable *Dst,
-                                IsChecked Dinfo) ;
-      void surroundByCast(std::string, Expr*);
-
-
-      ASTContext* Context;
-      ProgramInfo& Info;
-      Rewriter& Writer;
-      ConstraintResolver CR;
-
+  bool needCasting(ConstraintVariable*, ConstraintVariable*, IsChecked);
+  std::string getCastString(ConstraintVariable *Src, ConstraintVariable *Dst,
+                            IsChecked Dinfo) ;
+  void surroundByCast(const std::string&, Expr*);
 };
 #endif // _CASTPLACEMENT_H

--- a/clang/include/clang/CConv/ConstraintsGraph.h
+++ b/clang/include/clang/CConv/ConstraintsGraph.h
@@ -268,11 +268,11 @@ template<> struct GraphTraits<GraphVizOutputGraph> {
                   decltype(&GetTargetNode)>;
 
   static nodes_iterator nodes_begin(const GraphVizOutputGraph &G) {
-    return const_cast<GraphVizOutputGraph&>(G).Nodes.begin();
+    return const_cast<GraphVizOutputGraph &>(G).Nodes.begin();
   }
 
   static nodes_iterator nodes_end(const GraphVizOutputGraph &G) {
-    return const_cast<GraphVizOutputGraph&>(G).Nodes.end();
+    return const_cast<GraphVizOutputGraph &>(G).Nodes.end();
   }
 
   static ChildIteratorType child_begin(NodeRef N) {
@@ -286,7 +286,7 @@ template<> struct GraphTraits<GraphVizOutputGraph> {
 
 template<> struct DOTGraphTraits<GraphVizOutputGraph>
     : public llvm::DefaultDOTGraphTraits,
-             llvm::GraphTraits<GraphVizOutputGraph> {
+      llvm::GraphTraits<GraphVizOutputGraph> {
   DOTGraphTraits(bool simple = false) : DefaultDOTGraphTraits(simple) {}
 
   std::string getNodeLabel(const DataNode<Atom *, GraphVizEdge> *Node,

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -94,7 +94,7 @@ public:
 
   // Parameter map is used for cast insertion, post-rewriting
   void merge_MF(ParameterMap &MF);
-  ParameterMap &get_MF();
+  ParameterMap &getMF();
 
   ConstraintsInfo &getInterimConstraintState() {
     return CState;

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -9,77 +9,55 @@
 // classes of CastPlacement.h
 //===----------------------------------------------------------------------===//
 
+#include <clang/Tooling/Refactoring/SourceCode.h>
 #include "clang/CConv/ConstraintResolver.h"
-#include "clang/CConv/RewriteUtils.h"
-#include "clang/CConv/Utils.h"
-#include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/CConv/ArrayBoundsInferenceConsumer.h"
-#include "clang/CConv/CCGlobalOptions.h"
-#include "clang/CConv/MappingVisitor.h"
 #include "clang/CConv/CastPlacement.h"
-#include "llvm/Support/raw_ostream.h"
-#include "clang/Tooling/Refactoring/SourceCode.h"
-#include <sstream>
+#include "clang/CConv/CCGlobalOptions.h"
 
 using namespace clang;
 
-
 bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
   Decl *D = CE->getCalleeDecl();
-  if (Rewriter::isRewritable(CE->getExprLoc()) && D) {
+  if (D != nullptr && Rewriter::isRewritable(CE->getExprLoc())) {
     PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(CE, *Context);
-    if (FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+    if (auto *FD = dyn_cast<FunctionDecl>(D)) {
       // Get the constraint variable for the function.
       std::set<FVConstraint *> *V = Info.getFuncConstraints(FD, Context);
       // Function has no definition i.e., external function.
-      assert(V);
-//        if (V == nullptr) {
-//          V = Info.getFuncDeclConstraints(FD, Context);
-//        }
-      // TODO Deubgging lines
-      // llvm::errs() << "Decl for: " << FD->getNameAsString() << "\nVars:";
-      // for (auto &CV : V) {
-      //   CV->dump();
-      //   llvm::errs() << "\n";
-      // }
+      assert("Function has no definition" && V != nullptr);
 
       // Did we see this function in another file?
       auto Fname = FD->getNameAsString();
-      auto PInfo = Info.get_MF()[Fname];
-
-      if (V != nullptr && V->size() > 0 &&
-          !ConstraintResolver::canFunctionBeSkipped(Fname)) {
+      if (!V->empty() && !ConstraintResolver::canFunctionBeSkipped(Fname)) {
         // Get the FV constraint for the Callee.
         FVConstraint *FV = *(V->begin());
         // Now we need to check the type of the arguments and corresponding
-        // parameters to see, if any explicit casting is needed.
+        // parameters to see if any explicit casting is needed.
         if (FV) {
           ProgramInfo::CallTypeParamBindingsT TypeVars;
           if (Info.hasTypeParamBindings(CE, Context))
             TypeVars = Info.getTypeParamBindings(CE, Context);
-          unsigned i = 0;
+          auto PInfo = Info.get_MF()[Fname];
+          unsigned PIdx = 0;
           for (const auto &A : CE->arguments()) {
-            if (i < FD->getNumParams()) {
+            if (PIdx < FD->getNumParams()) {
 
               // Avoid adding incorrect casts to generic function arguments by
               // removing implicit casts when on arguments with a consistently
               // used generic type.
-              CVarSet ArgumentConstraints;
+              Expr *ArgExpr = A;
               const TypeVariableType
-                  *TyVar = getTypeVariableType(FD->getParamDecl(i));
+                  *TyVar = getTypeVariableType(FD->getParamDecl(PIdx));
               if (TyVar && TypeVars.find(TyVar->GetIndex()) != TypeVars.end()
                   && TypeVars[TyVar->GetIndex()] != nullptr)
-                ArgumentConstraints =
-                    CR.getExprConstraintVars(A->IgnoreImpCasts());
-              else
-                ArgumentConstraints = CR.getExprConstraintVars(A);
-              CVarSet &ParameterConstraints =
-                  FV->getParamVar(i);
-              bool CastInserted = false;
+                ArgExpr = ArgExpr->IgnoreImpCasts();
+
+              CVarSet ArgumentConstraints = CR.getExprConstraintVars(ArgExpr);
+              CVarSet &ParameterConstraints = FV->getParamVar(PIdx);
               for (auto *ArgumentC : ArgumentConstraints) {
-                CastInserted = false;
+                bool CastInserted = false;
                 for (auto *ParameterC : ParameterConstraints) {
-                  auto Dinfo = i < PInfo.size() ? PInfo[i] : CHECKED;
+                  auto Dinfo = PIdx < PInfo.size() ? PInfo[PIdx] : CHECKED;
                   if (needCasting(ArgumentC, ParameterC, Dinfo)) {
                     // We expect the cast string to end with "(".
                     std::string CastString =
@@ -92,9 +70,8 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
                 // If we have already inserted a cast, then break.
                 if (CastInserted) break;
               }
-
             }
-            i++;
+            PIdx++;
           }
         }
       }
@@ -110,35 +87,30 @@ bool CastPlacementVisitor::needCasting(ConstraintVariable *Src,
                                        ConstraintVariable *Dst,
                                        IsChecked Dinfo) {
   auto &E = Info.getConstraints().getVariables();
-  auto SrcChecked = Src->isChecked(E);
   // Check if the src is a checked type.
-  if (SrcChecked) {
-    // Check if Dst is an itype, if yes then
-    // Src should have exactly same checked type else we need to insert cast.
-    if (Dst->hasItype()) {
-    return !Dst->solutionEqualTo(Info.getConstraints(), Src);
-    }
+  if (Src->isChecked(E)) {
+    // If Dst has an itype, Src must have exactly the same checked type. If this
+    // is not the case, we must insert a case.
+    if (Dst->hasItype())
+      return !Dst->solutionEqualTo(Info.getConstraints(), Src);
 
     // Is Dst Wild?
-    if (!Dst->isChecked(E) || Dinfo == WILD) {
+    if (!Dst->isChecked(E) || Dinfo == WILD)
       return true;
-    }
-
-  } return false; }
+  }
+  return false;
+}
 
 // Get the type name to insert for casting.
 std::string CastPlacementVisitor::getCastString(ConstraintVariable *Src,
                                                 ConstraintVariable *Dst,
                                                 IsChecked Dinfo) {
   assert(needCasting(Src, Dst, Dinfo) && "No casting needed.");
-  // The destination type should be a non-checked type.
-  // This is not necessary because of itypes
-  //auto &E = Info.getConstraints().getVariables();
-  //assert(!Dst->anyChanges(E) || Dinfo == WILD);
   return "((" + Dst->getRewritableOriginalTy() + ")";
 }
 
-void CastPlacementVisitor::surroundByCast(std::string CastPrefix, Expr *E) {
+void CastPlacementVisitor::surroundByCast(const std::string &CastPrefix,
+                                          Expr *E) {
   if (Writer.InsertTextAfterToken(E->getEndLoc(), ")")) {
     // This means we failed to insert the text at the end of the RHS.
     // This can happen because of Macro expansion.
@@ -146,7 +118,7 @@ void CastPlacementVisitor::surroundByCast(std::string CastPrefix, Expr *E) {
     // If yes, then we will use parent statement to add ")"
     auto CRA = CharSourceRange::getTokenRange(E->getSourceRange());
     auto NewCRA = clang::Lexer::makeFileCharRange(CRA,
-                                                Context->getSourceManager(),
+                                                  Context->getSourceManager(),
                                                   Context->getLangOpts());
     std::string SrcText = clang::tooling::getText(CRA, *Context);
     // Only insert if there is anything to write.

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -32,7 +32,7 @@ void ProgramInfo::merge_MF(ParameterMap &mf) {
 }
 
 
-ParameterMap &ProgramInfo::get_MF() {
+ParameterMap &ProgramInfo::getMF() {
   return MF;
 }
 

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -383,7 +383,6 @@ void RewriteConsumer::HandleTranslationUnit(ASTContext &Context) {
   TypeArgumentAdder TPA(&Context, Info, R);
   TranslationUnitDecl *TUD = Context.getTranslationUnitDecl();
   for (const auto &D : TUD->decls()) {
-    ECPV.TraverseDecl(D);
     if (AddCheckedRegions) {
       // Adding checked regions enabled!?
       // TODO: Should checked region finding happen somewhere else? This is
@@ -392,6 +391,10 @@ void RewriteConsumer::HandleTranslationUnit(ASTContext &Context) {
       CRA.TraverseDecl(D);
     }
     TER.TraverseDecl(D);
+    // Cast placement must happen after type expression rewriting (i.e. cast and
+    // compound literal) so that casts to unchecked pointer on itype function
+    // calls can override rewritings of casts to checked types.
+    ECPV.TraverseDecl(D);
     TPA.TraverseDecl(D);
   }
 

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -14,6 +14,7 @@
 #include "clang/CConv/CheckedRegions.h"
 #include "clang/CConv/DeclRewriter.h"
 #include "clang/Tooling/Refactoring/SourceCode.h"
+#include "clang/CConv/CCGlobalOptions.h"
 
 using namespace llvm;
 using namespace clang;

--- a/clang/test/CheckedCRewriter/itypecast.c
+++ b/clang/test/CheckedCRewriter/itypecast.c
@@ -8,7 +8,6 @@
 // RUN: cconv-standalone -output-postfix=checked %s 
 // RUN: cconv-standalone %S/itypecast.checked.c -- | diff -w %S/itypecast.checked.c -
 // RUN: rm %S/itypecast.checked.c
-// XFAIL: *
 
 int foo(int **p:itype(_Ptr<_Ptr<int>>));
 int bar(int **p:itype(_Ptr<int *>));
@@ -49,3 +48,19 @@ int func(void) {
 //CHECK-NEXT: fptr1(2, 0);
 //CHECK-NEXT: baz(((int ((*)(const int *, const int *)) )fptr1));
 //CHECK-NEXT: baz(fptr2);
+
+int func2(void) {
+    int **fp1;
+    // CHECK: _Ptr<int *> fp1 = ((void *)0);
+    *fp1 = 1;
+    foo(fp1);
+    // CHECK: foo(((int **)fp1));
+}
+
+int func3(void) {
+    _Ptr<int *> fp1 = ((void *)0);
+    // CHECK: _Ptr<int *> fp1 = ((void *)0);
+    *fp1 = 1;
+    foo(((int **)fp1));
+    // CHECK: foo(((int **)fp1));
+}


### PR DESCRIPTION
Fix the cast insertion problem brought up in issue #231 where unnecessary casts would be added onto arguments to itype functions in successive invocations of 3C. To fix this, the cast insertion visitor checks if a cast already exists on and expression when inserting a new cast. If there is a cast, the existing cast type is replaced by the new cast type.