### PR TITLE
Refactoring to remove singleton ConstraintVariable sets

### DIFF
--- a/clang/include/clang/CConv/CheckedRegions.h
+++ b/clang/include/clang/CConv/CheckedRegions.h
@@ -83,8 +83,8 @@ class CheckedRegionFinder : public clang::RecursiveASTVisitor<CheckedRegionFinde
     bool containsUncheckedPtr(clang::QualType Qt);
     bool containsUncheckedPtrAcc(clang::QualType Qt, std::set<std::string> &Seen);
     bool isUncheckedStruct(clang::QualType Qt, std::set<std::string> &Seen);
-    bool isWild(std::set<ConstraintVariable*>&);
-    bool isWild(std::set<FVConstraint*>*);
+    bool isWild(const std::set<ConstraintVariable*>&);
+    bool isWild(const std::set<FVConstraint*>*);
 
     clang::ASTContext* Context;
     clang::Rewriter& Writer;

--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -46,8 +46,10 @@ public:
 
   // Check if the set contains any valid constraints.
   bool containsValidCons(CVarSet &CVs);
+  bool isValidCons(ConstraintVariable *CV);
   // Try to get the bounds key from the constraint variable set.
   bool resolveBoundsKey(CVarSet &CVs, BoundsKey &BK);
+  bool resolveBoundsKey(ConstraintVariable *CV, BoundsKey &BK);
 
   static bool canFunctionBeSkipped(const std::string &FN);
 

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -379,7 +379,7 @@ private:
   FunctionVariableConstraint(FunctionVariableConstraint *Ot,
                              Constraints &CS);
   // N constraints on the return value of the function.
-  std::set<ConstraintVariable *> returnVars;
+  ConstraintVariable *returnVars;
   // A vector of K sets of N constraints on the parameter values, for
   // K parameters accepted by the function.
   std::vector<std::set<ConstraintVariable *>> paramVars;
@@ -410,7 +410,7 @@ public:
                              clang::DeclaratorDecl *D, std::string N,
                              ProgramInfo &I, const clang::ASTContext &C);
 
-  const std::set<ConstraintVariable *> &getReturnVars() const {
+  ConstraintVariable *getReturnVars() const {
     return returnVars;
   }
 
@@ -465,7 +465,7 @@ public:
   // An FVConstraint is empty if every constraint associated is empty.
   bool isEmpty(void) const override {
 
-    if (returnVars.size() > 0)
+    if (returnVars != nullptr)
       return false;
 
     for (const auto &u : paramVars)

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -394,8 +394,7 @@ private:
   // Flag to indicate whether this is a function pointer or not.
   bool IsFunctionPtr;
 
-  void equateFVConstraintVars(const std::set<ConstraintVariable *> &Cset,
-                              ProgramInfo &Info) const;
+  void equateFVConstraintVars(ConstraintVariable *CV, ProgramInfo &Info) const;
 
 public:
   FunctionVariableConstraint() :

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -171,11 +171,11 @@ enum ConsAction {
 
 void constrainConsVarGeq(const std::set<ConstraintVariable *> &LHS,
                          const std::set<ConstraintVariable *> &RHS,
-                         Constraints &CS,
-                         PersistentSourceLoc *PL,
-                         ConsAction CA,
-                         bool doEqType,
-                         ProgramInfo *Info);
+                         Constraints &CS, PersistentSourceLoc *PL,
+                         ConsAction CA, bool doEqType, ProgramInfo *Info);
+void constrainConsVarGeq(ConstraintVariable *LHS, const CVarSet &RHS,
+                         Constraints &CS, PersistentSourceLoc *PL,
+                         ConsAction CA, bool doEqType, ProgramInfo *Info);
 void constrainConsVarGeq(ConstraintVariable *LHS, ConstraintVariable *RHS,
                          Constraints &CS, PersistentSourceLoc *PL,
                          ConsAction CA, bool doEqType, ProgramInfo *Info);

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -284,7 +284,7 @@ public:
 
   // Is an itype present for this constraint? If yes,
   // what is the text of that itype?
-  bool hasItype() const { return ItypeStr.size() > 0; }
+  bool hasItype() const override { return ItypeStr.size() > 0; }
   std::string getItype() const { return ItypeStr; }
   // Check if this variable has bounds annotation.
   bool hasBoundsStr() const { return !BoundsAnnotationStr.empty(); }
@@ -295,7 +295,8 @@ public:
 
   bool getIsOriginallyChecked() const override { return OriginallyChecked; }
 
-  bool solutionEqualTo(Constraints &CS, const ConstraintVariable *CV) const;
+  bool solutionEqualTo(Constraints &CS,
+                       const ConstraintVariable *CV) const override;
 
   // Constructor for when we have a Decl. K is the current free
   // constraint variable index. We don't need to explicitly pass
@@ -314,33 +315,34 @@ public:
 
   const CAtoms &getCvars() const { return vars; }
 
-  void brainTransplant(ConstraintVariable *From, ProgramInfo &I);
-  void mergeDeclaration(ConstraintVariable *From, ProgramInfo &I);
+  void brainTransplant(ConstraintVariable *From, ProgramInfo &I) override;
+  void mergeDeclaration(ConstraintVariable *From, ProgramInfo &I) override;
 
   static bool classof(const ConstraintVariable *S) {
     return S->getKind() == PointerVariable;
   }
 
   std::string mkString(EnvironmentMap &E, bool EmitName =true,
-                       bool ForItype =false, bool EmitPointee = false) const;
+                       bool ForItype = false,
+                       bool EmitPointee = false) const override;
 
   FunctionVariableConstraint *getFV() const { return FV; }
 
-  void print(llvm::raw_ostream &O) const ;
-  void dump() const { print(llvm::errs()); }
-  void dump_json(llvm::raw_ostream &O) const;
-  void constrainToWild(Constraints &CS) const;
-  void constrainToWild(Constraints &CS, const std::string &Rsn) const;
+  void print(llvm::raw_ostream &O) const override ;
+  void dump() const override { print(llvm::errs()); }
+  void dump_json(llvm::raw_ostream &O) const override;
+  void constrainToWild(Constraints &CS) const override;
+  void constrainToWild(Constraints &CS, const std::string &Rsn) const override;
   void constrainToWild(Constraints &CS, const std::string &Rsn,
-                       PersistentSourceLoc *PL) const;
+                       PersistentSourceLoc *PL) const override;
   void constrainOuterTo(Constraints &CS, ConstAtom *C, bool doLB = false);
-  bool anyChanges(EnvironmentMap &E) const;
+  bool anyChanges(EnvironmentMap &E) const override;
   bool anyArgumentIsWild(EnvironmentMap &E);
-  bool hasWild(EnvironmentMap &E, int AIdx = -1) const;
-  bool hasArr(EnvironmentMap &E, int AIdx = -1) const;
-  bool hasNtArr(EnvironmentMap &E, int AIdx = -1) const;
+  bool hasWild(EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasArr(EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasNtArr(EnvironmentMap &E, int AIdx = -1) const override;
 
-  void equateArgumentConstraints(ProgramInfo &I);
+  void equateArgumentConstraints(ProgramInfo &I) override;
 
   bool isPartOfFunctionPrototype() const  { return partOFFuncPrototype; }
   // Add the provided constraint variable as an argument constraint.
@@ -348,16 +350,16 @@ public:
   // Get the set of constraint variables corresponding to the arguments.
   const std::set<ConstraintVariable *> &getArgumentConstraints() const;
 
-  bool isEmpty(void) const { return vars.size() == 0; }
+  bool isEmpty(void) const override { return vars.size() == 0; }
 
-  ConstraintVariable *getCopy(Constraints &CS);
+  ConstraintVariable *getCopy(Constraints &CS) override;
 
   // Retrieve the atom at the specified index. This function includes special
   // handling for generic constraint variables to create deeper pointers as
   // they are needed.
   Atom *getAtom(unsigned int AtomIdx, Constraints &CS);
 
-  virtual ~PointerVariableConstraint() {};
+  ~PointerVariableConstraint() override {};
 };
 
 typedef PointerVariableConstraint PVConstraint;
@@ -429,37 +431,39 @@ public:
     return S->getKind() == FunctionVariable;
   }
 
-  void brainTransplant(ConstraintVariable *From, ProgramInfo &I);
-  void mergeDeclaration(ConstraintVariable *FromCV, ProgramInfo &I);
+  void brainTransplant(ConstraintVariable *From, ProgramInfo &I) override;
+  void mergeDeclaration(ConstraintVariable *FromCV, ProgramInfo &I) override;
 
   const std::set<ConstraintVariable *> &getParamVar(unsigned i) const {
     assert(i < paramVars.size());
     return paramVars.at(i);
   }
 
-  bool hasItype() const;
-  bool solutionEqualTo(Constraints &CS, const ConstraintVariable *CV) const;
+  bool hasItype() const override;
+  bool solutionEqualTo(Constraints &CS,
+                       const ConstraintVariable *CV) const override;
 
   std::string mkString(EnvironmentMap &E, bool EmitName =true,
-                       bool ForItype =false, bool EmitPointee=false) const;
-  void print(llvm::raw_ostream &O) const;
-  void dump() const { print(llvm::errs()); }
-  void dump_json(llvm::raw_ostream &O) const;
-  void constrainToWild(Constraints &CS) const;
-  void constrainToWild(Constraints &CS, const std::string &Rsn) const;
+                       bool ForItype = false,
+                       bool EmitPointee = false) const override;
+  void print(llvm::raw_ostream &O) const override;
+  void dump() const override { print(llvm::errs()); }
+  void dump_json(llvm::raw_ostream &O) const override;
+  void constrainToWild(Constraints &CS) const override;
+  void constrainToWild(Constraints &CS, const std::string &Rsn) const override;
   void constrainToWild(Constraints &CS, const std::string &Rsn,
-                       PersistentSourceLoc *PL) const;
-  bool anyChanges(EnvironmentMap &E) const;
-  bool hasWild(EnvironmentMap &E, int AIdx = -1) const;
-  bool hasArr(EnvironmentMap &E, int AIdx = -1) const;
-  bool hasNtArr(EnvironmentMap &E, int AIdx = -1) const;
+                       PersistentSourceLoc *PL) const override;
+  bool anyChanges(EnvironmentMap &E) const override;
+  bool hasWild(EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasArr(EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasNtArr(EnvironmentMap &E, int AIdx = -1) const override;
 
-  void equateArgumentConstraints(ProgramInfo &P);
+  void equateArgumentConstraints(ProgramInfo &P) override;
 
-  ConstraintVariable *getCopy(Constraints &CS);
+  ConstraintVariable *getCopy(Constraints &CS) override;
 
   // An FVConstraint is empty if every constraint associated is empty.
-  bool isEmpty(void) const {
+  bool isEmpty(void) const override {
 
     if (returnVars.size() > 0)
       return false;
@@ -474,7 +478,7 @@ public:
 
   bool getIsOriginallyChecked() const override;
 
-  virtual ~FunctionVariableConstraint() {};
+  ~FunctionVariableConstraint() override {};
 };
 
 typedef FunctionVariableConstraint FVConstraint;

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -382,7 +382,7 @@ private:
   ConstraintVariable *returnVars;
   // A vector of K sets of N constraints on the parameter values, for
   // K parameters accepted by the function.
-  std::vector<std::set<ConstraintVariable *>> paramVars;
+  std::vector<ConstraintVariable *> paramVars;
   // Storing of parameters in the case of untyped prototypes
   std::vector<ParamDeferment> deferredParams;
   // File name in which this declaration is found.
@@ -434,7 +434,7 @@ public:
   void brainTransplant(ConstraintVariable *From, ProgramInfo &I) override;
   void mergeDeclaration(ConstraintVariable *FromCV, ProgramInfo &I) override;
 
-  const std::set<ConstraintVariable *> &getParamVar(unsigned i) const {
+  ConstraintVariable *getParamVar(unsigned i) const {
     assert(i < paramVars.size());
     return paramVars.at(i);
   }
@@ -469,9 +469,8 @@ public:
       return false;
 
     for (const auto &u : paramVars)
-      for (const auto &v : u)
-        if (!v->isEmpty())
-          return false;
+      if (!u->isEmpty())
+        return false;
 
     return true;
   }

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -379,10 +379,10 @@ private:
   FunctionVariableConstraint(FunctionVariableConstraint *Ot,
                              Constraints &CS);
   // N constraints on the return value of the function.
-  ConstraintVariable *returnVars;
+  ConstraintVariable *ReturnVar;
   // A vector of K sets of N constraints on the parameter values, for
   // K parameters accepted by the function.
-  std::vector<ConstraintVariable *> paramVars;
+  std::vector<ConstraintVariable *> ParamVars;
   // Storing of parameters in the case of untyped prototypes
   std::vector<ParamDeferment> deferredParams;
   // File name in which this declaration is found.
@@ -410,8 +410,8 @@ public:
                              clang::DeclaratorDecl *D, std::string N,
                              ProgramInfo &I, const clang::ASTContext &C);
 
-  ConstraintVariable *getReturnVars() const {
-    return returnVars;
+  ConstraintVariable *getReturnVar() const {
+    return ReturnVar;
   }
 
   const std::vector<ParamDeferment> &getDeferredParams() const {
@@ -421,7 +421,7 @@ public:
   void addDeferredParams(PersistentSourceLoc PL,
                          std::vector<CVarSet> Ps);
 
-  size_t numParams() const { return paramVars.size(); }
+  size_t numParams() const { return ParamVars.size(); }
 
   bool hasProtoType() const { return Hasproto; }
   bool hasBody() const { return Hasbody; }
@@ -435,8 +435,8 @@ public:
   void mergeDeclaration(ConstraintVariable *FromCV, ProgramInfo &I) override;
 
   ConstraintVariable *getParamVar(unsigned i) const {
-    assert(i < paramVars.size());
-    return paramVars.at(i);
+    assert(i < ParamVars.size());
+    return ParamVars.at(i);
   }
 
   bool hasItype() const override;
@@ -465,10 +465,10 @@ public:
   // An FVConstraint is empty if every constraint associated is empty.
   bool isEmpty(void) const override {
 
-    if (returnVars != nullptr)
+    if (ReturnVar != nullptr)
       return false;
 
-    for (const auto &u : paramVars)
+    for (const auto &u : ParamVars)
       if (!u->isEmpty())
         return false;
 

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -45,18 +45,19 @@ public:
   typedef std::map<PersistentSourceLoc, CallTypeParamBindingsT>
       TypeParamBindingsT;
 
-  typedef std::map<std::string, std::map<std::string, std::set<FVConstraint *>>>
-      StaticFunctionMapType;
 
-  typedef std::map<std::string, std::set<FVConstraint *>>
+  typedef std::map<std::string, const std::set<FVConstraint *>>
       ExternalFunctionMapType;
+  typedef std::map<std::string, ExternalFunctionMapType> StaticFunctionMapType;
 
   ProgramInfo();
   void print(llvm::raw_ostream &O) const;
   void dump() const { print(llvm::errs()); }
   void dump_json(llvm::raw_ostream &O) const;
-  void dump_stats(std::set<std::string> &F) { print_stats(F, llvm::errs()); }
-  void print_stats(std::set<std::string> &F, llvm::raw_ostream &O,
+  void dump_stats(const std::set<std::string> &F) {
+    print_stats(F, llvm::errs());
+  }
+  void print_stats(const std::set<std::string> &F, llvm::raw_ostream &O,
                    bool OnlySummary = false, bool JsonFormat = false);
 
   // Populate Variables, VarDeclToStatement, RVariables, and DepthMap with
@@ -69,16 +70,17 @@ public:
   // should all be empty. 
   void exitCompilationUnit();
 
-  CVarSet
-      &getPersistentConstraintVars(Expr *E, ASTContext *AstContext);
+  CVarSet &getPersistentConstraintVars(Expr *E, ASTContext *AstContext);
   // Get constraint variable for the provided Decl
-  CVarSet getVariable(clang::Decl *D,
-                                             clang::ASTContext *C);
+  CVarSet getVariable(clang::Decl *D, clang::ASTContext *C);
 
   // Retrieve a function's constraints by decl, or by name; nullptr if not found
-  std::set<FVConstraint *> *getFuncConstraints(FunctionDecl *D, ASTContext *C);
-  std::set<FVConstraint *> *getExtFuncDefnConstraintSet(std::string FuncName);
-  std::set<FVConstraint *> *getStaticFuncConstraintSet(std::string FuncName, std::string FileName);
+  const std::set<FVConstraint *> *getFuncConstraints
+      (FunctionDecl *D, ASTContext *C) const;
+  const std::set<FVConstraint *> *getExtFuncDefnConstraintSet
+      (std::string FuncName) const;
+  const std::set<FVConstraint *> *getStaticFuncConstraintSet
+      (std::string FuncName, std::string FileName) const;
 
   // Check if the given function is an extern function.
   bool isAnExternFunction(const std::string &FName);
@@ -93,26 +95,27 @@ public:
   AVarBoundsInfo &getABoundsInfo() { return ArrBInfo; }
 
   // Parameter map is used for cast insertion, post-rewriting
-  void merge_MF(ParameterMap &MF);
+  void merge_MF(const ParameterMap &MF);
   ParameterMap &getMF();
 
   ConstraintsInfo &getInterimConstraintState() {
     return CState;
   }
-  bool computeInterimConstraintState(std::set<std::string> &FilePaths);
+  bool computeInterimConstraintState(const std::set<std::string> &FilePaths);
 
-  ExternalFunctionMapType &getExternFuncDefFVMap() {
+  const ExternalFunctionMapType &getExternFuncDefFVMap() const {
     return ExternalFunctionFVCons;
   }
 
-  StaticFunctionMapType &getStaticFuncDefFVMap() {
+  const StaticFunctionMapType &getStaticFuncDefFVMap() const {
     return StaticFunctionFVCons;
   }
 
   void setTypeParamBinding(CallExpr *CE, unsigned int TypeVarIdx,
                            ConstraintVariable *CV, ASTContext *C);
-  bool hasTypeParamBindings(CallExpr *CE, ASTContext *C);
-  CallTypeParamBindingsT &getTypeParamBindings(CallExpr *CE, ASTContext *C);
+  bool hasTypeParamBindings(CallExpr *CE, ASTContext *C) const;
+  const CallTypeParamBindingsT &getTypeParamBindings(CallExpr *CE,
+                                                     ASTContext *C) const;
 
   void constrainWildIfMacro(CVarSet &S, SourceLocation Location);
 
@@ -156,14 +159,14 @@ private:
   // Returns true if successful else false.
   bool insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
                                      const std::string &FuncName,
-                                     std::set<FVConstraint *> &ToIns);
+                                     const std::set<FVConstraint *> &ToIns);
 
   // Inserts the given FVConstraint* set into the provided static map.
   // Returns true if successful else false.
   bool insertIntoStaticFunctionMap(StaticFunctionMapType &Map,
                                    const std::string &FuncName,
                                    const std::string &FileName,
-                                   std::set<FVConstraint *> &ToIns);
+                                   const std::set<FVConstraint *> &ToIns);
 
 
   // Special-case handling for decl introductions. For the moment this covers:
@@ -174,13 +177,12 @@ private:
   // Inserts the given FVConstraint* set into the global map, depending
   // on whether static or not; returns true on success
   bool
-  insertNewFVConstraints(FunctionDecl *FD, std::set<FVConstraint *> &FVcons,
-                         ASTContext *C);
+  insertNewFVConstraints(FunctionDecl *FD,
+                         const std::set<FVConstraint *> &FVcons, ASTContext *C);
 
-  // Retrieves a FVConstraint* based on the decl (which could be static,
-  //   or global)
-  std::set<FVConstraint *> *getFuncFVConstraints(FunctionDecl *FD,
-                                                 ASTContext *C);
+  // Retrieves a FVConstraint* from a Decl (which could be static, or global)
+  const std::set<FVConstraint *> *getFuncFVConstraints(FunctionDecl *FD,
+                                                       ASTContext *C);
   // For each pointer type in the declaration of D, add a variable to the
   // constraint system for that pointer type.
   void addVariable(clang::DeclaratorDecl *D, clang::ASTContext *astContext);

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -74,10 +74,10 @@ public:
   CVarSet getVariable(clang::Decl *D, clang::ASTContext *C);
 
   // Retrieve a function's constraints by decl, or by name; nullptr if not found
-  FVConstraint *getFuncConstraints (FunctionDecl *D, ASTContext *C) const;
-  FVConstraint *getExtFuncDefnConstraintSet (std::string FuncName) const;
-  FVConstraint *getStaticFuncConstraintSet(std::string FuncName,
-                                           std::string FileName) const;
+  FVConstraint *getFuncConstraint (FunctionDecl *D, ASTContext *C) const;
+  FVConstraint *getExtFuncDefnConstraint (std::string FuncName) const;
+  FVConstraint *getStaticFuncConstraint(std::string FuncName,
+                                        std::string FileName) const;
 
   // Check if the given function is an extern function.
   bool isAnExternFunction(const std::string &FName);

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -173,11 +173,11 @@ private:
 
   // Inserts the given FVConstraint* set into the global map, depending
   // on whether static or not; returns true on success
-  bool insertNewFVConstraints(FunctionDecl *FD, FVConstraint *FVcons,
-                              ASTContext *C);
+  bool insertNewFVConstraint(FunctionDecl *FD, FVConstraint *FVCon,
+                             ASTContext *C);
 
   // Retrieves a FVConstraint* from a Decl (which could be static, or global)
-  FVConstraint *getFuncFVConstraints(FunctionDecl *FD, ASTContext *C);
+  FVConstraint *getFuncFVConstraint(FunctionDecl *FD, ASTContext *C);
 
   // For each pointer type in the declaration of D, add a variable to the
   // constraint system for that pointer type.

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -46,8 +46,7 @@ public:
       TypeParamBindingsT;
 
 
-  typedef std::map<std::string, const std::set<FVConstraint *>>
-      ExternalFunctionMapType;
+  typedef std::map<std::string, FVConstraint *> ExternalFunctionMapType;
   typedef std::map<std::string, ExternalFunctionMapType> StaticFunctionMapType;
 
   ProgramInfo();
@@ -75,12 +74,10 @@ public:
   CVarSet getVariable(clang::Decl *D, clang::ASTContext *C);
 
   // Retrieve a function's constraints by decl, or by name; nullptr if not found
-  const std::set<FVConstraint *> *getFuncConstraints
-      (FunctionDecl *D, ASTContext *C) const;
-  const std::set<FVConstraint *> *getExtFuncDefnConstraintSet
-      (std::string FuncName) const;
-  const std::set<FVConstraint *> *getStaticFuncConstraintSet
-      (std::string FuncName, std::string FileName) const;
+  FVConstraint *getFuncConstraints (FunctionDecl *D, ASTContext *C) const;
+  FVConstraint *getExtFuncDefnConstraintSet (std::string FuncName) const;
+  FVConstraint *getStaticFuncConstraintSet(std::string FuncName,
+                                           std::string FileName) const;
 
   // Check if the given function is an extern function.
   bool isAnExternFunction(const std::string &FName);
@@ -159,14 +156,14 @@ private:
   // Returns true if successful else false.
   bool insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
                                      const std::string &FuncName,
-                                     const std::set<FVConstraint *> &ToIns);
+                                     FVConstraint *ToIns);
 
   // Inserts the given FVConstraint* set into the provided static map.
   // Returns true if successful else false.
   bool insertIntoStaticFunctionMap(StaticFunctionMapType &Map,
                                    const std::string &FuncName,
                                    const std::string &FileName,
-                                   const std::set<FVConstraint *> &ToIns);
+                                   FVConstraint *ToIns);
 
 
   // Special-case handling for decl introductions. For the moment this covers:
@@ -176,13 +173,12 @@ private:
 
   // Inserts the given FVConstraint* set into the global map, depending
   // on whether static or not; returns true on success
-  bool
-  insertNewFVConstraints(FunctionDecl *FD,
-                         const std::set<FVConstraint *> &FVcons, ASTContext *C);
+  bool insertNewFVConstraints(FunctionDecl *FD, FVConstraint *FVcons,
+                              ASTContext *C);
 
   // Retrieves a FVConstraint* from a Decl (which could be static, or global)
-  const std::set<FVConstraint *> *getFuncFVConstraints(FunctionDecl *FD,
-                                                       ASTContext *C);
+  FVConstraint *getFuncFVConstraints(FunctionDecl *FD, ASTContext *C);
+
   // For each pointer type in the declaration of D, add a variable to the
   // constraint system for that pointer type.
   void addVariable(clang::DeclaratorDecl *D, clang::ASTContext *astContext);

--- a/clang/include/clang/CConv/Utils.h
+++ b/clang/include/clang/CConv/Utils.h
@@ -61,7 +61,7 @@ private:
 extern std::set<std::string> FilePaths;
 
 template <typename T>
-T getOnly(std::set<T> &singletonSet) {
+T getOnly(const std::set<T> &singletonSet) {
   assert(singletonSet.size() == 1);
   return (*singletonSet.begin());
 }

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -679,11 +679,11 @@ bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
         FV = PI->getExtFuncDefnConstraintSet(FuncName);
       }
 
-      if (hasArray(FV->getParamVar(ParmNum), CS)) {
+      if (hasArray({FV->getParamVar(ParmNum)}, CS)) {
         ArrPointers.insert(Bkey);
       }
       // Does this array belongs to a valid program variable?
-      if (isInSrcArray(FV->getParamVar(ParmNum), CS)) {
+      if (isInSrcArray({FV->getParamVar(ParmNum)}, CS)) {
         InProgramArrPtrBoundsKeys.insert(Bkey);
       }
 

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -673,10 +673,10 @@ bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
       bool IsStatic = std::get<2>(ParmTup);
       unsigned ParmNum = std::get<3>(ParmTup);
       FVConstraint *FV = nullptr;
-      if (IsStatic || !PI->getExtFuncDefnConstraintSet(FuncName)) {
-        FV = PI->getStaticFuncConstraintSet(FuncName, FileName);
+      if (IsStatic || !PI->getExtFuncDefnConstraint(FuncName)) {
+        FV = PI->getStaticFuncConstraint(FuncName, FileName);
       } else {
-        FV = PI->getExtFuncDefnConstraintSet(FuncName);
+        FV = PI->getExtFuncDefnConstraint(FuncName);
       }
 
       if (hasArray({FV->getParamVar(ParmNum)}, CS)) {

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -674,9 +674,9 @@ bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
       unsigned ParmNum = std::get<3>(ParmTup);
       FVConstraint *FV = nullptr;
       if (IsStatic || !PI->getExtFuncDefnConstraintSet(FuncName)) {
-        FV = getOnly(*(PI->getStaticFuncConstraintSet(FuncName, FileName)));
+        FV = PI->getStaticFuncConstraintSet(FuncName, FileName);
       } else {
-        FV = getOnly(*(PI->getExtFuncDefnConstraintSet(FuncName)));
+        FV = PI->getExtFuncDefnConstraintSet(FuncName);
       }
 
       if (hasArray(FV->getParamVar(ParmNum), CS)) {

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -333,7 +333,7 @@ void AVarBoundsInfo::insertProgramVar(BoundsKey NK, ProgramVar *PV) {
   PVarInfo[NK] = PV;
 }
 
-bool hasArray(CVarSet &CSet, Constraints &CS) {
+bool hasArray(const CVarSet &CSet, Constraints &CS) {
   auto &E = CS.getVariables();
   for (auto *CK : CSet) {
     if (PVConstraint *PV = dyn_cast<PVConstraint>(CK)) {
@@ -346,7 +346,7 @@ bool hasArray(CVarSet &CSet, Constraints &CS) {
   return false;
 }
 
-bool isInSrcArray(CVarSet &CSet, Constraints &CS) {
+bool isInSrcArray(const CVarSet &CSet, Constraints &CS) {
   auto &E = CS.getVariables();
   for (auto *CK : CSet) {
     if (PVConstraint *PV = dyn_cast<PVConstraint>(CK)) {

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -20,7 +20,7 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
   auto *FD = dyn_cast_or_null<FunctionDecl>(CE->getCalleeDecl());
   if (FD && Rewriter::isRewritable(CE->getExprLoc())) {
     // Get the constraint variable for the function.
-    FVConstraint *FV = Info.getFuncConstraints(FD, Context);
+    FVConstraint *FV = Info.getFuncConstraint(FD, Context);
     // Function has no definition i.e., external function.
     assert("Function has no definition" && FV != nullptr);
 

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -20,7 +20,7 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
   auto *FD = dyn_cast_or_null<FunctionDecl>(CE->getCalleeDecl());
   if (FD && Rewriter::isRewritable(CE->getExprLoc())) {
     // Get the constraint variable for the function.
-    std::set<FVConstraint *> *V = Info.getFuncConstraints(FD, Context);
+    const std::set<FVConstraint *> *V = Info.getFuncConstraints(FD, Context);
     // Function has no definition i.e., external function.
     assert("Function has no definition" && V != nullptr);
 

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -52,7 +52,7 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
               ArgExpr = ArgExpr->IgnoreImpCasts();
 
             CVarSet ArgumentConstraints = CR.getExprConstraintVars(ArgExpr);
-            CVarSet &ParameterConstraints = FV->getParamVar(PIdx);
+            const CVarSet &ParameterConstraints = FV->getParamVar(PIdx);
             for (auto *ArgumentC : ArgumentConstraints) {
               bool CastInserted = false;
               for (auto *ParameterC : ParameterConstraints) {

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -20,58 +20,52 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
   auto *FD = dyn_cast_or_null<FunctionDecl>(CE->getCalleeDecl());
   if (FD && Rewriter::isRewritable(CE->getExprLoc())) {
     // Get the constraint variable for the function.
-    const std::set<FVConstraint *> *V = Info.getFuncConstraints(FD, Context);
+    FVConstraint *FV = Info.getFuncConstraints(FD, Context);
     // Function has no definition i.e., external function.
-    assert("Function has no definition" && V != nullptr);
+    assert("Function has no definition" && FV != nullptr);
 
     // Did we see this function in another file?
     auto Fname = FD->getNameAsString();
-    if (!V->empty() && !ConstraintResolver::canFunctionBeSkipped(Fname)) {
-      // Get the FV constraint for the Callee.
-      // TODO: This seems to assume that V is a singleton set. Validate this
-      //       assumption and use getOnly.
-      if (FVConstraint *FV = *(V->begin())) {
-        // Now we need to check the type of the arguments and corresponding
-        // parameters to see if any explicit casting is needed.
-        ProgramInfo::CallTypeParamBindingsT TypeVars;
-        if (Info.hasTypeParamBindings(CE, Context))
-          TypeVars = Info.getTypeParamBindings(CE, Context);
-        auto PInfo = Info.getMF()[Fname];
-        unsigned PIdx = 0;
-        for (const auto &A : CE->arguments()) {
-          if (PIdx < FD->getNumParams()) {
+    if (!ConstraintResolver::canFunctionBeSkipped(Fname)) {
+      // Now we need to check the type of the arguments and corresponding
+      // parameters to see if any explicit casting is needed.
+      ProgramInfo::CallTypeParamBindingsT TypeVars;
+      if (Info.hasTypeParamBindings(CE, Context))
+        TypeVars = Info.getTypeParamBindings(CE, Context);
+      auto PInfo = Info.getMF()[Fname];
+      unsigned PIdx = 0;
+      for (const auto &A : CE->arguments()) {
+        if (PIdx < FD->getNumParams()) {
+          // Avoid adding incorrect casts to generic function arguments by
+          // removing implicit casts when on arguments with a consistently
+          // used generic type.
+          Expr *ArgExpr = A;
+          const TypeVariableType
+              *TyVar = getTypeVariableType(FD->getParamDecl(PIdx));
+          if (TyVar && TypeVars.find(TyVar->GetIndex()) != TypeVars.end()
+              && TypeVars[TyVar->GetIndex()] != nullptr)
+            ArgExpr = ArgExpr->IgnoreImpCasts();
 
-            // Avoid adding incorrect casts to generic function arguments by
-            // removing implicit casts when on arguments with a consistently
-            // used generic type.
-            Expr *ArgExpr = A;
-            const TypeVariableType
-                *TyVar = getTypeVariableType(FD->getParamDecl(PIdx));
-            if (TyVar && TypeVars.find(TyVar->GetIndex()) != TypeVars.end()
-                && TypeVars[TyVar->GetIndex()] != nullptr)
-              ArgExpr = ArgExpr->IgnoreImpCasts();
-
-            CVarSet ArgumentConstraints = CR.getExprConstraintVars(ArgExpr);
-            const CVarSet &ParameterConstraints = FV->getParamVar(PIdx);
-            for (auto *ArgumentC : ArgumentConstraints) {
-              bool CastInserted = false;
-              for (auto *ParameterC : ParameterConstraints) {
-                auto Dinfo = PIdx < PInfo.size() ? PInfo[PIdx] : CHECKED;
-                if (needCasting(ArgumentC, ParameterC, Dinfo)) {
-                  // We expect the cast string to end with "(".
-                  std::string CastString =
-                      getCastString(ArgumentC, ParameterC, Dinfo);
-                  surroundByCast(CastString, A);
-                  CastInserted = true;
-                  break;
-                }
+          CVarSet ArgumentConstraints = CR.getExprConstraintVars(ArgExpr);
+          const CVarSet &ParameterConstraints = FV->getParamVar(PIdx);
+          for (auto *ArgumentC : ArgumentConstraints) {
+            bool CastInserted = false;
+            for (auto *ParameterC : ParameterConstraints) {
+              auto Dinfo = PIdx < PInfo.size() ? PInfo[PIdx] : CHECKED;
+              if (needCasting(ArgumentC, ParameterC, Dinfo)) {
+                // We expect the cast string to end with "(".
+                std::string CastString =
+                    getCastString(ArgumentC, ParameterC, Dinfo);
+                surroundByCast(CastString, A);
+                CastInserted = true;
+                break;
               }
-              // If we have already inserted a cast, then break.
-              if (CastInserted) break;
             }
+            // If we have already inserted a cast, then break.
+            if (CastInserted) break;
           }
-          PIdx++;
         }
+        PIdx++;
       }
     }
   }

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -47,22 +47,16 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
             ArgExpr = ArgExpr->IgnoreImpCasts();
 
           CVarSet ArgumentConstraints = CR.getExprConstraintVars(ArgExpr);
-          const CVarSet &ParameterConstraints = FV->getParamVar(PIdx);
+          ConstraintVariable *ParameterC = FV->getParamVar(PIdx);
           for (auto *ArgumentC : ArgumentConstraints) {
-            bool CastInserted = false;
-            for (auto *ParameterC : ParameterConstraints) {
-              auto Dinfo = PIdx < PInfo.size() ? PInfo[PIdx] : CHECKED;
-              if (needCasting(ArgumentC, ParameterC, Dinfo)) {
-                // We expect the cast string to end with "(".
-                std::string CastString =
-                    getCastString(ArgumentC, ParameterC, Dinfo);
-                surroundByCast(CastString, A);
-                CastInserted = true;
-                break;
-              }
+            auto Dinfo = PIdx < PInfo.size() ? PInfo[PIdx] : CHECKED;
+            if (needCasting(ArgumentC, ParameterC, Dinfo)) {
+              // We expect the cast string to end with "(".
+              std::string CastString =
+                  getCastString(ArgumentC, ParameterC, Dinfo);
+              surroundByCast(CastString, A);
+              break;
             }
-            // If we have already inserted a cast, then break.
-            if (CastInserted) break;
           }
         }
         PIdx++;

--- a/clang/lib/CConv/CheckedRegions.cpp
+++ b/clang/lib/CConv/CheckedRegions.cpp
@@ -235,7 +235,7 @@ bool CheckedRegionFinder::VisitDeclRefExpr(DeclRefExpr* DR) {
   bool IW = isWild(CVSet ) || containsUncheckedPtr(T);
 
   if (auto FD = dyn_cast<FunctionDecl>(D)) {
-    auto *FV = Info.getFuncConstraints(FD, Context);
+    auto *FV = Info.getFuncConstraint(FD, Context);
     IW |= FV->hasWild(Info.getConstraints().getVariables());
     for (const auto& param: FD->parameters()) {
       auto CVSet = Info.getVariable(param, Context);

--- a/clang/lib/CConv/CheckedRegions.cpp
+++ b/clang/lib/CConv/CheckedRegions.cpp
@@ -235,7 +235,7 @@ bool CheckedRegionFinder::VisitDeclRefExpr(DeclRefExpr* DR) {
   bool IW = isWild(CVSet ) || containsUncheckedPtr(T);
 
   if (auto FD = dyn_cast<FunctionDecl>(D)) {
-    auto FV = Info.getFuncConstraints(FD, Context);
+    const auto *FV = Info.getFuncConstraints(FD, Context);
     IW |= isWild(FV);
     for (const auto& param: FD->parameters()) {
       auto CVSet = Info.getVariable(param, Context);
@@ -298,7 +298,7 @@ bool CheckedRegionFinder::isInStatementPosition(CallExpr *C) {
   }
 }
 
-bool CheckedRegionFinder::isWild(std::set<ConstraintVariable*> &S) { 
+bool CheckedRegionFinder::isWild(const std::set<ConstraintVariable*> &S) {
   for (auto Cv : S) 
     if (Cv->hasWild(Info.getConstraints().getVariables()))
       return true;
@@ -306,7 +306,7 @@ bool CheckedRegionFinder::isWild(std::set<ConstraintVariable*> &S) {
   return false;
 }
 
-bool CheckedRegionFinder::isWild(std::set<FVConstraint*> *S) {
+bool CheckedRegionFinder::isWild(const std::set<FVConstraint*> *S) {
   for (auto Fv : *S)
     if (Fv->hasWild(Info.getConstraints().getVariables()))
       return true;

--- a/clang/lib/CConv/CheckedRegions.cpp
+++ b/clang/lib/CConv/CheckedRegions.cpp
@@ -235,8 +235,8 @@ bool CheckedRegionFinder::VisitDeclRefExpr(DeclRefExpr* DR) {
   bool IW = isWild(CVSet ) || containsUncheckedPtr(T);
 
   if (auto FD = dyn_cast<FunctionDecl>(D)) {
-    const auto *FV = Info.getFuncConstraints(FD, Context);
-    IW |= isWild(FV);
+    auto *FV = Info.getFuncConstraints(FD, Context);
+    IW |= FV->hasWild(Info.getConstraints().getVariables());
     for (const auto& param: FD->parameters()) {
       auto CVSet = Info.getVariable(param, Context);
       IW |= isWild(CVSet);

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -214,13 +214,13 @@ public:
             if (callUntyped) {
               deferred.push_back(ArgumentConstraints);
             } else if (i < TargetFV->numParams()) {
-            // constrain the arg CV to the param CV
-              CVarSet ParameterDC =
-                  TargetFV->getParamVar(i);
-              constrainConsVarGeq(ParameterDC, ArgumentConstraints, CS, &PL,
-                                  Wild_to_Safe, false, &Info);
+              // constrain the arg CV to the param CV
+              ConstraintVariable *ParameterDC = TargetFV->getParamVar(i);
+              for (auto *AC : ArgumentConstraints)
+                constrainConsVarGeq(ParameterDC, AC, CS, &PL, Wild_to_Safe,
+                                    false, &Info);
               if (AllTypes && TFD != nullptr &&
-                  !CB.containsValidCons(ParameterDC) &&
+                  !CB.isValidCons(ParameterDC) &&
                   !CB.containsValidCons(ArgumentConstraints)) {
                 auto *PVD = TFD->getParamDecl(i);
                 auto &ABI = Info.getABoundsInfo();

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -216,9 +216,8 @@ public:
             } else if (i < TargetFV->numParams()) {
               // constrain the arg CV to the param CV
               ConstraintVariable *ParameterDC = TargetFV->getParamVar(i);
-              for (auto *AC : ArgumentConstraints)
-                constrainConsVarGeq(ParameterDC, AC, CS, &PL, Wild_to_Safe,
-                                    false, &Info);
+              constrainConsVarGeq(ParameterDC, ArgumentConstraints, CS, &PL,
+                                  Wild_to_Safe, false, &Info);
               if (AllTypes && TFD != nullptr &&
                   !CB.isValidCons(ParameterDC) &&
                   !CB.containsValidCons(ArgumentConstraints)) {
@@ -285,9 +284,8 @@ public:
       if (FVConstraint *FV = dyn_cast<FVConstraint>(F)) {
         // This is to ensure that the return type of the function is same
         // as the type of return expression.
-        for (ConstraintVariable *CV : RconsVar)
-          constrainConsVarGeq(FV->getReturnVar(), CV, Info.getConstraints(),
-                              &PL, Same_to_Same, false, &Info);
+        constrainConsVarGeq(FV->getReturnVar(), RconsVar, Info.getConstraints(),
+                            &PL, Same_to_Same, false, &Info);
       }
     }
     return true;

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -286,7 +286,7 @@ public:
         // This is to ensure that the return type of the function is same
         // as the type of return expression.
         for (ConstraintVariable *CV : RconsVar)
-          constrainConsVarGeq(FV->getReturnVars(), CV, Info.getConstraints(),
+          constrainConsVarGeq(FV->getReturnVar(), CV, Info.getConstraints(),
                               &PL, Same_to_Same, false, &Info);
       }
     }

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -285,9 +285,9 @@ public:
       if (FVConstraint *FV = dyn_cast<FVConstraint>(F)) {
         // This is to ensure that the return type of the function is same
         // as the type of return expression.
-        constrainConsVarGeq(FV->getReturnVars(), RconsVar,
-                            Info.getConstraints(), &PL, Same_to_Same, false,
-                            &Info);
+        for (ConstraintVariable *CV : RconsVar)
+          constrainConsVarGeq(FV->getReturnVars(), CV, Info.getConstraints(),
+                              &PL, Same_to_Same, false, &Info);
       }
     }
     return true;

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -435,10 +435,10 @@ CVarSet
 
           for (ConstraintVariable *C : tmp) {
             if (FVConstraint *FV = dyn_cast<FVConstraint>(C)) {
-              ReturnCVs.insert(FV->getReturnVars());
+              ReturnCVs.insert(FV->getReturnVar());
             } else if (PVConstraint *PV = dyn_cast<PVConstraint>(C)) {
               if (FVConstraint *FV = PV->getFV())
-                ReturnCVs.insert(FV->getReturnVars());
+                ReturnCVs.insert(FV->getReturnVar());
             }
           }
         } else if (DeclaratorDecl *FD = dyn_cast<DeclaratorDecl>(D)) {
@@ -477,13 +477,13 @@ CVarSet
             ConstraintVariable *J = getOnly(TmpCSet);
             /* Direct function call */
             if (FVConstraint *FVC = dyn_cast<FVConstraint>(J))
-              ReturnCVs.insert(FVC->getReturnVars());
+              ReturnCVs.insert(FVC->getReturnVar());
               /* Call via function pointer */
             else {
               PVConstraint *tmp = dyn_cast<PVConstraint>(J);
               assert(tmp != nullptr);
               if (FVConstraint *FVC = tmp->getFV())
-                ReturnCVs.insert(FVC->getReturnVars());
+                ReturnCVs.insert(FVC->getReturnVar());
               else {
                 // No FVConstraint -- make WILD
                 auto *TmpFV = new FVConstraint();

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -435,13 +435,10 @@ CVarSet
 
           for (ConstraintVariable *C : tmp) {
             if (FVConstraint *FV = dyn_cast<FVConstraint>(C)) {
-              ReturnCVs.insert(FV->getReturnVars().begin(),
-                               FV->getReturnVars().end());
+              ReturnCVs.insert(FV->getReturnVars());
             } else if (PVConstraint *PV = dyn_cast<PVConstraint>(C)) {
-              if (FVConstraint *FV = PV->getFV()) {
-                ReturnCVs.insert(FV->getReturnVars().begin(),
-                                 FV->getReturnVars().end());
-              }
+              if (FVConstraint *FV = PV->getFV())
+                ReturnCVs.insert(FV->getReturnVars());
             }
           }
         } else if (DeclaratorDecl *FD = dyn_cast<DeclaratorDecl>(D)) {
@@ -480,15 +477,13 @@ CVarSet
             ConstraintVariable *J = getOnly(TmpCSet);
             /* Direct function call */
             if (FVConstraint *FVC = dyn_cast<FVConstraint>(J))
-              ReturnCVs.insert(FVC->getReturnVars().begin(),
-                               FVC->getReturnVars().end());
+              ReturnCVs.insert(FVC->getReturnVars());
               /* Call via function pointer */
             else {
               PVConstraint *tmp = dyn_cast<PVConstraint>(J);
               assert(tmp != nullptr);
               if (FVConstraint *FVC = tmp->getFV())
-                ReturnCVs.insert(FVC->getReturnVars().begin(),
-                                 FVC->getReturnVars().end());
+                ReturnCVs.insert(FVC->getReturnVars());
               else {
                 // No FVConstraint -- make WILD
                 auto *TmpFV = new FVConstraint();

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -288,7 +288,7 @@ CVarSet
           // constraining GEQ these vars would be the cast always be WILD.
           if (!isNULLExpression(ECE, *Context)) {
             PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(ECE, *Context);
-            constrainConsVarGeq(Ret, Vars, Info.getConstraints(), &PL,
+            constrainConsVarGeq(P, Vars, Info.getConstraints(), &PL,
                                 Same_to_Same, false, &Info);
           }
         }
@@ -521,9 +521,8 @@ CVarSet
           TmpCVs.insert(NewCV);
           // If this is realloc, constrain the first arg to flow to the return
           if (!ReallocFlow.empty()) {
-            for (auto &Constraint : ReallocFlow)
-              constrainConsVarGeq(NewCV, Constraint, Info.getConstraints(),
-                                  nullptr, Wild_to_Safe, false, &Info);
+            constrainConsVarGeq(NewCV, ReallocFlow, Info.getConstraints(),
+                                nullptr, Wild_to_Safe, false, &Info);
           }
         }
         Ret = TmpCVs;
@@ -555,17 +554,15 @@ CVarSet
         // (int[]){e1, e2, e3, ... }
       } else if (CompoundLiteralExpr *CLE =
           dyn_cast<CompoundLiteralExpr>(E)) {
-        CVarSet T;
         CVarSet Vars = getExprConstraintVars(CLE->getInitializer());
 
         PVConstraint *P = getRewritablePVConstraint(CLE);
-        T = {P};
 
         PersistentSourceLoc PL = PersistentSourceLoc::mkPSL(CLE, *Context);
-        constrainConsVarGeq(T, Vars, Info.getConstraints(), &PL, Same_to_Same,
+        constrainConsVarGeq(P, Vars, Info.getConstraints(), &PL, Same_to_Same,
                             false, &Info);
 
-        Ret = T;
+        Ret = {P};
         // "foo"
       } else if (clang::StringLiteral *Str =
           dyn_cast<clang::StringLiteral>(E)) {

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -1126,21 +1126,6 @@ bool FunctionVariableConstraint::hasItype() const {
   return ReturnVar->hasItype();
 }
 
-static bool cvSetsSolutionEqualTo(Constraints &CS,
-                                  const CVarSet &CVS1,
-                                  const CVarSet &CVS2) {
-  bool Ret = false;
-  if (CVS1.size() == CVS2.size()) {
-    Ret = CVS1.size() <= 1;
-    if (CVS1.size() == 1) {
-     auto *CV1 = getOnly(CVS1);
-     auto *CV2 = getOnly(CVS2);
-     Ret = CV1->solutionEqualTo(CS, CV2);
-    }
-  }
-  return Ret;
-}
-
 bool FunctionVariableConstraint::
     solutionEqualTo(Constraints &CS, const ConstraintVariable *CV) const {
   bool Ret = false;

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -895,7 +895,7 @@ void FunctionVariableConstraint::equateArgumentConstraints(ProgramInfo &Info) {
 
   // Is this not a function pointer?
   if (!IsFunctionPtr) {
-    std::set<FVConstraint *> *DefnCons = nullptr;
+    const std::set<FVConstraint *> *DefnCons = nullptr;
 
     // Get appropriate constraints based on whether the function is static or not.
     if (IsStatic) {

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -826,13 +826,11 @@ void PVConstraint::equateArgumentConstraints(ProgramInfo &Info) {
 }
 
 void FunctionVariableConstraint::equateFVConstraintVars
-    (const CVarSet &Cset, ProgramInfo &Info) const {
-  for (auto *TmpCons : Cset) {
-    if (FVConstraint *FVCons = dyn_cast<FVConstraint>(TmpCons)) {
-      for (auto &PCon : FVCons->ParamVars)
-        PCon->equateArgumentConstraints(Info);
-      FVCons->ReturnVar->equateArgumentConstraints(Info);
-    }
+    (ConstraintVariable *CV, ProgramInfo &Info) const {
+  if (FVConstraint *FVCons = dyn_cast<FVConstraint>(CV)) {
+    for (auto &PCon : FVCons->ParamVars)
+      PCon->equateArgumentConstraints(Info);
+    FVCons->ReturnVar->equateArgumentConstraints(Info);
   }
 }
 
@@ -842,11 +840,9 @@ void FunctionVariableConstraint::equateArgumentConstraints(ProgramInfo &Info) {
   }
 
   HasEqArgumentConstraints = true;
-  CVarSet TmpCSet;
-  TmpCSet.insert(this);
 
   // Equate arguments and parameters vars.
-  this->equateFVConstraintVars(TmpCSet, Info);
+  this->equateFVConstraintVars(this, Info);
 
   // Is this not a function pointer?
   if (!IsFunctionPtr) {
@@ -861,8 +857,7 @@ void FunctionVariableConstraint::equateArgumentConstraints(ProgramInfo &Info) {
     assert(DefnCons != nullptr);
 
     // Equate arguments and parameters vars.
-    CVarSet TmpDefn = {DefnCons};
-    this->equateFVConstraintVars(TmpDefn, Info);
+    this->equateFVConstraintVars(DefnCons, Info);
   }
 }
 

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -817,10 +817,8 @@ void PVConstraint::equateArgumentConstraints(ProgramInfo &Info) {
     return;
   }
   HasEqArgumentConstraints = true;
-  for (auto *ArgCons : this->argumentConstraints) {
-    constrainConsVarGeq(this, ArgCons, Info.getConstraints(), nullptr,
-                        Same_to_Same, true, &Info);
-  }
+  constrainConsVarGeq(this, this->argumentConstraints, Info.getConstraints(),
+                      nullptr, Same_to_Same, true, &Info);
 
   if (this->FV != nullptr) {
     this->FV->equateArgumentConstraints(Info);
@@ -1435,19 +1433,20 @@ void constrainConsVarGeq(ConstraintVariable *LHS, ConstraintVariable *RHS,
   }
 }
 
+
+void constrainConsVarGeq(ConstraintVariable *LHS, const CVarSet &RHS,
+                         Constraints &CS, PersistentSourceLoc *PL,
+                         ConsAction CA, bool doEqType, ProgramInfo *Info) {
+  for (const auto &J : RHS)
+    constrainConsVarGeq(LHS, J, CS, PL, CA, doEqType, Info);
+}
+
 // Given an RHS and a LHS, constrain them to be equal.
-void constrainConsVarGeq(const CVarSet &LHS,
-                      const CVarSet &RHS,
-                      Constraints &CS,
-                      PersistentSourceLoc *PL,
-                      ConsAction CA,
-                      bool doEqType,
-                      ProgramInfo *Info) {
-  for (const auto &I : LHS) {
-    for (const auto &J : RHS) {
-      constrainConsVarGeq(I, J, CS, PL, CA, doEqType, Info);
-    }
-  }
+void constrainConsVarGeq(const CVarSet &LHS, const CVarSet &RHS,
+                         Constraints &CS, PersistentSourceLoc *PL,
+                         ConsAction CA, bool doEqType, ProgramInfo *Info) {
+  for (const auto &I : LHS)
+    constrainConsVarGeq(I, RHS, CS, PL, CA, doEqType, Info);
 }
 
 // True if [C] is a PVConstraint that contains at least one Atom (i.e.,
@@ -1563,10 +1562,8 @@ void FunctionVariableConstraint::brainTransplant(ConstraintVariable *FromCV,
       for(unsigned i = 0; i < deferred.PS.size(); i++) {
         ConstraintVariable *ParamDC = getParamVar(i);
         CVarSet ArgDC = deferred.PS[i];
-        for (auto *P : ArgDC) {
-          constrainConsVarGeq(ParamDC, P, CS, &(deferred.PL), Wild_to_Safe,
-                              false, &I);
-        }
+        constrainConsVarGeq(ParamDC, ArgDC, CS, &(deferred.PL), Wild_to_Safe,
+                            false, &I);
       }
     }
   } else {

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -893,7 +893,7 @@ void FunctionVariableConstraint::equateArgumentConstraints(ProgramInfo &Info) {
 
   // Is this not a function pointer?
   if (!IsFunctionPtr) {
-    const std::set<FVConstraint *> *DefnCons = nullptr;
+    FVConstraint *DefnCons = nullptr;
 
     // Get appropriate constraints based on whether the function is static or not.
     if (IsStatic) {
@@ -904,9 +904,7 @@ void FunctionVariableConstraint::equateArgumentConstraints(ProgramInfo &Info) {
     assert(DefnCons != nullptr);
 
     // Equate arguments and parameters vars.
-    CVarSet TmpDefn;
-    TmpDefn.clear();
-    TmpDefn.insert(DefnCons->begin(), DefnCons->end());
+    CVarSet TmpDefn = {DefnCons};
     this->equateFVConstraintVars(TmpDefn, Info);
   }
 }

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -19,7 +19,7 @@
 
 using namespace clang;
 
-std::string ConstraintVariable::getRewritableOriginalTy() {
+std::string ConstraintVariable::getRewritableOriginalTy() const {
   std::string OrigTyString = getOriginalTy();
   std::string SpaceStr = " ";
   std::string AsterixStr = "*";
@@ -32,7 +32,7 @@ std::string ConstraintVariable::getRewritableOriginalTy() {
   }
   return OrigTyString;
 }
-bool ConstraintVariable::isChecked(EnvironmentMap &E) {
+bool ConstraintVariable::isChecked(EnvironmentMap &E) const {
   return getIsOriginallyChecked() || anyChanges(E);
 }
 
@@ -418,7 +418,7 @@ void PointerVariableConstraint::dump_json(llvm::raw_ostream &O) const {
 }
 
 void PointerVariableConstraint::getQualString(uint32_t TypeIdx,
-                                              std::ostringstream &Ss) {
+                                              std::ostringstream &Ss) const {
   auto QIter = QualMap.find(TypeIdx);
   if (QIter != QualMap.end()) {
     for (Qualification Q : QIter->second) {
@@ -451,7 +451,7 @@ bool PointerVariableConstraint::emitArraySize(std::ostringstream &Pss,
                                               uint32_t TypeIdx,
                                               bool &EmitName,
                                               bool &EmittedCheckedAnnotation,
-                                              bool Nt) {
+                                              bool Nt) const {
   bool Ret = false;
   if (ArrPresent) {
     auto i = arrSizes.find(TypeIdx);
@@ -491,7 +491,7 @@ std::string
 PointerVariableConstraint::mkString(EnvironmentMap &E,
                                     bool EmitName,
                                     bool ForItype,
-                                    bool EmitPointee) {
+                                    bool EmitPointee) const {
   std::ostringstream Ss;
   std::ostringstream Pss;
   unsigned CaratsToAdd = 0;
@@ -654,7 +654,7 @@ bool PVConstraint::addArgumentConstraint(ConstraintVariable *DstCons,
   return this->Parent->addArgumentConstraint(DstCons, Info);
 }
 
-CVarSet &PVConstraint::getArgumentConstraints() {
+const CVarSet &PVConstraint::getArgumentConstraints() const {
   return argumentConstraints;
 }
 
@@ -779,7 +779,7 @@ FunctionVariableConstraint::FunctionVariableConstraint(const Type *Ty,
   returnVars.insert(new PVConstraint(RT, D, RETVAR, I, Ctx, &N, IsGeneric));
 }
 
-void FunctionVariableConstraint::constrainToWild(Constraints &CS) {
+void FunctionVariableConstraint::constrainToWild(Constraints &CS) const {
   for (const auto &V : returnVars)
     V->constrainToWild(CS);
 
@@ -789,7 +789,7 @@ void FunctionVariableConstraint::constrainToWild(Constraints &CS) {
 }
 
 void FunctionVariableConstraint::constrainToWild(Constraints &CS,
-                                                 const std::string &Rsn) {
+                                                 const std::string &Rsn) const {
   for (const auto &V : returnVars)
     V->constrainToWild(CS, Rsn);
 
@@ -798,9 +798,8 @@ void FunctionVariableConstraint::constrainToWild(Constraints &CS,
       U->constrainToWild(CS, Rsn);
 }
 
-void FunctionVariableConstraint::constrainToWild(Constraints &CS,
-                                                 const std::string &Rsn,
-                                                 PersistentSourceLoc *PL) {
+void FunctionVariableConstraint::constrainToWild
+    (Constraints &CS, const std::string &Rsn, PersistentSourceLoc *PL) const {
   for (const auto &V : returnVars)
     V->constrainToWild(CS, Rsn, PL);
 
@@ -809,7 +808,7 @@ void FunctionVariableConstraint::constrainToWild(Constraints &CS,
       U->constrainToWild(CS, Rsn, PL);
 }
 
-bool FunctionVariableConstraint::anyChanges(EnvironmentMap &E) {
+bool FunctionVariableConstraint::anyChanges(EnvironmentMap &E) const {
   bool f = false;
 
   for (const auto &C : returnVars)
@@ -818,7 +817,7 @@ bool FunctionVariableConstraint::anyChanges(EnvironmentMap &E) {
   return f;
 }
 
-bool FunctionVariableConstraint::hasWild(EnvironmentMap &E, int AIdx)
+bool FunctionVariableConstraint::hasWild(EnvironmentMap &E, int AIdx) const
 {
   for (const auto &C : returnVars)
     if (C->hasWild(E, AIdx))
@@ -827,7 +826,7 @@ bool FunctionVariableConstraint::hasWild(EnvironmentMap &E, int AIdx)
   return false;
 }
 
-bool FunctionVariableConstraint::hasArr(EnvironmentMap &E, int AIdx)
+bool FunctionVariableConstraint::hasArr(EnvironmentMap &E, int AIdx) const
 {
   for (const auto &C : returnVars)
     if (C->hasArr(E, AIdx))
@@ -836,7 +835,7 @@ bool FunctionVariableConstraint::hasArr(EnvironmentMap &E, int AIdx)
   return false;
 }
 
-bool FunctionVariableConstraint::hasNtArr(EnvironmentMap &E, int AIdx)
+bool FunctionVariableConstraint::hasNtArr(EnvironmentMap &E, int AIdx) const
 {
   for (const auto &C : returnVars)
     if (C->hasNtArr(E, AIdx))
@@ -864,9 +863,8 @@ void PVConstraint::equateArgumentConstraints(ProgramInfo &Info) {
   }
 }
 
-void
-FunctionVariableConstraint::equateFVConstraintVars(
-    CVarSet &Cset, ProgramInfo &Info) {
+void FunctionVariableConstraint::equateFVConstraintVars
+    (const CVarSet &Cset, ProgramInfo &Info) const {
   for (auto *TmpCons : Cset) {
     if (FVConstraint *FVCons = dyn_cast<FVConstraint>(TmpCons)) {
       for (auto &PConSet : FVCons->paramVars) {
@@ -913,7 +911,7 @@ void FunctionVariableConstraint::equateArgumentConstraints(ProgramInfo &Info) {
   }
 }
 
-void PointerVariableConstraint::constrainToWild(Constraints &CS) {
+void PointerVariableConstraint::constrainToWild(Constraints &CS) const {
   ConstAtom *WA = CS.getWild();
   for (const auto &V : vars) {
     if (VarAtom *VA = dyn_cast<VarAtom>(V))
@@ -926,7 +924,7 @@ void PointerVariableConstraint::constrainToWild(Constraints &CS) {
 
 void PointerVariableConstraint::constrainToWild(Constraints &CS,
                                                 const std::string &Rsn,
-                                                PersistentSourceLoc *PL) {
+                                                PersistentSourceLoc *PL) const {
   ConstAtom *WA = CS.getWild();
   for (const auto &V : vars) {
     if (VarAtom *VA = dyn_cast<VarAtom>(V))
@@ -938,7 +936,7 @@ void PointerVariableConstraint::constrainToWild(Constraints &CS,
 }
 
 void PointerVariableConstraint::constrainToWild(Constraints &CS,
-                                                const std::string &Rsn) {
+                                                const std::string &Rsn) const {
   ConstAtom *WA = CS.getWild();
   for (const auto &V : vars) {
     if (VarAtom *VA = dyn_cast<VarAtom>(V))
@@ -986,7 +984,7 @@ bool PointerVariableConstraint::anyArgumentIsWild(EnvironmentMap &E) {
   return false;
 }
 
-bool PointerVariableConstraint::anyChanges(EnvironmentMap &E) {
+bool PointerVariableConstraint::anyChanges(EnvironmentMap &E) const {
   // If a pointer variable was checked in the input program, it will have the
   // same checked type in the output, so it cannot have changed.
   if (OriginallyChecked)
@@ -1027,7 +1025,7 @@ PointerVariableConstraint::getSolution(const Atom *A, EnvironmentMap &E) const {
   return CS;
 }
 
-bool PointerVariableConstraint::hasWild(EnvironmentMap &E, int AIdx)
+bool PointerVariableConstraint::hasWild(EnvironmentMap &E, int AIdx) const
 {
   int VarIdx = 0;
   for (const auto &C : vars) {
@@ -1045,7 +1043,7 @@ bool PointerVariableConstraint::hasWild(EnvironmentMap &E, int AIdx)
   return false;
 }
 
-bool PointerVariableConstraint::hasArr(EnvironmentMap &E, int AIdx)
+bool PointerVariableConstraint::hasArr(EnvironmentMap &E, int AIdx) const
 {
   int VarIdx = 0;
   for (const auto &C : vars) {
@@ -1063,7 +1061,7 @@ bool PointerVariableConstraint::hasArr(EnvironmentMap &E, int AIdx)
   return false;
 }
 
-bool PointerVariableConstraint::hasNtArr(EnvironmentMap &E, int AIdx)
+bool PointerVariableConstraint::hasNtArr(EnvironmentMap &E, int AIdx) const
 {
   int VarIdx = 0;
   for (const auto &C : vars) {
@@ -1081,24 +1079,24 @@ bool PointerVariableConstraint::hasNtArr(EnvironmentMap &E, int AIdx)
   return false;
 }
 
-bool PointerVariableConstraint::isTopCvarUnsizedArr() {
+bool PointerVariableConstraint::isTopCvarUnsizedArr() const {
   if (arrSizes.find(0) != arrSizes.end()) {
-    return arrSizes[0].first != O_SizedArray;
+    return arrSizes.at(0).first != O_SizedArray;
   }
   return true;
 }
 
 bool PointerVariableConstraint::
-    solutionEqualTo(Constraints &CS, ConstraintVariable *CV) {
+    solutionEqualTo(Constraints &CS, const ConstraintVariable *CV) const {
   bool Ret = false;
   if (CV != nullptr) {
-    if (PVConstraint *PV = dyn_cast<PVConstraint>(CV)) {
+    if (const auto *PV = dyn_cast<PVConstraint>(CV)) {
       auto &OthCVars = PV->vars;
       if (IsGeneric || PV->IsGeneric || vars.size() == OthCVars.size()) {
         Ret = true;
 
-        CAtoms::iterator I = vars.begin();
-        CAtoms::iterator J = OthCVars.begin();
+        auto I = vars.begin();
+        auto J = OthCVars.begin();
         // Special handling for zero width arrays so they can compare equal to
         // ARR or PTR.
         if (IsZeroWidthArray) {
@@ -1185,7 +1183,7 @@ void FunctionVariableConstraint::dump_json(raw_ostream &O) const {
   O << "}}";
 }
 
-bool FunctionVariableConstraint::hasItype() {
+bool FunctionVariableConstraint::hasItype() const {
   for (auto &RV : getReturnVars()) {
     if (RV->hasItype()) {
       return true;
@@ -1195,8 +1193,8 @@ bool FunctionVariableConstraint::hasItype() {
 }
 
 static bool cvSetsSolutionEqualTo(Constraints &CS,
-                                CVarSet &CVS1,
-                                CVarSet &CVS2) {
+                                  const CVarSet &CVS1,
+                                  const CVarSet &CVS2) {
   bool Ret = false;
   if (CVS1.size() == CVS2.size()) {
     Ret = CVS1.size() <= 1;
@@ -1210,13 +1208,13 @@ static bool cvSetsSolutionEqualTo(Constraints &CS,
 }
 
 bool FunctionVariableConstraint::
-    solutionEqualTo(Constraints &CS, ConstraintVariable *CV) {
+    solutionEqualTo(Constraints &CS, const ConstraintVariable *CV) const {
   bool Ret = false;
   if (CV != nullptr) {
-    if (FVConstraint *OtherFV = dyn_cast<FVConstraint>(CV)) {
+    if (const auto *OtherFV = dyn_cast<FVConstraint>(CV)) {
       Ret = (numParams() == OtherFV->numParams());
       Ret = Ret && cvSetsSolutionEqualTo(CS, getReturnVars(),
-                                       OtherFV->getReturnVars());
+                                         OtherFV->getReturnVars());
       for (unsigned i=0; i < numParams(); i++) {
         Ret = Ret && cvSetsSolutionEqualTo(CS, getParamVar(i),
                                          OtherFV->getParamVar(i));
@@ -1229,7 +1227,7 @@ bool FunctionVariableConstraint::
 std::string
 FunctionVariableConstraint::mkString(EnvironmentMap &E,
                                      bool EmitName, bool ForItype,
-                                     bool EmitPointee) {
+                                     bool EmitPointee) const {
   std::string Ret = "";
   // TODO punting on what to do here. The right thing to do is to figure out
   // The LUB of all of the V in returnVars.
@@ -1416,10 +1414,8 @@ void constrainConsVarGeq(ConstraintVariable *LHS, ConstraintVariable *RHS,
         // Constrain the parameters contravariantly.
         if (FCLHS->numParams() == FCRHS->numParams()) {
           for (unsigned i = 0; i < FCLHS->numParams(); i++) {
-            CVarSet &LHSV =
-                FCLHS->getParamVar(i);
-            CVarSet &RHSV =
-                FCRHS->getParamVar(i);
+            const CVarSet &LHSV = FCLHS->getParamVar(i);
+            const CVarSet &RHSV = FCRHS->getParamVar(i);
             // FIXME: Make neg(CA) here? Now: Function pointers equated
             constrainConsVarGeq(RHSV, LHSV, CS, PL, Same_to_Same, doEqType,
                                 Info);
@@ -1514,8 +1510,8 @@ void constrainConsVarGeq(ConstraintVariable *LHS, ConstraintVariable *RHS,
 }
 
 // Given an RHS and a LHS, constrain them to be equal.
-void constrainConsVarGeq(CVarSet &LHS,
-                      CVarSet &RHS,
+void constrainConsVarGeq(const CVarSet &LHS,
+                      const CVarSet &RHS,
                       Constraints &CS,
                       PersistentSourceLoc *PL,
                       ConsAction CA,
@@ -1530,11 +1526,9 @@ void constrainConsVarGeq(CVarSet &LHS,
 
 // True if [C] is a PVConstraint that contains at least one Atom (i.e.,
 //   it represents a C pointer).
-bool isAValidPVConstraint(ConstraintVariable *C) {
-  if (C != nullptr) {
-    if (PVConstraint *PV = dyn_cast<PVConstraint>(C))
-      return !PV->getCvars().empty();
-  }
+bool isAValidPVConstraint(const ConstraintVariable *C) {
+  if (const auto *PV = dyn_cast_or_null<PVConstraint>(C))
+    return !PV->getCvars().empty();
   return false;
 }
 
@@ -1632,15 +1626,15 @@ void FunctionVariableConstraint::brainTransplant(ConstraintVariable *FromCV,
   // Transplant params.
   if (numParams() == From->numParams()) {
     for (unsigned i = 0; i < From->numParams(); i++) {
-      CVarSet &FromP = From->getParamVar(i);
-      CVarSet &P = getParamVar(i);
+      const CVarSet &FromP = From->getParamVar(i);
+      const CVarSet &P = getParamVar(i);
       auto FromVar = getOnly(FromP);
       auto Var = getOnly(P);
       Var->brainTransplant(FromVar, I);
     }
   } else if (numParams() != 0 && From->numParams() == 0) {
     auto &CS = I.getConstraints();
-    std::vector<ParamDeferment> &defers = From->getDeferredParams();
+    const std::vector<ParamDeferment> &defers = From->getDeferredParams();
     assert(getDeferredParams().size() == 0);
     for (auto deferred : defers ) {
       assert(numParams() == deferred.PS.size());
@@ -1677,9 +1671,9 @@ void FunctionVariableConstraint::mergeDeclaration(ConstraintVariable *FromCV,
     // Standard merge
     assert(this->numParams() == From->numParams());
     for (unsigned i = 0; i < From->numParams(); i++) {
-      CVarSet &FromP = From->getParamVar(i);
+      const CVarSet &FromP = From->getParamVar(i);
       auto FromVar = getOnly(FromP);
-      CVarSet &P = getParamVar(i);
+      const CVarSet &P = getParamVar(i);
       auto Var = getOnly(P);
       Var->mergeDeclaration(FromVar, I);
     }
@@ -1694,7 +1688,7 @@ void FunctionVariableConstraint::addDeferredParams
 }
 
 
-bool FunctionVariableConstraint::getIsOriginallyChecked() {
+bool FunctionVariableConstraint::getIsOriginallyChecked() const {
   for (const auto &R : returnVars)
     if (R->getIsOriginallyChecked())
       return true;

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -854,9 +854,9 @@ void FunctionVariableConstraint::equateArgumentConstraints(ProgramInfo &Info) {
 
     // Get appropriate constraints based on whether the function is static or not.
     if (IsStatic) {
-      DefnCons = Info.getStaticFuncConstraintSet(Name, FileName);
+      DefnCons = Info.getStaticFuncConstraint(Name, FileName);
     } else {
-      DefnCons = Info.getExtFuncDefnConstraintSet(Name);
+      DefnCons = Info.getExtFuncDefnConstraint(Name);
     }
     assert(DefnCons != nullptr);
 

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -453,7 +453,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
     return true;
   VisitedSet.insert(FuncName);
 
-  FVConstraint *Defnc = getOnly(*Info.getFuncConstraints(Definition, Context));
+  FVConstraint *Defnc = Info.getFuncConstraints(Definition, Context);
   assert(Defnc != nullptr);
 
   // If this is an external function, there is no need to rewrite the

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -453,7 +453,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
     return true;
   VisitedSet.insert(FuncName);
 
-  FVConstraint *Defnc = Info.getFuncConstraints(Definition, Context);
+  FVConstraint *Defnc = Info.getFuncConstraint(Definition, Context);
   assert(Defnc != nullptr);
 
   // If this is an external function, there is no need to rewrite the

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -510,7 +510,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   }
 
   // Get rewritten return variable
-  auto *Defn = dyn_cast<PVConstraint>(getOnly(Defnc->getReturnVars()));
+  auto *Defn = dyn_cast<PVConstraint>(Defnc->getReturnVars());
 
   std::string ReturnVar = "";
   std::string ItypeStr = "";

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -510,7 +510,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   }
 
   // Get rewritten return variable
-  auto *Defn = dyn_cast<PVConstraint>(Defnc->getReturnVars());
+  auto *Defn = dyn_cast<PVConstraint>(Defnc->getReturnVar());
 
   std::string ReturnVar = "";
   std::string ItypeStr = "";

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -469,7 +469,7 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   // Get rewritten parameter variable declarations
   std::vector<std::string> ParmStrs;
   for (unsigned i = 0; i < Defnc->numParams(); ++i) {
-    auto *Defn = dyn_cast<PVConstraint>(getOnly(Defnc->getParamVar(i)));
+    auto *Defn = dyn_cast<PVConstraint>(Defnc->getParamVar(i));
     assert(Defn);
 
     if (isAValidPVConstraint(Defn) && Defn->anyChanges(CS.getVariables())) {

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -37,9 +37,9 @@ ParameterMap &ProgramInfo::getMF() {
 void dumpExtFuncMap(const ProgramInfo::ExternalFunctionMapType &EMap,
                     raw_ostream &O) {
   for (const auto &DefM : EMap) {
-    O << "Func Name:" << DefM.first << " => ";
+    O << "Func Name:" << DefM.first << " => [ ";
     DefM.second->print(O);
-    O << "\n";
+    O << " ]\n";
   }
 }
 
@@ -48,9 +48,9 @@ void dumpStaticFuncMap(const ProgramInfo::StaticFunctionMapType &EMap,
   for (const auto &DefM : EMap) {
     O << "File Name:" << DefM.first << " => ";
     for (const auto &Tmp : DefM.second) {
-      O << " Func Name:"<< Tmp.first << " => \n";
+      O << " Func Name:"<< Tmp.first << " => [ \n";
       Tmp.second->print(O);
-      O << "\n";
+      O << " ]\n";
     }
     O << "\n";
   }

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -451,7 +451,7 @@ ProgramInfo::insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
                                            FVConstraint *newC) {
   bool RetVal = false;
   if (Map.find(FuncName) == Map.end()) {
-    Map.insert(std::make_pair(FuncName, newC));
+    Map[FuncName] = newC;
     RetVal = true;
   } else {
     auto *oldC = Map[FuncName];
@@ -459,8 +459,7 @@ ProgramInfo::insertIntoExternalFunctionMap(ExternalFunctionMapType &Map,
         (newC->hasBody() ||
          (oldC->numParams() == 0 && newC->numParams() != 0))) {
       newC->brainTransplant(oldC, *this);
-      Map.erase(FuncName);
-      Map.insert(std::make_pair(FuncName, newC));
+      Map[FuncName] = newC;
       RetVal = true;
     } else if (!oldC->hasBody()) {
       // if the current FV constraint is not a definition?
@@ -479,7 +478,7 @@ bool ProgramInfo::insertIntoStaticFunctionMap (StaticFunctionMapType &Map,
                                                FVConstraint *ToIns) {
   bool RetVal = false;
   if (Map.find(FileName) == Map.end()) {
-    Map[FileName].insert(std::make_pair(FuncName, ToIns));
+    Map[FileName][FuncName] = ToIns;
     RetVal = true;
   } else {
     RetVal = insertIntoExternalFunctionMap(Map[FileName],FuncName,ToIns);
@@ -671,7 +670,7 @@ FVConstraint *
       assert("FunFVars can only be null if FuncName is not in the map!"
                  && ExternalFunctionFVCons.find(FuncName)
                      == ExternalFunctionFVCons.end());
-      ExternalFunctionFVCons.insert(std::make_pair(FuncName, F));
+      ExternalFunctionFVCons[FuncName] = F;
       FunFVars = ExternalFunctionFVCons[FuncName];
     }
   } else {

--- a/clang/lib/CConv/TypeVariableAnalysis.cpp
+++ b/clang/lib/CConv/TypeVariableAnalysis.cpp
@@ -115,8 +115,7 @@ bool TypeVarVisitor::VisitCallExpr(CallExpr *CE) {
         // Constrain this variable GEQ the function arguments using the type
         // variable so if any of them are wild, the type argument will also be
         // an unchecked pointer.
-        std::set<ConstraintVariable *> CVs = {P};
-        constrainConsVarGeq(CVs, TVEntry.second.getConstraintVariables(),
+        constrainConsVarGeq(P, TVEntry.second.getConstraintVariables(),
                             Info.getConstraints(), nullptr, Safe_to_Wild,
                             false, &Info);
 


### PR DESCRIPTION
Some of the `std::set<ConstraintVariable*>` sets we have are being used exclusively as singleton sets. This pull requests removes these sets, replacing them with a single ConstraintVariable pointer.

The first two commits should not be controversial. These add `const` qualifiers onto method declarations to make it easier to identify where constraint variable sets can possibly be mutated. After adding the `const`s, I only have to look at the non-`const` methods that access a set to determine if the set is used exclusively as a singleton set.

The third commit adds `override` annotations to the `ConstraintVariable` class hierarchy. This helps ensure I haven't broken an virtual methods while adding consts to their signatures. 

The next three commits are the body of this pull requests. Each of the commits takes one `std::set<ConstraintVariable*>`  field and replaces it with a single constraint variable pointer. These commits are mostly independent, so they can be looked at in isolation.