### PR TITLE
Fix to add -xclang flag and clean up arguments adjuster

### DIFF
--- a/clang/lib/CConv/CConv.cpp
+++ b/clang/lib/CConv/CConv.cpp
@@ -109,14 +109,15 @@ ArgumentsAdjuster getIgnoreCheckedPointerAdjuster() {
     bool HasAdjuster = false;
     for (size_t i = 0, e = Args.size(); i < e; ++i) {
       StringRef Arg = Args[i];
-      AdjustedArgs.push_back(Args[i]);
+      AdjustedArgs.push_back(Arg);
       if (Arg == "-fcheckedc-convert-tool") {
         HasAdjuster = true;
-        break;
       }
     }
-    if (!DisableCCTypeChecker && !HasAdjuster)
+    if (!DisableCCTypeChecker && !HasAdjuster) {
+      AdjustedArgs.push_back("-Xclang");
       AdjustedArgs.push_back("-fcheckedc-convert-tool");
+    }
     return AdjustedArgs;
   };
 }


### PR DESCRIPTION
It's not clear that this flag is the reason the tests are failing on Windows, but here's to hoping it is. 
I confirmed these changes still allow all tests to pass on Mac. 