### PR TITLE
Context sensitive array bounds for all function calls

### DIFF
--- a/clang/include/clang/CConv/AVarBoundsInfo.h
+++ b/clang/include/clang/CConv/AVarBoundsInfo.h
@@ -300,7 +300,7 @@ private:
   void insertProgramVar(BoundsKey NK, ProgramVar *PV);
 
   void insertCtxSensBoundsKey(ProgramVar *OldPV, BoundsKey NK,
-                              CtxFunctionArgScope *CFAS);
+                              const CtxFunctionArgScope *CFAS);
 
   // Check if the provided bounds key corresponds to function return.
   bool isFunctionReturn(BoundsKey BK);

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -176,13 +176,20 @@ enum ConsAction {
 void constrainConsVarGeq(const std::set<ConstraintVariable *> &LHS,
                          const std::set<ConstraintVariable *> &RHS,
                          Constraints &CS, PersistentSourceLoc *PL,
-                         ConsAction CA, bool doEqType, ProgramInfo *Info);
+                         ConsAction CA, bool doEqType,
+                         ProgramInfo *Info,
+                         bool HandleBoundsKey = true);
 void constrainConsVarGeq(ConstraintVariable *LHS, const CVarSet &RHS,
                          Constraints &CS, PersistentSourceLoc *PL,
-                         ConsAction CA, bool doEqType, ProgramInfo *Info);
-void constrainConsVarGeq(ConstraintVariable *LHS, ConstraintVariable *RHS,
+                         ConsAction CA, bool doEqType,
+                         ProgramInfo *Info,
+                         bool HandleBoundsKey = true);
+void constrainConsVarGeq(ConstraintVariable *LHS,
+                         ConstraintVariable *RHS,
                          Constraints &CS, PersistentSourceLoc *PL,
-                         ConsAction CA, bool doEqType, ProgramInfo *Info);
+                         ConsAction CA, bool doEqType,
+                         ProgramInfo *Info,
+                         bool HandleBoundsKey = true);
 
 // True if [C] is a PVConstraint that contains at least one Atom (i.e.,
 //   it represents a C pointer)

--- a/clang/include/clang/CConv/PersistentSourceLoc.h
+++ b/clang/include/clang/CConv/PersistentSourceLoc.h
@@ -68,6 +68,9 @@ public:
   static
   PersistentSourceLoc mkPSL(const clang::Stmt *S, clang::ASTContext &Context);
 
+  static
+  PersistentSourceLoc mkPSL(const clang::Expr *E, clang::ASTContext &Context);
+
 private:
   // Create a PersistentSourceLoc based on absolute file path
   // from the given SourceRange and SourceLocation.

--- a/clang/include/clang/CConv/ProgramVar.h
+++ b/clang/include/clang/CConv/ProgramVar.h
@@ -145,7 +145,7 @@ private:
 class FunctionParamScope : public ProgramVarScope {
 public:
   friend class FunctionScope;
-  FunctionParamScope(std::string FN, bool IsSt) :
+  FunctionParamScope(const std::string &FN, bool IsSt) :
       ProgramVarScope(FunctionParamScopeKind),
       FName(FN), IsStatic(IsSt) { }
 
@@ -189,8 +189,8 @@ public:
     return "FuncParm_" + FName;
   }
 
-  const std::string *getFName() const {
-    return &(this->FName);
+  const llvm::StringRef getFName() const {
+    return this->FName;
   }
 
   bool getIsStatic() const {
@@ -211,8 +211,8 @@ private:
 class CtxFunctionArgScope : public FunctionParamScope {
 public:
   friend class FunctionScope;
-  CtxFunctionArgScope(std::string FN, bool IsSt,
-                        const PersistentSourceLoc &CtxPSL) :
+  CtxFunctionArgScope(const std::string &FN, bool IsSt,
+                      const PersistentSourceLoc &CtxPSL) :
     FunctionParamScope(FN, IsSt) {
     PSL = CtxPSL;
     this->Kind = CtxFunctionArgScopeKind;

--- a/clang/include/clang/CConv/RewriteUtils.h
+++ b/clang/include/clang/CConv/RewriteUtils.h
@@ -203,6 +203,8 @@ public:
   ArrayBoundsRewriter(ASTContext *C, ProgramInfo &I): Context(C), Info(I) {}
   // Get the string representation of the bounds for the given variable.
   std::string getBoundsString(PVConstraint *PV, Decl *D, bool Isitype = false);
+  // Check if the constraint variable has newly created bounds string.
+  bool hasNewBoundsString(PVConstraint *PV, Decl *D, bool Isitype = false);
 private:
   ASTContext *Context;
   ProgramInfo &Info;

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -571,7 +571,7 @@ public:
                std::map<BoundsKey, ProgramVar *> &VarM,
                std::set<BoundsKey> &P): TS(S), Res(R), VM(VarM)
                , PtrAtoms(P) { }
-  void vistBoundsKey(BoundsKey V) const {
+  void visitBoundsKey(BoundsKey V) const {
     // If the variable is non-pointer?
     if (VM.find(V) != VM.end() && PtrAtoms.find(V) == PtrAtoms.end()) {
       auto *S = VM[V];
@@ -673,10 +673,10 @@ AvarBoundsInference::
 }
 
 bool AvarBoundsInference::inferPossibleBounds(BoundsKey K, ABounds *SB,
+                                              AVarGraph &BKGraph,
                                               std::set<ABounds *> &EB) {
   bool RetVal = false;
   if (SB != nullptr) {
-    auto &VarG = BI->ProgVarGraph;
     auto *Kvar = BI->getProgramVar(K);
     bool ValidB = false;
     auto BKind = SB->getKind();
@@ -701,9 +701,13 @@ bool AvarBoundsInference::inferPossibleBounds(BoundsKey K, ABounds *SB,
         // bounds variable.
         ScopeVisitor TV(Kvar->getScope(), PotentialB, BI->PVarInfo,
                         BI->PointerBoundsKey);
-        VarG.visitBreadthFirst(SBKey, [&TV](BoundsKey BK) {
-          TV.vistBoundsKey(BK);
+        BKGraph.visitBreadthFirst(SBKey, [&TV](BoundsKey BK) {
+          TV.visitBoundsKey(BK);
         });
+      }
+
+      if (*Kvar->getScope() == *SBVar->getScope()) {
+        PotentialB.insert(SBVar);
       }
 
       mergeReachableProgramVars(PotentialB);
@@ -738,6 +742,7 @@ bool AvarBoundsInference::getRelevantBounds(std::set<BoundsKey> &RBKeys,
 
 bool AvarBoundsInference::predictBounds(BoundsKey K,
                                         std::set<BoundsKey> &Neighbours,
+                                        AVarGraph &BKGraph,
                                         ABounds **KB) {
   std::set<ABounds *> ResBounds;
   std::set<ABounds *> KBounds;
@@ -761,7 +766,7 @@ bool AvarBoundsInference::predictBounds(BoundsKey K,
 
         // For function returns we should have atleast one common bound
         // from all the return values.
-        if (!inferPossibleBounds(K, B, KBounds) && IsFuncRet) {
+        if (!inferPossibleBounds(K, B, BKGraph, KBounds) && IsFuncRet) {
           IsValid = false;
           break;
         }
@@ -781,7 +786,7 @@ bool AvarBoundsInference::predictBounds(BoundsKey K,
   }
   return IsValid;
 }
-bool AvarBoundsInference::inferBounds(BoundsKey K, bool FromPB) {
+bool AvarBoundsInference::inferBounds(BoundsKey K, AVarGraph &BKGraph, bool FromPB) {
   bool IsChanged = false;
 
   if (BI->InvalidBounds.find(K) == BI->InvalidBounds.end()) {
@@ -790,7 +795,6 @@ bool AvarBoundsInference::inferBounds(BoundsKey K, bool FromPB) {
     if (FromPB) {
       auto &PotBDs = BI->PotentialCntBounds;
       if (PotBDs.find(K) != PotBDs.end()) {
-        auto &VarG = BI->ProgVarGraph;
         ProgramVar *Kvar = BI->getProgramVar(K);
         std::set<ProgramVar *> PotentialB;
         PotentialB.clear();
@@ -803,8 +807,8 @@ bool AvarBoundsInference::inferBounds(BoundsKey K, bool FromPB) {
             // bounds variable.
             ScopeVisitor TV(Kvar->getScope(), PotentialB, BI->PVarInfo,
                             BI->PointerBoundsKey);
-            VarG.visitBreadthFirst(TK, [&TV](BoundsKey BK) {
-              TV.vistBoundsKey(BK);
+            BKGraph.visitBreadthFirst(TK, [&TV](BoundsKey BK) {
+              TV.visitBoundsKey(BK);
             });
           } else {
             PotentialB.insert(TKVar);
@@ -821,8 +825,8 @@ bool AvarBoundsInference::inferBounds(BoundsKey K, bool FromPB) {
       // Infer from the flow-graph.
       std::set<BoundsKey> TmpBkeys;
       // Try to predict bounds from predecessors.
-      BI->ProgVarGraph.getPredecessors(K, TmpBkeys);
-      if (!predictBounds(K, TmpBkeys, &KB)) {
+      BKGraph.getPredecessors(K, TmpBkeys);
+      if (!predictBounds(K, TmpBkeys, BKGraph, &KB)) {
         KB = nullptr;
       }
     }
@@ -836,6 +840,7 @@ bool AvarBoundsInference::inferBounds(BoundsKey K, bool FromPB) {
 }
 
 bool AVarBoundsInfo::performWorkListInference(std::set<BoundsKey> &ArrNeededBounds,
+                                              AVarGraph &BKGraph,
                                               bool FromPB) {
   bool RetVal = false;
   std::set<BoundsKey> WorkList;
@@ -852,7 +857,7 @@ bool AVarBoundsInfo::performWorkListInference(std::set<BoundsKey> &ArrNeededBoun
       // Remove the bounds key from the worklist.
       WorkList.erase(CurrArrKey);
       // Can we find bounds for this Arr?
-      if (BI.inferBounds(CurrArrKey, FromPB)) {
+      if (BI.inferBounds(CurrArrKey, BKGraph, FromPB)) {
         // Record the stats.
         BoundsInferStats.DataflowMatch.insert(CurrArrKey);
         // We found the bounds.
@@ -860,7 +865,7 @@ bool AVarBoundsInfo::performWorkListInference(std::set<BoundsKey> &ArrNeededBoun
         RetVal = true;
         Changed = true;
         // Get all the successors of the ARR whose bounds we just found.
-        ProgVarGraph.getSuccessors(CurrArrKey, NextIterArrs);
+        BKGraph.getSuccessors(CurrArrKey, NextIterArrs);
       }
     }
     if (Changed) {
@@ -870,20 +875,30 @@ bool AVarBoundsInfo::performWorkListInference(std::set<BoundsKey> &ArrNeededBoun
   return RetVal;
 }
 
+void
+AVarBoundsInfo::insertCtxSensBoundsKey(ProgramVar *OldPV,
+                                       BoundsKey NK,
+                                       CtxFunctionArgScope *CFAS) {
+  ProgramVar *NKVar = OldPV->makeCopy(NK);
+  NKVar->setScope(CFAS);
+  insertProgramVar(NK, NKVar);
+  ProgVarGraph.addEdge(OldPV->getKey(), NKVar->getKey());
+  CtxSensProgVarGraph.addEdge(NKVar->getKey(), OldPV->getKey());
+}
+
 // Here, we create a new BoundsKey for every BoundsKey var that is related to
 // any ConstraintVariable in CSet and store the information by the
 // corresponding call expression (CE).
-// Here, we only care about variables that have bounds declaration
-// or that are used in a bounds declaration.
 bool
-AVarBoundsInfo::contextualizeCVar(CallExpr *CE, const CVarSet &CSet) {
+AVarBoundsInfo::contextualizeCVar(CallExpr *CE, const CVarSet &CSet,
+                                  ASTContext *C) {
   for (auto *CV : CSet) {
     // If this is a FV Constraint the contextualize its returns and
     // parameters.
     if (FVConstraint *FV = dyn_cast_or_null<FVConstraint>(CV)) {
-      contextualizeCVar(CE, {FV->getReturnVar()});
+      contextualizeCVar(CE, {FV->getReturnVar()}, C);
       for (unsigned i = 0; i < FV->numParams(); i++) {
-        contextualizeCVar(CE, {FV->getParamVar(i)});
+        contextualizeCVar(CE, {FV->getParamVar(i)}, C);
       }
     }
 
@@ -891,20 +906,20 @@ AVarBoundsInfo::contextualizeCVar(CallExpr *CE, const CVarSet &CSet) {
       if (PV->hasBoundsKey()) {
         // First duplicate the bounds key.
         BoundsKey CK = PV->getBoundsKey();
-        // Either this is a regular variable and used in a bounds declaration
-        // or a pointer that has bounds declaration? Then we need to
-        // contextualize it.
-        // If this is just a regular pointer or variable without declared
-        // bounds. We ignore it.
-        if((PV->getCvars().empty() && !ABounds::isKeyUsedInBounds(CK)) ||
-            !PV->hasBoundsStr())
-          continue;
-
+        PersistentSourceLoc CEPSL = PersistentSourceLoc::mkPSL(CE, *C);
         ProgramVar *CKVar = getProgramVar(CK);
+
+        // Create a context sensitive scope.
+        CtxFunctionArgScope *CFAS = nullptr;
+        if (FunctionParamScope *FPS =
+          dyn_cast_or_null<FunctionParamScope>(CKVar->getScope())) {
+          CFAS = CtxFunctionArgScope::getCtxFunctionParamScope(FPS, CEPSL);
+        }
+
         auto &BKeyMap = CSBoundsKey[CE];
         if (BKeyMap.find(CK) == BKeyMap.end()) {
           BoundsKey NK = ++BCount;
-          insertProgramVar(NK, CKVar->makeCopy(NK));
+          insertCtxSensBoundsKey(CKVar, NK, CFAS);
           BKeyMap[CK] = NK;
           // Next duplicate the Bounds information.
           BoundsPriority TP = Invalid;
@@ -915,7 +930,7 @@ AVarBoundsInfo::contextualizeCVar(CallExpr *CE, const CVarSet &CSet) {
             if (BKeyMap.find(NBK) == BKeyMap.end()) {
               BoundsKey TmpBK = ++BCount;
               BKeyMap[NBK] = TmpBK;
-              insertProgramVar(TmpBK, NBKVar->makeCopy(TmpBK));
+              insertCtxSensBoundsKey(NBKVar, TmpBK, CFAS);
             }
             CKBounds = CKBounds->makeCopy(BKeyMap[NBK]);
             replaceBounds(NK, TP, CKBounds);
@@ -1013,6 +1028,34 @@ void AVarBoundsInfo::computerArrPointers(ProgramInfo *PI,
       continue;
     }
   }
+
+  // Get all context-sensitive BoundsKey for each of the actual BKs
+  // and consider them to be array pointers as well.
+  // Since context-sensitive BoundsKey will be immediate children
+  // of the regular bounds key, we just get the neighbours (predecessors
+  // and successors) of the regular bounds key to get the context-sensitive
+  // counterparts.
+  std::set<BoundsKey> CtxSensBKeys;
+  CtxSensBKeys.clear();
+  std::set<BoundsKey> TmpBKeys, TmpBKeysF;
+  for (auto BK : ArrPointers) {
+    TmpBKeys.clear();
+    ProgVarGraph.getPredecessors(BK, TmpBKeys);
+    TmpBKeysF.insert(TmpBKeys.begin(), TmpBKeys.end());
+    TmpBKeys.clear();
+    ProgVarGraph.getSuccessors(BK, TmpBKeys);
+    TmpBKeysF.insert(TmpBKeys.begin(), TmpBKeys.end());
+    for (auto TBK : TmpBKeysF) {
+      ProgramVar *TmpPVar = getProgramVar(TBK);
+      if (TmpPVar != nullptr) {
+        if (isa<CtxFunctionArgScope>(TmpPVar->getScope())) {
+          CtxSensBKeys.insert(TBK);
+        }
+      }
+    }
+  }
+
+  ArrPointers.insert(CtxSensBKeys.begin(), CtxSensBKeys.end());
 }
 
 bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
@@ -1057,9 +1100,12 @@ bool AVarBoundsInfo::performFlowAnalysis(ProgramInfo *PI) {
   while (Changed) {
     Changed = false;
     // Use flow-graph.
-    Changed = performWorkListInference(ArrNeededBounds) || Changed;
+    Changed = performWorkListInference(ArrNeededBounds, this->ProgVarGraph) || Changed;
     // Use potential length variables.
-    Changed = performWorkListInference(ArrNeededBounds, true) || Changed;
+    Changed = performWorkListInference(ArrNeededBounds, this->ProgVarGraph, true) || Changed;
+    // Try solving using context-sensitive BoundsKey.
+    Changed = performWorkListInference(ArrNeededBounds, this->CtxSensProgVarGraph) || Changed;
+    Changed = performWorkListInference(ArrNeededBounds, this->CtxSensProgVarGraph, true) || Changed;
   }
 
   return RetVal;
@@ -1140,7 +1186,7 @@ bool ContextSensitiveBoundsKeyVisitor::VisitCallExpr(CallExpr *CE) {
   if (FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(CE->getCalleeDecl())) {
     // Contextualize the function at this call-site.
     for (auto *CFV : Info.getVariable(FD, Context)) {
-      Info.getABoundsInfo().contextualizeCVar(CE, {CFV});
+      Info.getABoundsInfo().contextualizeCVar(CE, {CFV}, Context);
     }
   }
   return true;

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -221,7 +221,7 @@ BoundsKey AVarBoundsInfo::getVariable(clang::VarDecl *VD) {
   if (!hasVarKey(PSL)) {
     BoundsKey NK = ++BCount;
     insertVarKey(PSL, NK);
-    ProgramVarScope *PVS = nullptr;
+    const ProgramVarScope *PVS = nullptr;
     if (VD->hasGlobalStorage()) {
       PVS = GlobalScope::getGlobalScope();
     } else {
@@ -251,8 +251,8 @@ BoundsKey AVarBoundsInfo::getVariable(clang::ParmVarDecl *PVD) {
                                   FD->isStatic(), ParamIdx);
   if (ParamDeclVarMap.left().find(ParamKey) == ParamDeclVarMap.left().end()) {
     BoundsKey NK = ++BCount;
-    FunctionParamScope *FPS =
-        FunctionParamScope::getFunctionParamScope(FD->getNameAsString(),
+    const FunctionParamScope *FPS =
+          FunctionParamScope::getFunctionParamScope(FD->getNameAsString(),
                                                   FD->isStatic());
     std::string ParamName = PVD->getNameAsString();
     // If this is a parameter without name!?
@@ -277,8 +277,8 @@ BoundsKey AVarBoundsInfo::getVariable(clang::FunctionDecl *FD) {
                                  FD->isStatic());
   if (FuncDeclVarMap.left().find(FuncKey) == FuncDeclVarMap.left().end()) {
     BoundsKey NK = ++BCount;
-    FunctionParamScope *FPS =
-        FunctionParamScope::getFunctionParamScope(FD->getNameAsString(),
+    const FunctionParamScope *FPS =
+          FunctionParamScope::getFunctionParamScope(FD->getNameAsString(),
                                                   FD->isStatic());
 
     auto *PVar = new ProgramVar(NK, FD->getNameAsString(), FPS);
@@ -297,7 +297,7 @@ BoundsKey AVarBoundsInfo::getVariable(clang::FieldDecl *FD) {
     BoundsKey NK = ++BCount;
     insertVarKey(PSL, NK);
     std::string StName = FD->getParent()->getNameAsString();
-    StructScope *SS = StructScope::getStructScope(StName);
+    const StructScope *SS = StructScope::getStructScope(StName);
     auto *PVar = new ProgramVar(NK, FD->getNameAsString(), SS);
     insertProgramVar(NK, PVar);
     if (FD->getType()->isPointerType())
@@ -567,7 +567,7 @@ bool isInSrcArray(const CVarSet &CSet, Constraints &CS) {
 // This class picks variables that are in the same scope as the provided scope.
 class ScopeVisitor {
 public:
-  ScopeVisitor(ProgramVarScope *S, std::set<ProgramVar *> &R,
+  ScopeVisitor(const ProgramVarScope *S, std::set<ProgramVar *> &R,
                std::map<BoundsKey, ProgramVar *> &VarM,
                std::set<BoundsKey> &P): TS(S), Res(R), VM(VarM)
                , PtrAtoms(P) { }
@@ -595,7 +595,7 @@ public:
       }
     }
   }
-  ProgramVarScope *TS;
+  const ProgramVarScope *TS;
   std::set<ProgramVar *> &Res;
   std::map<BoundsKey, ProgramVar *> &VM;
   std::set<BoundsKey> &PtrAtoms;
@@ -878,7 +878,7 @@ bool AVarBoundsInfo::performWorkListInference(std::set<BoundsKey> &ArrNeededBoun
 void
 AVarBoundsInfo::insertCtxSensBoundsKey(ProgramVar *OldPV,
                                        BoundsKey NK,
-                                       CtxFunctionArgScope *CFAS) {
+                                       const CtxFunctionArgScope *CFAS) {
   ProgramVar *NKVar = OldPV->makeCopy(NK);
   NKVar->setScope(CFAS);
   insertProgramVar(NK, NKVar);
@@ -910,8 +910,8 @@ AVarBoundsInfo::contextualizeCVar(CallExpr *CE, const CVarSet &CSet,
         ProgramVar *CKVar = getProgramVar(CK);
 
         // Create a context sensitive scope.
-        CtxFunctionArgScope *CFAS = nullptr;
-        if (FunctionParamScope *FPS =
+        const CtxFunctionArgScope *CFAS = nullptr;
+        if (auto *FPS =
           dyn_cast_or_null<FunctionParamScope>(CKVar->getScope())) {
           CFAS = CtxFunctionArgScope::getCtxFunctionParamScope(FPS, CEPSL);
         }

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -851,6 +851,13 @@ void LengthVarInference::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE) {
                               "to any basic block");
   // First, get the BoundsKey for the base.
   Expr *BE = ASE->getBase()->IgnoreParenCasts();
+
+  // If this is a multi-level array dereference i.e., a[i][j],
+  // then try-processing the base ASE i.e., a[i].
+  if (ArraySubscriptExpr *SubASE = dyn_cast_or_null<ArraySubscriptExpr>(BE)) {
+    VisitArraySubscriptExpr(SubASE);
+    return;
+  }
   auto BaseCVars = CR->getExprConstraintVars(BE);
   // Next get the index used.
   Expr *IdxExpr = ASE->getIdx()->IgnoreParenCasts();

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -234,8 +234,10 @@ public:
             } else if (i < TargetFV->numParams()) {
               // constrain the arg CV to the param CV
               ConstraintVariable *ParameterDC = TargetFV->getParamVar(i);
+              // Do not handle bounds key here because we will be
+              // doing context-sensitive assignment next.
               constrainConsVarGeq(ParameterDC, ArgumentConstraints, CS, &PL,
-                                  Wild_to_Safe, false, &Info);
+                                  Wild_to_Safe, false, &Info, false);
               
               if (AllTypes && TFD != nullptr) {
                 auto *PVD = TFD->getParamDecl(i);

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -579,6 +579,11 @@ bool FunctionDeclBuilder::VisitFunctionDecl(FunctionDecl *FD) {
   if (DidAnyReturn)
     NewSig = getStorageQualifierString(Definition) + ReturnVar;
 
+  // We need to rewrite params if there is a bounds strings for
+  // the return too.
+  DidAnyParams = DidAnyParams ||
+                 ABRewriter.hasNewBoundsString(Defn, FD, GeneratedRetIType);
+
   if (DidAnyReturn && DidAnyParams)
     NewSig += Defnc->getName();
 

--- a/clang/lib/CConv/PersistentSourceLoc.cpp
+++ b/clang/lib/CConv/PersistentSourceLoc.cpp
@@ -39,6 +39,12 @@ PersistentSourceLoc::mkPSL(const Stmt *S, ASTContext &Context) {
   return mkPSL(S->getSourceRange(), S->getBeginLoc(), Context);
 }
 
+// Create a PersistentSourceLoc for an Expression.
+PersistentSourceLoc
+PersistentSourceLoc::mkPSL(const clang::Expr *E, clang::ASTContext &Context) {
+  return mkPSL(E->getSourceRange(), E->getBeginLoc(), Context);
+}
+
 // Use the PresumedLoc infrastructure to get a file name and expansion
 // line and column numbers for a SourceLocation.
 PersistentSourceLoc 

--- a/clang/lib/CConv/ProgramVar.cpp
+++ b/clang/lib/CConv/ProgramVar.cpp
@@ -18,6 +18,8 @@ std::map<std::pair<std::string, bool>, FunctionScope*>
     FunctionScope::FnScopeMap;
 std::map<std::pair<std::string, bool>, FunctionParamScope*>
     FunctionParamScope::FnParmScopeMap;
+std::map<std::tuple<std::string, bool, PersistentSourceLoc>,
+  CtxFunctionArgScope *> CtxFunctionArgScope::CtxFnArgScopeMap;
 
 GlobalScope *GlobalScope::getGlobalScope() {
   if (ProgScope == nullptr) {
@@ -42,7 +44,20 @@ FunctionParamScope *FunctionParamScope::getFunctionParamScope(
   return FnParmScopeMap[MapK];
 }
 
-FunctionScope *FunctionScope::getFunctionScope(std::string FnName, bool IsSt) {
+CtxFunctionArgScope *CtxFunctionArgScope::getCtxFunctionParamScope(
+  FunctionParamScope *FPS, const PersistentSourceLoc &PSL) {
+  auto MapT = std::make_tuple(FPS->getFName(), FPS->getIsStatic(),
+                              PSL);
+  if (CtxFnArgScopeMap.find(MapT) == CtxFnArgScopeMap.end()) {
+    CtxFnArgScopeMap[MapT] =
+      new CtxFunctionArgScope(FPS->getFName(), FPS->getIsStatic(),
+                              PSL);
+  }
+  return CtxFnArgScopeMap[MapT];
+}
+
+FunctionScope *FunctionScope::getFunctionScope(std::string FnName,
+                                               bool IsSt) {
   auto MapK = std::make_pair(FnName, IsSt);
   if (FnScopeMap.find(MapK) == FnScopeMap.end()) {
     FnScopeMap[MapK] = new FunctionScope(FnName, IsSt);

--- a/clang/lib/CConv/ProgramVar.cpp
+++ b/clang/lib/CConv/ProgramVar.cpp
@@ -46,7 +46,7 @@ const FunctionParamScope *FunctionParamScope::getFunctionParamScope(
 
 const CtxFunctionArgScope *CtxFunctionArgScope::getCtxFunctionParamScope(
   const FunctionParamScope *FPS, const PersistentSourceLoc &PSL) {
-  CtxFunctionArgScope TmpAS(*(FPS->getFName()), FPS->getIsStatic(), PSL);
+  CtxFunctionArgScope TmpAS(FPS->getFName(), FPS->getIsStatic(), PSL);
   if (AllCtxFnArgScopes.find(TmpAS) == AllCtxFnArgScopes.end()) {
     AllCtxFnArgScopes.insert(TmpAS);
   }

--- a/clang/lib/CConv/ProgramVar.cpp
+++ b/clang/lib/CConv/ProgramVar.cpp
@@ -13,13 +13,12 @@
 #include "clang/CConv/ProgramVar.h"
 
 GlobalScope *GlobalScope::ProgScope = nullptr;
-std::map<std::string, StructScope*> StructScope::StScopeMap;
-std::map<std::pair<std::string, bool>, FunctionScope*>
-    FunctionScope::FnScopeMap;
-std::map<std::pair<std::string, bool>, FunctionParamScope*>
-    FunctionParamScope::FnParmScopeMap;
-std::map<std::tuple<std::string, bool, PersistentSourceLoc>,
-  CtxFunctionArgScope *> CtxFunctionArgScope::CtxFnArgScopeMap;
+std::set<StructScope, PVSComp> StructScope::AllStScopes;
+std::set<FunctionParamScope, PVSComp>
+  FunctionParamScope::AllFnParamScopes;
+std::set<FunctionScope, PVSComp> FunctionScope::AllFnScopes;
+std::set<CtxFunctionArgScope, PVSComp>
+  CtxFunctionArgScope::AllCtxFnArgScopes;
 
 GlobalScope *GlobalScope::getGlobalScope() {
   if (ProgScope == nullptr) {
@@ -28,41 +27,39 @@ GlobalScope *GlobalScope::getGlobalScope() {
   return ProgScope;
 }
 
-StructScope *StructScope::getStructScope(std::string StName) {
-  if (StScopeMap.find(StName) == StScopeMap.end()) {
-    StScopeMap[StName] = new StructScope(StName);
+const StructScope *StructScope::getStructScope(std::string StName) {
+  StructScope TmpS(StName);
+  if (AllStScopes.find(TmpS) == AllStScopes.end()) {
+    AllStScopes.insert(TmpS);
   }
-  return StScopeMap[StName];
+  return &(*AllStScopes.find(TmpS));
 }
 
-FunctionParamScope *FunctionParamScope::getFunctionParamScope(
+const FunctionParamScope *FunctionParamScope::getFunctionParamScope(
     std::string FnName, bool IsSt) {
-  auto MapK = std::make_pair(FnName, IsSt);
-  if (FnParmScopeMap.find(MapK) == FnParmScopeMap.end()) {
-    FnParmScopeMap[MapK] = new FunctionParamScope(FnName, IsSt);
+  FunctionParamScope TmpFPS(FnName, IsSt);
+  if (AllFnParamScopes.find(TmpFPS) == AllFnParamScopes.end()) {
+    AllFnParamScopes.insert(TmpFPS);
   }
-  return FnParmScopeMap[MapK];
+  return &(*AllFnParamScopes.find(TmpFPS));
 }
 
-CtxFunctionArgScope *CtxFunctionArgScope::getCtxFunctionParamScope(
-  FunctionParamScope *FPS, const PersistentSourceLoc &PSL) {
-  auto MapT = std::make_tuple(FPS->getFName(), FPS->getIsStatic(),
-                              PSL);
-  if (CtxFnArgScopeMap.find(MapT) == CtxFnArgScopeMap.end()) {
-    CtxFnArgScopeMap[MapT] =
-      new CtxFunctionArgScope(FPS->getFName(), FPS->getIsStatic(),
-                              PSL);
+const CtxFunctionArgScope *CtxFunctionArgScope::getCtxFunctionParamScope(
+  const FunctionParamScope *FPS, const PersistentSourceLoc &PSL) {
+  CtxFunctionArgScope TmpAS(*(FPS->getFName()), FPS->getIsStatic(), PSL);
+  if (AllCtxFnArgScopes.find(TmpAS) == AllCtxFnArgScopes.end()) {
+    AllCtxFnArgScopes.insert(TmpAS);
   }
-  return CtxFnArgScopeMap[MapT];
+  return &(*AllCtxFnArgScopes.find(TmpAS));
 }
 
-FunctionScope *FunctionScope::getFunctionScope(std::string FnName,
+const FunctionScope *FunctionScope::getFunctionScope(std::string FnName,
                                                bool IsSt) {
-  auto MapK = std::make_pair(FnName, IsSt);
-  if (FnScopeMap.find(MapK) == FnScopeMap.end()) {
-    FnScopeMap[MapK] = new FunctionScope(FnName, IsSt);
+  FunctionScope TmpFS(FnName, IsSt);
+  if (AllFnScopes.find(TmpFS) == AllFnScopes.end()) {
+    AllFnScopes.insert(TmpFS);
   }
-  return FnScopeMap[MapK];
+  return &(*AllFnScopes.find(TmpFS));
 }
 
 

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -360,6 +360,13 @@ std::string ArrayBoundsRewriter::getBoundsString(PVConstraint *PV,
   return BString;
 }
 
+bool ArrayBoundsRewriter::hasNewBoundsString(PVConstraint *PV, Decl *D,
+                                             bool Isitype) {
+  std::string BStr = getBoundsString(PV, D, Isitype);
+  // There is a bounds string but has nothing declared?
+  return !BStr.empty() && !PV->hasBoundsStr();
+}
+
 std::set<PersistentSourceLoc *> RewriteConsumer::EmittedDiagnostics;
 void RewriteConsumer::emitRootCauseDiagnostics(ASTContext &Context) {
   clang::DiagnosticsEngine &DE = Context.getDiagnostics();

--- a/clang/test/CheckedCRewriter/3d-allocation.c
+++ b/clang/test/CheckedCRewriter/3d-allocation.c
@@ -12,7 +12,7 @@ extern _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_c
 
 int ***malloc3d(int y, int x, int z) {
 	//CHECK_NOALL: int ***malloc3d(int y, int x, int z) {
-	//CHECK_ALL: _Array_ptr<_Array_ptr<_Array_ptr<int>>> malloc3d(int y, int x, int z) {
+	//CHECK_ALL: _Array_ptr<_Array_ptr<_Array_ptr<int>>> malloc3d(int y, int x, int z) : count(y) {
 
 	int i, j;
 
@@ -63,7 +63,7 @@ int main(void) {
 
 	int ***t2 = malloc3d(y, x, z);
 	//CHECK_NOALL: int ***t2 = malloc3d(y, x, z);
-	//CHECK_ALL: 	_Array_ptr<_Array_ptr<_Array_ptr<int>>> t2 =  malloc3d(y, x, z);
+	//CHECK_ALL: 	_Array_ptr<_Array_ptr<_Array_ptr<int>>> t2 : count(y) = malloc3d(y, x, z);
 
 
 	for (i = 0; i < y; ++i) {

--- a/clang/test/CheckedCRewriter/contextsensitivebounds1.c
+++ b/clang/test/CheckedCRewriter/contextsensitivebounds1.c
@@ -1,0 +1,64 @@
+/**
+Test for context sensitive bounds for internal functions.
+**/
+
+// RUN: cconv-standalone -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+_Itype_for_any(T) void *somefunc(unsigned long size) : itype(_Array_ptr<T>) byte_count(size);
+struct hash_node
+{
+  int *p_key;
+  int *q_key;
+  int *r_key;
+  int *w_key;
+  int *y_key;
+  unsigned pqlen;
+  unsigned r_len;
+  unsigned xo;
+  unsigned lo;
+};
+
+//CHECK_ALL: _Array_ptr<int> p_key : byte_count(pqlen);
+//CHECK_NOALL: int *p_key;
+//CHECK_ALL: _Array_ptr<int> q_key : byte_count(pqlen);
+//CHECK_NOALL: int *q_key;
+//CHECK_ALL: _Array_ptr<int> r_key : byte_count(r_len);
+//CHECK_NOALL: int *r_key;
+//CHECK_ALL: _Array_ptr<int> w_key : count(xo);
+//CHECK_NOALL: int *w_key;
+//CHECK_ALL: _Array_ptr<int> y_key : count(lo);
+//CHECK_NOALL: int *y_key;
+  
+int bar(struct hash_node *p) {
+    p->p_key = p->q_key;
+    return 0;
+}
+//CHECK_ALL: int bar(_Ptr<struct hash_node> p) {
+//CHECK_NOALL: int bar(_Ptr<struct hash_node> p) {
+
+
+void ctxsensfunc(int *p, unsigned n) {
+    unsigned i;
+    for (i=0; i<n; i++) {
+	p[i] = 0;
+    }
+}
+//CHECK_ALL: void ctxsensfunc(_Array_ptr<int> p : count(n), unsigned n) {
+//CHECK_NOALL: void ctxsensfunc(int *p, unsigned n) {
+
+int foo() {
+    unsigned i,j;
+    struct hash_node *n = somefunc(sizeof(struct hash_node));
+    i = 5*sizeof(int);
+    n->pqlen = i;
+    n->p_key = somefunc(i);
+    n->r_key = somefunc(n->r_len);
+    ctxsensfunc(n->w_key, n->xo);
+    n->p_key[0] = 1;
+    n->r_key[0] = 1;
+    j = n->lo;
+    ctxsensfunc(n->y_key, j);
+    return 0;
+}
+//CHECK_ALL: _Ptr<struct hash_node> n =  somefunc<struct hash_node>(sizeof(struct hash_node));
+//CHECK_NOALL: struct hash_node *n =  somefunc<struct hash_node>(sizeof(struct hash_node));


### PR DESCRIPTION
We will create context-sensitive bounds key for inferring array bounds. Previously, we did this only for functions that have bounds declarations, but this pull-request extends this to all functions.

Consider the following code:

```
struct hash_node
{
  int *w_key;
  int *y_key;
  unsigned xo;
  unsigned lo;
};
void ctxsensfunc(int *p, unsigned n) {
    unsigned i;
    for (i=0; i<n; i++) {
	p[i] = 0;
    }
}

int foo() {
    unsigned j;
    struct hash_node *n
    ctxsensfunc(n->w_key, n->xo);
    j = n->lo;
    ctxsensfunc(n->y_key, j);
    return 0;
}

```

Here, for each of the call-sites of `ctxsensfunc` we create new BoundsKey and array length inference will correctly infer the length of the structure members as follows:

```
struct hash_node
{
  _Array_len<int> w_key : count(xo);
  _Array_len<int> y_key : count(lo);
  unsigned xo;
  unsigned lo;
};
void ctxsensfunc(_Array_len<int> p : count(n), unsigned n) {
    unsigned i;
    for (i=0; i<n; i++) {
	p[i] = 0;
    }
}

int foo() {
    unsigned j;
    struct hash_node *n
    ctxsensfunc(n->w_key, n->xo);
    j = n->lo;
    ctxsensfunc(n->y_key, j);
    return 0;
}

```
