### PR TITLE
Fix macro expansion bug

### DIFF
--- a/clang/include/clang/CConv/AVarBoundsInfo.h
+++ b/clang/include/clang/CConv/AVarBoundsInfo.h
@@ -177,7 +177,7 @@ public:
   bool handleAssignment(clang::Expr *L, const CVarSet &LCVars,
                         clang::Expr *R, const CVarSet &RCVars,
                         ASTContext *C, ConstraintResolver *CR);
-  bool handleAssignment(clang::Decl *L, ConstraintVariable *LCVar,
+  bool handleAssignment(clang::Decl *L, CVarOption LCVar,
                         clang::Expr *R, const CVarSet &RCVars,
                         ASTContext *C, ConstraintResolver *CR);
   // Handle context sensitive assignment.

--- a/clang/include/clang/CConv/AVarBoundsInfo.h
+++ b/clang/include/clang/CConv/AVarBoundsInfo.h
@@ -174,11 +174,11 @@ public:
                                clang::Expr *R,
                                ASTContext *C,
                                ConstraintResolver *CR);
-  bool handleAssignment(clang::Expr *L, CVarSet &LCVars,
-                        clang::Expr *R, CVarSet &RCVars,
+  bool handleAssignment(clang::Expr *L, const CVarSet &LCVars,
+                        clang::Expr *R, const CVarSet &RCVars,
                         ASTContext *C, ConstraintResolver *CR);
-  bool handleAssignment(clang::Decl *L, CVarSet &LCVars,
-                        clang::Expr *R, CVarSet &RCVars,
+  bool handleAssignment(clang::Decl *L, ConstraintVariable *LCVar,
+                        clang::Expr *R, const CVarSet &RCVars,
                         ASTContext *C, ConstraintResolver *CR);
   // Handle context sensitive assignment.
   bool handleContextSensitiveAssignment(CallExpr *CE, clang::Decl *L,

--- a/clang/include/clang/CConv/CheckedRegions.h
+++ b/clang/include/clang/CConv/CheckedRegions.h
@@ -84,8 +84,7 @@ class CheckedRegionFinder : public clang::RecursiveASTVisitor<CheckedRegionFinde
     bool containsUncheckedPtr(clang::QualType Qt);
     bool containsUncheckedPtrAcc(clang::QualType Qt, std::set<std::string> &Seen);
     bool isUncheckedStruct(clang::QualType Qt, std::set<std::string> &Seen);
-    bool isWild(const ConstraintVariable*);
-    bool isWild(const FVConstraint*);
+    bool isWild(CVarOption CVar);
 
     clang::ASTContext* Context;
     clang::Rewriter& Writer;

--- a/clang/include/clang/CConv/CheckedRegions.h
+++ b/clang/include/clang/CConv/CheckedRegions.h
@@ -84,8 +84,8 @@ class CheckedRegionFinder : public clang::RecursiveASTVisitor<CheckedRegionFinde
     bool containsUncheckedPtr(clang::QualType Qt);
     bool containsUncheckedPtrAcc(clang::QualType Qt, std::set<std::string> &Seen);
     bool isUncheckedStruct(clang::QualType Qt, std::set<std::string> &Seen);
-    bool isWild(const std::set<ConstraintVariable*>&);
-    bool isWild(const std::set<FVConstraint*>*);
+    bool isWild(const ConstraintVariable*);
+    bool isWild(const FVConstraint*);
 
     clang::ASTContext* Context;
     clang::Rewriter& Writer;

--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -26,8 +26,7 @@ public:
 
   virtual ~ConstraintResolver();
 
-  void constraintAllCVarsToWild(CVarSet &CSet,
-                                std::string rsn,
+  void constraintAllCVarsToWild(const CVarSet &CSet, const std::string &Rsn,
                                 Expr *AtExpr = nullptr);
 
   // Returns a set of ConstraintVariables which represent the result of
@@ -48,7 +47,7 @@ public:
   bool containsValidCons(const CVarSet &CVs);
   bool isValidCons(ConstraintVariable *CV);
   // Try to get the bounds key from the constraint variable set.
-  bool resolveBoundsKey(CVarSet &CVs, BoundsKey &BK);
+  bool resolveBoundsKey(const CVarSet &CVs, BoundsKey &BK);
   bool resolveBoundsKey(ConstraintVariable *CV, BoundsKey &BK);
 
   static bool canFunctionBeSkipped(const std::string &FN);

--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -69,9 +69,7 @@ private:
 
   CVarSet getAllSubExprConstraintVars(std::vector<Expr *> &Exprs);
   CVarSet getBaseVarPVConstraint(DeclRefExpr *Decl);
-  bool hasPersistentConstraints(clang::Expr *E);
-  CVarSet getPersistentConstraints(clang::Expr *E);
-  void storePersistentConstraints(clang::Expr *E, CVarSet &Vars);
+
   PVConstraint *getRewritablePVConstraint(Expr *E);
 };
 

--- a/clang/include/clang/CConv/ConstraintResolver.h
+++ b/clang/include/clang/CConv/ConstraintResolver.h
@@ -28,6 +28,8 @@ public:
 
   void constraintAllCVarsToWild(const CVarSet &CSet, const std::string &Rsn,
                                 Expr *AtExpr = nullptr);
+  void constraintCVarToWild(CVarOption CVar, const std::string &Rsn,
+                            Expr *AtExpr = nullptr);
 
   // Returns a set of ConstraintVariables which represent the result of
   // evaluating the expression E. Will explore E recursively, but will
@@ -48,7 +50,7 @@ public:
   bool isValidCons(ConstraintVariable *CV);
   // Try to get the bounds key from the constraint variable set.
   bool resolveBoundsKey(const CVarSet &CVs, BoundsKey &BK);
-  bool resolveBoundsKey(ConstraintVariable *CV, BoundsKey &BK);
+  bool resolveBoundsKey(CVarOption CV, BoundsKey &BK);
 
   static bool canFunctionBeSkipped(const std::string &FN);
 

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -158,10 +158,6 @@ public:
 
   virtual ~ConstraintVariable() {};
 
-  // Sometimes, constraint variables can be produced that are empty. This
-  // tests for the existence of those constraint variables.
-  virtual bool isEmpty(void) const = 0;
-
   virtual bool getIsOriginallyChecked() const = 0;
 };
 
@@ -370,8 +366,6 @@ public:
   // Get the set of constraint variables corresponding to the arguments.
   const std::set<ConstraintVariable *> &getArgumentConstraints() const;
 
-  bool isEmpty(void) const override { return vars.size() == 0; }
-
   ConstraintVariable *getCopy(Constraints &CS) override;
 
   // Retrieve the atom at the specified index. This function includes special
@@ -480,19 +474,6 @@ public:
   void equateArgumentConstraints(ProgramInfo &P) override;
 
   ConstraintVariable *getCopy(Constraints &CS) override;
-
-  // An FVConstraint is empty if every constraint associated is empty.
-  bool isEmpty(void) const override {
-
-    if (ReturnVar != nullptr)
-      return false;
-
-    for (const auto &u : ParamVars)
-      if (!u->isEmpty())
-        return false;
-
-    return true;
-  }
 
   bool getIsOriginallyChecked() const override;
 

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -162,7 +162,7 @@ public:
 };
 
 typedef std::set<ConstraintVariable *> CVarSet;
-typedef llvm::Optional<ConstraintVariable *> CVarOption;
+typedef Option<ConstraintVariable> CVarOption;
 
 enum ConsAction {
   Safe_to_Wild,

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -88,7 +88,7 @@ public:
   // the name of the variable, false for just the type.
   // The 'forIType' parameter is true when the generated string is expected
   // to be used inside an itype
-  virtual std::string mkString(EnvironmentMap &E,
+  virtual std::string mkString(const EnvironmentMap &E,
                                bool emitName=true, bool forItype=false,
                                bool emitPointee=false) const = 0;
 
@@ -123,20 +123,20 @@ public:
   // have a binding in E other than top. E should be the EnvironmentMap that
   // results from running unification on the set of constraints and the
   // environment.
-  bool isChecked(EnvironmentMap &E) const;
+  bool isChecked(const EnvironmentMap &E) const;
 
   // Returns true if this constraint variable has a different checked type after
   // running unification. Note that if the constraint variable had a checked
   // type in the input program, it will have the same checked type after solving
   // so, the type will not have changed. To test if the type is checked, use
   // isChecked instead.
-  virtual bool anyChanges(EnvironmentMap &E) const = 0;
+  virtual bool anyChanges(const EnvironmentMap &E) const = 0;
 
   // Here, AIdx is the pointer level which needs to be checked.
   // By default, we check for all pointer levels (or VarAtoms)
-  virtual bool hasWild(EnvironmentMap &E, int AIdx = -1) const = 0;
-  virtual bool hasArr(EnvironmentMap &E, int AIdx = -1) const = 0;
-  virtual bool hasNtArr(EnvironmentMap &E, int AIdx = -1) const = 0;
+  virtual bool hasWild(const EnvironmentMap &E, int AIdx = -1) const = 0;
+  virtual bool hasArr(const EnvironmentMap &E, int AIdx = -1) const = 0;
+  virtual bool hasNtArr(const EnvironmentMap &E, int AIdx = -1) const = 0;
 
   // Force use of equality constraints in function calls for this CV
   virtual void equateArgumentConstraints(ProgramInfo &I) = 0;
@@ -247,7 +247,7 @@ private:
   // the values used as arguments.
   std::set<ConstraintVariable *> argumentConstraints;
   // Get solution for the atom of a pointer.
-  const ConstAtom *getSolution(const Atom *A, EnvironmentMap &E) const;
+  const ConstAtom *getSolution(const Atom *A, const EnvironmentMap &E) const;
 
   PointerVariableConstraint(PointerVariableConstraint *Ot, Constraints &CS);
   PointerVariableConstraint *Parent;
@@ -341,7 +341,7 @@ public:
     return S->getKind() == PointerVariable;
   }
 
-  std::string mkString(EnvironmentMap &E, bool EmitName =true,
+  std::string mkString(const EnvironmentMap &E, bool EmitName =true,
                        bool ForItype = false,
                        bool EmitPointee = false) const override;
 
@@ -355,11 +355,11 @@ public:
   void constrainToWild(Constraints &CS, const std::string &Rsn,
                        PersistentSourceLoc *PL) const override;
   void constrainOuterTo(Constraints &CS, ConstAtom *C, bool doLB = false);
-  bool anyChanges(EnvironmentMap &E) const override;
-  bool anyArgumentIsWild(EnvironmentMap &E);
-  bool hasWild(EnvironmentMap &E, int AIdx = -1) const override;
-  bool hasArr(EnvironmentMap &E, int AIdx = -1) const override;
-  bool hasNtArr(EnvironmentMap &E, int AIdx = -1) const override;
+  bool anyChanges(const EnvironmentMap &E) const override;
+  bool anyArgumentIsWild(const EnvironmentMap &E);
+  bool hasWild(const EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasArr(const EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasNtArr(const EnvironmentMap &E, int AIdx = -1) const override;
 
   void equateArgumentConstraints(ProgramInfo &I) override;
 
@@ -461,7 +461,7 @@ public:
   bool solutionEqualTo(Constraints &CS,
                        const ConstraintVariable *CV) const override;
 
-  std::string mkString(EnvironmentMap &E, bool EmitName =true,
+  std::string mkString(const EnvironmentMap &E, bool EmitName =true,
                        bool ForItype = false,
                        bool EmitPointee = false) const override;
   void print(llvm::raw_ostream &O) const override;
@@ -471,10 +471,10 @@ public:
   void constrainToWild(Constraints &CS, const std::string &Rsn) const override;
   void constrainToWild(Constraints &CS, const std::string &Rsn,
                        PersistentSourceLoc *PL) const override;
-  bool anyChanges(EnvironmentMap &E) const override;
-  bool hasWild(EnvironmentMap &E, int AIdx = -1) const override;
-  bool hasArr(EnvironmentMap &E, int AIdx = -1) const override;
-  bool hasNtArr(EnvironmentMap &E, int AIdx = -1) const override;
+  bool anyChanges(const EnvironmentMap &E) const override;
+  bool hasWild(const EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasArr(const EnvironmentMap &E, int AIdx = -1) const override;
+  bool hasNtArr(const EnvironmentMap &E, int AIdx = -1) const override;
 
   void equateArgumentConstraints(ProgramInfo &P) override;
 

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -236,6 +236,12 @@ private:
                      bool &AllArray, bool &ArrayRun, bool Nt) const;
   void addArrayAnnotations(std::stack<std::string> &CheckedArrs,
                            std::deque<std::string> &EndStrs) const;
+
+  // Utility used by the constructor to extract string representation of the
+  // base type that preserves macros where possible.
+  static std::string extractBaseType(DeclaratorDecl *D, QualType QT,
+                                     const Type *Ty, const ASTContext &C);
+
   // Flag to indicate that this constraint is a part of function prototype
   // e.g., Parameters or Return.
   bool partOFFuncPrototype;

--- a/clang/include/clang/CConv/ConstraintVariables.h
+++ b/clang/include/clang/CConv/ConstraintVariables.h
@@ -166,6 +166,7 @@ public:
 };
 
 typedef std::set<ConstraintVariable *> CVarSet;
+typedef llvm::Optional<ConstraintVariable *> CVarOption;
 
 enum ConsAction {
   Safe_to_Wild,

--- a/clang/include/clang/CConv/Constraints.h
+++ b/clang/include/clang/CConv/Constraints.h
@@ -529,6 +529,7 @@ class ConstraintsEnv {
 public:
   ConstraintsEnv() : consFreeKey(0), useChecked(true) { environment.clear(); }
   EnvironmentMap &getVariables() { return environment; }
+  const EnvironmentMap &getVariables() const { return environment; }
   void dump() const;
   void print(llvm::raw_ostream &) const;
   void dump_json(llvm::raw_ostream &) const;
@@ -574,7 +575,8 @@ public:
   // a client wants to examine the environment is untenable.
   ConstraintSet &getConstraints() { return constraints; }
   EnvironmentMap &getVariables() { return environment.getVariables(); }
-  
+  const EnvironmentMap &getVariables() const { return environment.getVariables(); }
+
   EnvironmentMap &getitypeVarMap() { return itypeConstraintVars; }
 
   void editConstraintHook(Constraint *C);

--- a/clang/include/clang/CConv/Constraints.h
+++ b/clang/include/clang/CConv/Constraints.h
@@ -528,7 +528,6 @@ class ConstraintsEnv {
 
 public:
   ConstraintsEnv() : consFreeKey(0), useChecked(true) { environment.clear(); }
-  EnvironmentMap &getVariables() { return environment; }
   const EnvironmentMap &getVariables() const { return environment; }
   void dump() const;
   void print(llvm::raw_ostream &) const;
@@ -573,11 +572,10 @@ public:
   // It's important to return these by reference. Programs can have 
   // 10-100-100000 constraints and variables, and copying them each time
   // a client wants to examine the environment is untenable.
-  ConstraintSet &getConstraints() { return constraints; }
-  EnvironmentMap &getVariables() { return environment.getVariables(); }
-  const EnvironmentMap &getVariables() const { return environment.getVariables(); }
-
-  EnvironmentMap &getitypeVarMap() { return itypeConstraintVars; }
+  const ConstraintSet &getConstraints() const { return constraints; }
+  const EnvironmentMap &getVariables() const {
+    return environment.getVariables();
+  }
 
   void editConstraintHook(Constraint *C);
 
@@ -619,11 +617,6 @@ private:
   ConstraintsGraph *PtrTypCG;
   std::map<std::string, ConstraintSet> constraintsByReason;
   ConstraintsEnv environment;
-  // Map of constraint variables, which are identified
-  // as itype pointers
-  // These should be the constraint variables of only
-  // function parameters or returns.
-  EnvironmentMap itypeConstraintVars;
 
   // Confirm a constraint is well-formed
   bool check(Constraint *C);

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -74,7 +74,8 @@ public:
                                   ASTContext *C);
 
   // Get constraint variable for the provided Decl
-  ConstraintVariable *getVariable(clang::Decl *D, clang::ASTContext *C);
+  CVarOption getVariable(clang::Decl *D,
+                                                   clang::ASTContext *C);
 
   // Retrieve a function's constraints by decl, or by name; nullptr if not found
   FVConstraint *getFuncConstraint (FunctionDecl *D, ASTContext *C) const;

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -186,7 +186,7 @@ private:
 
   // For each pointer type in the declaration of D, add a variable to the
   // constraint system for that pointer type.
-  void addVariable(clang::DeclaratorDecl *D, clang::ASTContext *astContext);
+  void addVariable(clang::DeclaratorDecl *D, clang::ASTContext *AstContext);
 };
 
 #endif

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -74,13 +74,14 @@ public:
                                   ASTContext *C);
 
   // Get constraint variable for the provided Decl
-  CVarSet getVariable(clang::Decl *D, clang::ASTContext *C);
+  ConstraintVariable *getVariable(clang::Decl *D, clang::ASTContext *C);
 
   // Retrieve a function's constraints by decl, or by name; nullptr if not found
   FVConstraint *getFuncConstraint (FunctionDecl *D, ASTContext *C) const;
   FVConstraint *getExtFuncDefnConstraint (std::string FuncName) const;
   FVConstraint *getStaticFuncConstraint(std::string FuncName,
                                         std::string FileName) const;
+
 
   // Check if the given function is an extern function.
   bool isAnExternFunction(const std::string &FName);
@@ -113,7 +114,7 @@ public:
   const CallTypeParamBindingsT &getTypeParamBindings(CallExpr *CE,
                                                      ASTContext *C) const;
 
-  void constrainWildIfMacro(CVarSet &S, SourceLocation Location);
+  void constrainWildIfMacro(ConstraintVariable *CV, SourceLocation Location);
 
 private:
   // List of constraint variables for declarations, indexed by their location in
@@ -123,7 +124,7 @@ private:
 
   // Map with the same purpose as the Variables map, this stores constraint vars
   // non-declaration expressions.
-  VariableMap ExprConstraintVars;
+  std::map<PersistentSourceLoc, CVarSet> ExprConstraintVars;
 
   // Constraint system.
   Constraints CS;

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -74,8 +74,7 @@ public:
                                   ASTContext *C);
 
   // Get constraint variable for the provided Decl
-  CVarOption getVariable(clang::Decl *D,
-                                                   clang::ASTContext *C);
+  CVarOption getVariable(clang::Decl *D, clang::ASTContext *C);
 
   // Retrieve a function's constraints by decl, or by name; nullptr if not found
   FVConstraint *getFuncConstraint (FunctionDecl *D, ASTContext *C) const;
@@ -123,8 +122,8 @@ private:
   // analysis from compilation unit to compilation unit.
   VariableMap Variables;
 
-  // Map with the same purpose as the Variables map, this stores constraint vars
-  // non-declaration expressions.
+  // Map with the same purpose as the Variables map, this stores constraint
+  // variables for non-declaration expressions.
   std::map<PersistentSourceLoc, CVarSet> ExprConstraintVars;
 
   // Constraint system.
@@ -143,8 +142,7 @@ private:
   StaticFunctionMapType StaticFunctionFVCons;
   std::map<std::string, std::set<PVConstraint *>> GlobalVariableSymbols;
 
-  // Object that contains all the bounds information of various
-  // array variables.
+  // Object that contains all the bounds information of various array variables.
   AVarBoundsInfo ArrBInfo;
   // Constraints state.
   ConstraintsInfo CState;
@@ -153,9 +151,8 @@ private:
   // instantiated so they can be inserted during rewriting.
   TypeParamBindingsT TypeParamBindings;
 
-  // Function to check if an external symbol is okay to leave
-  // constrained.
-  bool isExternOkay(std::string Ext);
+  // Function to check if an external symbol is okay to leave constrained.
+  bool isExternOkay(const std::string &Ext);
 
   // Insert the given FVConstraint* set into the provided Map.
   // Returns true if successful else false.

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -68,7 +68,11 @@ public:
   // should all be empty. 
   void exitCompilationUnit();
 
-  CVarSet &getPersistentConstraintVars(Expr *E, ASTContext *AstContext);
+  bool hasPersistentConstraints(clang::Expr *E, ASTContext *C) const;
+  const CVarSet &getPersistentConstraints(clang::Expr *E, ASTContext *C) const;
+  void storePersistentConstraints(clang::Expr *E, const CVarSet &Vars,
+                                  ASTContext *C);
+
   // Get constraint variable for the provided Decl
   CVarSet getVariable(clang::Decl *D, clang::ASTContext *C);
 

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -116,10 +116,15 @@ public:
   void constrainWildIfMacro(CVarSet &S, SourceLocation Location);
 
 private:
-  // List of all constraint variables, indexed by their location in the source.
-  // This information persists across invocations of the constraint analysis
-  // from compilation unit to compilation unit.
+  // List of constraint variables for declarations, indexed by their location in
+  // the source. This information persists across invocations of the constraint
+  // analysis from compilation unit to compilation unit.
   VariableMap Variables;
+
+  // Map with the same purpose as the Variables map, this stores constraint vars
+  // non-declaration expressions.
+  VariableMap ExprConstraintVars;
+
   // Constraint system.
   Constraints CS;
   // Is the ProgramInfo persisted? Only tested in asserts. Starts at true.

--- a/clang/include/clang/CConv/ProgramInfo.h
+++ b/clang/include/clang/CConv/ProgramInfo.h
@@ -86,7 +86,7 @@ public:
   // constraints where appropriate.
   bool link();
 
-  VariableMap &getVarMap() { return Variables; }
+  const VariableMap &getVarMap() const { return Variables; }
   Constraints &getConstraints() { return CS;  }
   AVarBoundsInfo &getABoundsInfo() { return ArrBInfo; }
 

--- a/clang/include/clang/CConv/RewriteUtils.h
+++ b/clang/include/clang/CConv/RewriteUtils.h
@@ -28,7 +28,7 @@ public:
 
   std::string getReplacement() const { return Replacement; }
 
-  virtual SourceRange getSourceRange() const {
+  virtual SourceRange getSourceRange(SourceManager &SM) const {
     return getDecl()->getSourceRange();
   }
 
@@ -93,10 +93,13 @@ public:
            && (RewriteReturn || RewriteParams));
   }
 
-  SourceRange getSourceRange() const override {
-    FunctionTypeLoc TypeLoc =
-        getBaseTypeLoc(Decl->getTypeSourceInfo()->getTypeLoc())
-        .getAs<clang::FunctionTypeLoc>();
+  SourceRange getSourceRange(SourceManager &SM) const override {
+    TypeSourceInfo *TSInfo = Decl->getTypeSourceInfo();
+    if (!TSInfo)
+      return SourceRange(Decl->getBeginLoc(),
+                         getFunctionDeclarationEnd(Decl, SM));
+    FunctionTypeLoc TypeLoc = getBaseTypeLoc(TSInfo->getTypeLoc())
+                             .getAs<clang::FunctionTypeLoc>();
 
     assert("FunctionDecl doesn't have function type?" && !TypeLoc.isNull());
 

--- a/clang/include/clang/CConv/Utils.h
+++ b/clang/include/clang/CConv/Utils.h
@@ -31,6 +31,27 @@ typedef std::map<PersistentSourceLoc, ConstraintVariable *> VariableMap;
 // Maps a Decl to the DeclStmt that defines the Decl.
 typedef std::map<clang::Decl *, clang::DeclStmt *> VariableDecltoStmtMap;
 
+template<typename ValueT>
+class Option {
+public:
+  Option() : Value(nullptr), HasValue(false) {}
+  Option(ValueT &V) : Value(&V), HasValue(true) {}
+
+  ValueT &getValue() const {
+    assert("Inconsistent option!" && HasValue && Value != nullptr);
+    return *Value;
+  }
+
+  bool hasValue() const {
+    assert("Inconsistent option!" && HasValue == (Value != nullptr));
+    return HasValue;
+  }
+
+private:
+  ValueT *Value;
+  bool HasValue;
+};
+
 // Replacement for boost:bimap. A wrapper class around two std::maps to enable
 // map lookup from key to value or from value to key.
 template <typename KeyT, typename ValueT>

--- a/clang/include/clang/CConv/Utils.h
+++ b/clang/include/clang/CConv/Utils.h
@@ -26,8 +26,7 @@ class ConstraintVariable;
 class ProgramInfo;
 
 // Maps a Decl to the set of constraint variables for that Decl.
-typedef std::map<PersistentSourceLoc, 
-  std::set<ConstraintVariable *>> VariableMap;
+typedef std::map<PersistentSourceLoc, ConstraintVariable *> VariableMap;
 
 // Maps a Decl to the DeclStmt that defines the Decl.
 typedef std::map<clang::Decl *, clang::DeclStmt *> VariableDecltoStmtMap;

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -950,11 +950,11 @@ void AVarBoundsInfo::computerArrPointers(ProgramInfo *PI,
     auto &BkeyToPSL = DeclVarMap.right();
     if (BkeyToPSL.find(Bkey) != BkeyToPSL.end()) {
       auto &PSL = BkeyToPSL.at(Bkey);
-      if (hasArray(PI->getVarMap()[PSL], CS)) {
+      if (hasArray(PI->getVarMap().at(PSL), CS)) {
         ArrPointers.insert(Bkey);
       }
       // Does this array belongs to a valid program variable?
-      if (isInSrcArray(PI->getVarMap()[PSL], CS)) {
+      if (isInSrcArray(PI->getVarMap().at(PSL), CS)) {
         InProgramArrPtrBoundsKeys.insert(Bkey);
       }
       continue;

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -371,7 +371,7 @@ bool AVarBoundsInfo::handleContextSensitiveAssignment(CallExpr *CE,
   } else {
     // This is the assignment of regular variables.
     BoundsKey LKey, RKey;
-    if ((CR->resolveBoundsKey(LCVar, LKey) ||
+    if ((CR->resolveBoundsKey(*LCVar, LKey) ||
         tryGetVariable(L, LKey)) &&
         (CR->resolveBoundsKey(RCVars, RKey) ||
             tryGetVariable(R, *C, RKey))) {
@@ -1137,7 +1137,7 @@ bool ContextSensitiveBoundsKeyVisitor::VisitCallExpr(CallExpr *CE) {
     // Contextualize the function at this call-site.
     CVarOption COpt = Info.getVariable(FD, Context);
     if (COpt.hasValue())
-      Info.getABoundsInfo().contextualizeCVar(CE, {COpt.getValue()});
+      Info.getABoundsInfo().contextualizeCVar(CE, {&COpt.getValue()});
   }
   return true;
 }

--- a/clang/lib/CConv/AVarBoundsInfo.cpp
+++ b/clang/lib/CConv/AVarBoundsInfo.cpp
@@ -338,7 +338,7 @@ bool AVarBoundsInfo::handleAssignment(clang::Expr *L, const CVarSet &LCVars,
   return false;
 }
 
-bool AVarBoundsInfo::handleAssignment(clang::Decl *L, ConstraintVariable *LCVars,
+bool AVarBoundsInfo::handleAssignment(clang::Decl *L, CVarOption LCVars,
                                       clang::Expr *R, const CVarSet &RCVars,
                                       ASTContext *C, ConstraintResolver *CR) {
   BoundsKey LKey, RKey;
@@ -371,7 +371,7 @@ bool AVarBoundsInfo::handleContextSensitiveAssignment(CallExpr *CE,
   } else {
     // This is the assignment of regular variables.
     BoundsKey LKey, RKey;
-    if ((CR->resolveBoundsKey({LCVar}, LKey) ||
+    if ((CR->resolveBoundsKey(LCVar, LKey) ||
         tryGetVariable(L, LKey)) &&
         (CR->resolveBoundsKey(RCVars, RKey) ||
             tryGetVariable(R, *C, RKey))) {
@@ -1135,9 +1135,9 @@ ContextSensitiveBoundsKeyVisitor::~ContextSensitiveBoundsKeyVisitor() {
 bool ContextSensitiveBoundsKeyVisitor::VisitCallExpr(CallExpr *CE) {
   if (FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(CE->getCalleeDecl())) {
     // Contextualize the function at this call-site.
-    if (ConstraintVariable *CFV = Info.getVariable(FD, Context)) {
-      Info.getABoundsInfo().contextualizeCVar(CE, {CFV});
-    }
+    CVarOption COpt = Info.getVariable(FD, Context);
+    if (COpt.hasValue())
+      Info.getABoundsInfo().contextualizeCVar(CE, {COpt.getValue()});
   }
   return true;
 }

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -135,9 +135,10 @@ static bool needArrayBounds(Decl *D, ProgramInfo &Info, ASTContext *C,
                             bool IsNtArr) {
   const auto &E = Info.getConstraints().getVariables();
   CVarOption CVar = Info.getVariable(D, C);
-  if (CVar) {
-    if ((!IsNtArr && needArrayBounds(*CVar, E)) ||
-        (IsNtArr && needNTArrayBounds(*CVar, E)))
+  if (CVar.hasValue()) {
+    ConstraintVariable &CV = CVar.getValue();
+    if ((!IsNtArr && needArrayBounds(&CV, E)) ||
+        (IsNtArr && needNTArrayBounds(&CV, E)))
       return true;
     return false;
   }

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -101,19 +101,19 @@ static bool hasLengthKeyword(std::string VarName) {
 }
 
 // Check if the provided constraint variable is an array and it needs bounds.
-static bool needArrayBounds(ConstraintVariable *CV,
-                            EnvironmentMap &E) {
+static bool needArrayBounds(const ConstraintVariable *CV,
+                            const EnvironmentMap &E) {
   if (CV->hasArr(E, 0)) {
-    PVConstraint *PV = dyn_cast<PVConstraint>(CV);
+    const PVConstraint *PV = dyn_cast<PVConstraint>(CV);
     return !PV || PV->isTopCvarUnsizedArr();
   }
   return false;
 }
 
-static bool needNTArrayBounds(ConstraintVariable *CV,
-                              EnvironmentMap &E) {
+static bool needNTArrayBounds(const ConstraintVariable *CV,
+                              const EnvironmentMap &E) {
   if (CV->hasNtArr(E, 0)) {
-    PVConstraint *PV = dyn_cast<PVConstraint>(CV);
+    const PVConstraint *PV = dyn_cast<PVConstraint>(CV);
     return !PV || PV->isTopCvarUnsizedArr();
   }
   return false;
@@ -122,7 +122,7 @@ static bool needNTArrayBounds(ConstraintVariable *CV,
 static bool needArrayBounds(Expr *E, ProgramInfo &Info, ASTContext *C) {
   ConstraintResolver CR(Info, C);
   CVarSet ConsVar = CR.getExprConstraintVars(E);
-  auto &EnvMap = Info.getConstraints().getVariables();
+  const auto &EnvMap = Info.getConstraints().getVariables();
   for (auto CurrCVar : ConsVar) {
     if (needArrayBounds(CurrCVar, EnvMap) || needNTArrayBounds(CurrCVar, EnvMap))
       return true;
@@ -134,7 +134,7 @@ static bool needArrayBounds(Expr *E, ProgramInfo &Info, ASTContext *C) {
 static bool needArrayBounds(Decl *D, ProgramInfo &Info, ASTContext *C,
                             bool IsNtArr) {
   CVarSet ConsVar = Info.getVariable(D, C);
-  auto &E = Info.getConstraints().getVariables();
+  const auto &E = Info.getConstraints().getVariables();
   for (auto CurrCVar : ConsVar) {
     if ((!IsNtArr && needArrayBounds(CurrCVar, E)) ||
         (IsNtArr && needNTArrayBounds(CurrCVar, E)))

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -134,9 +134,10 @@ static bool needArrayBounds(Expr *E, ProgramInfo &Info, ASTContext *C) {
 static bool needArrayBounds(Decl *D, ProgramInfo &Info, ASTContext *C,
                             bool IsNtArr) {
   const auto &E = Info.getConstraints().getVariables();
-  if (ConstraintVariable *CurrCVar = Info.getVariable(D, C)) {
-    if ((!IsNtArr && needArrayBounds(CurrCVar, E)) ||
-        (IsNtArr && needNTArrayBounds(CurrCVar, E)))
+  CVarOption CVar = Info.getVariable(D, C);
+  if (CVar) {
+    if ((!IsNtArr && needArrayBounds(*CVar, E)) ||
+        (IsNtArr && needNTArrayBounds(*CVar, E)))
       return true;
     return false;
   }
@@ -178,9 +179,9 @@ bool tryGetBoundsKeyVar(Expr *E, BoundsKey &BK, ProgramInfo &Info,
 bool tryGetBoundsKeyVar(Decl *D, BoundsKey &BK, ProgramInfo &Info,
                         ASTContext *Context) {
   ConstraintResolver CR(Info, Context);
-  ConstraintVariable *CV = Info.getVariable(D, Context);
+  CVarOption CV = Info.getVariable(D, Context);
   auto &ABInfo = Info.getABoundsInfo();
-  return (CV && CR.resolveBoundsKey(CV, BK)) || ABInfo.tryGetVariable(D, BK);
+  return CR.resolveBoundsKey(CV, BK) || ABInfo.tryGetVariable(D, BK);
 }
 
 // Check if the provided expression is a call to one of the known

--- a/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
+++ b/clang/lib/CConv/ArrayBoundsInferenceConsumer.cpp
@@ -133,9 +133,8 @@ static bool needArrayBounds(Expr *E, ProgramInfo &Info, ASTContext *C) {
 
 static bool needArrayBounds(Decl *D, ProgramInfo &Info, ASTContext *C,
                             bool IsNtArr) {
-  CVarSet ConsVar = Info.getVariable(D, C);
   const auto &E = Info.getConstraints().getVariables();
-  for (auto CurrCVar : ConsVar) {
+  if (ConstraintVariable *CurrCVar = Info.getVariable(D, C)) {
     if ((!IsNtArr && needArrayBounds(CurrCVar, E)) ||
         (IsNtArr && needNTArrayBounds(CurrCVar, E)))
       return true;
@@ -179,10 +178,9 @@ bool tryGetBoundsKeyVar(Expr *E, BoundsKey &BK, ProgramInfo &Info,
 bool tryGetBoundsKeyVar(Decl *D, BoundsKey &BK, ProgramInfo &Info,
                         ASTContext *Context) {
   ConstraintResolver CR(Info, Context);
-  CVarSet CVs = Info.getVariable(D, Context);
+  ConstraintVariable *CV = Info.getVariable(D, Context);
   auto &ABInfo = Info.getABoundsInfo();
-  return CR.resolveBoundsKey(CVs, BK) ||
-         ABInfo.tryGetVariable(D, BK);
+  return (CV && CR.resolveBoundsKey(CV, BK)) || ABInfo.tryGetVariable(D, BK);
 }
 
 // Check if the provided expression is a call to one of the known

--- a/clang/lib/CConv/CastPlacement.cpp
+++ b/clang/lib/CConv/CastPlacement.cpp
@@ -70,7 +70,7 @@ bool CastPlacementVisitor::VisitCallExpr(CallExpr *CE) {
 // by src variable is assigned to dst.
 bool CastPlacementVisitor::needCasting(ConstraintVariable *Src,
                                        ConstraintVariable *Dst) {
-  auto &E = Info.getConstraints().getVariables();
+  const auto &E = Info.getConstraints().getVariables();
   // Check if the src is a checked type.
   if (Src->isChecked(E)) {
     // If Dst has an itype, Src must have exactly the same checked type. If this

--- a/clang/lib/CConv/CheckedRegions.cpp
+++ b/clang/lib/CConv/CheckedRegions.cpp
@@ -217,7 +217,8 @@ bool CheckedRegionFinder::VisitMemberExpr(MemberExpr *E){
   if (VD) {
     // Check if the variable is WILD.
     CVarOption Cv = Info.getVariable(VD, Context);
-    if (Cv && (*Cv)->hasWild(Info.getConstraints().getVariables()))
+    if (Cv.hasValue()
+        && Cv.getValue().hasWild(Info.getConstraints().getVariables()))
       Wild = true;
     // Check if the variable contains unchecked types.
     Wild |= containsUncheckedPtr(VD->getType());
@@ -296,7 +297,8 @@ bool CheckedRegionFinder::isInStatementPosition(CallExpr *C) {
 }
 
 bool CheckedRegionFinder::isWild(CVarOption Cv) {
-  if (Cv && (*Cv)->hasWild(Info.getConstraints().getVariables()))
+  if (Cv.hasValue()
+      && Cv.getValue().hasWild(Info.getConstraints().getVariables()))
     return true;
   return false;
 }
@@ -356,7 +358,8 @@ bool CheckedRegionFinder::isUncheckedStruct(QualType Qt, std::set<std::string> &
         auto Ftype = Fld->getType();
         Unsafe |= containsUncheckedPtrAcc(Ftype, Seen);
         CVarOption Cv = Info.getVariable(Fld, Context);
-        Unsafe |= (Cv && (*Cv)->hasWild(Info.getConstraints().getVariables()));
+        Unsafe |= (Cv.hasValue()
+            && Cv.getValue().hasWild(Info.getConstraints().getVariables()));
       }
       return Unsafe;
     }

--- a/clang/lib/CConv/CheckedRegions.cpp
+++ b/clang/lib/CConv/CheckedRegions.cpp
@@ -188,8 +188,8 @@ bool CheckedRegionFinder::VisitCallExpr(CallExpr *C) {
         || containsUncheckedPtr(type)
         || (std::any_of(FD->param_begin(), FD->param_end(),
            [this] (Decl *param) {
-              auto CVSet = Info.getVariable(param, Context);
-              return isWild(CVSet );
+              auto CV = Info.getVariable(param, Context);
+              return CV && isWild(CV);
             }));
     }
     handleChildren(C->children());
@@ -200,15 +200,15 @@ bool CheckedRegionFinder::VisitCallExpr(CallExpr *C) {
 }
 
 bool CheckedRegionFinder::VisitVarDecl(VarDecl *VD) {
-  auto CVSet = Info.getVariable(VD, Context);
-  Wild = isWild(CVSet) || containsUncheckedPtr(VD->getType());
+  auto CV = Info.getVariable(VD, Context);
+  Wild = (CV && isWild(CV)) || containsUncheckedPtr(VD->getType());
   return true;
 }
 
 bool CheckedRegionFinder::VisitParmVarDecl(ParmVarDecl *PVD) {
   // Check if the variable is WILD.
-  auto CVSet = Info.getVariable(PVD, Context);
-  Wild |= isWild(CVSet) | containsUncheckedPtr(PVD->getType());
+  auto CV = Info.getVariable(PVD, Context);
+  Wild |= (CV && isWild(CV)) || containsUncheckedPtr(PVD->getType());
   return true;
 }
 
@@ -216,12 +216,9 @@ bool CheckedRegionFinder::VisitMemberExpr(MemberExpr *E){
   ValueDecl *VD = E->getMemberDecl();
   if (VD) {
     // Check if the variable is WILD.
-    std::set<ConstraintVariable *> CVSet = Info.getVariable(VD, Context);
-    for (auto Cv : CVSet) {
-      if (Cv->hasWild(Info.getConstraints().getVariables())) {
-        Wild = true;
-      }
-    }
+    ConstraintVariable *Cv = Info.getVariable(VD, Context);
+    if (Cv && Cv->hasWild(Info.getConstraints().getVariables()))
+      Wild = true;
     // Check if the variable contains unchecked types.
     Wild |= containsUncheckedPtr(VD->getType());
   }
@@ -231,15 +228,15 @@ bool CheckedRegionFinder::VisitMemberExpr(MemberExpr *E){
 bool CheckedRegionFinder::VisitDeclRefExpr(DeclRefExpr* DR) {
   auto T = DR->getType();
   auto D = DR->getDecl();
-  auto CVSet = Info.getVariable(D, Context);
-  bool IW = isWild(CVSet ) || containsUncheckedPtr(T);
+  auto CV = Info.getVariable(D, Context);
+  bool IW = (CV && isWild(CV)) || containsUncheckedPtr(T);
 
   if (auto FD = dyn_cast<FunctionDecl>(D)) {
     auto *FV = Info.getFuncConstraint(FD, Context);
     IW |= FV->hasWild(Info.getConstraints().getVariables());
     for (const auto& param: FD->parameters()) {
-      auto CVSet = Info.getVariable(param, Context);
-      IW |= isWild(CVSet);
+      auto CV = Info.getVariable(param, Context);
+      IW |= (CV && isWild(CV));
     }
   }
 
@@ -298,18 +295,15 @@ bool CheckedRegionFinder::isInStatementPosition(CallExpr *C) {
   }
 }
 
-bool CheckedRegionFinder::isWild(const std::set<ConstraintVariable*> &S) {
-  for (auto Cv : S) 
-    if (Cv->hasWild(Info.getConstraints().getVariables()))
-      return true;
-
+bool CheckedRegionFinder::isWild(const ConstraintVariable* Cv) {
+  if (Cv->hasWild(Info.getConstraints().getVariables()))
+    return true;
   return false;
 }
 
-bool CheckedRegionFinder::isWild(const std::set<FVConstraint*> *S) {
-  for (auto Fv : *S)
-    if (Fv->hasWild(Info.getConstraints().getVariables()))
-      return true;
+bool CheckedRegionFinder::isWild(const FVConstraint* Fv) {
+  if (Fv->hasWild(Info.getConstraints().getVariables()))
+    return true;
   return false;
 }
 
@@ -367,10 +361,8 @@ bool CheckedRegionFinder::isUncheckedStruct(QualType Qt, std::set<std::string> &
       for (auto const &Fld : D->fields()) {
         auto Ftype = Fld->getType();
         Unsafe |= containsUncheckedPtrAcc(Ftype, Seen);
-        std::set<ConstraintVariable *> CVSet =
-            Info.getVariable(Fld, Context);
-        for (auto Cv : CVSet)
-          Unsafe |= Cv->hasWild(Info.getConstraints().getVariables());
+        ConstraintVariable *Cv = Info.getVariable(Fld, Context);
+        Unsafe |= (Cv && Cv->hasWild(Info.getConstraints().getVariables()));
       }
       return Unsafe;
     }

--- a/clang/lib/CConv/ConstraintBuilder.cpp
+++ b/clang/lib/CConv/ConstraintBuilder.cpp
@@ -498,8 +498,7 @@ public:
 
   bool VisitVarDecl(VarDecl *D) {
     FullSourceLoc FL = Context->getFullLoc(D->getBeginLoc());
-    if (FL.isValid() &&
-        (!isa<ParmVarDecl>(D) || D->getParentFunctionOrMethod() != nullptr))
+    if (FL.isValid() && !isa<ParmVarDecl>(D))
       addVariable(D);
     return true;
   }
@@ -512,7 +511,10 @@ public:
   }
 
   bool VisitRecordDecl(RecordDecl *Declaration) {
-    if (RecordDecl *Definition = Declaration->getDefinition()) {
+    if (Declaration->isThisDeclarationADefinition()) {
+      RecordDecl *Definition = Declaration->getDefinition();
+      assert("Declaration is a definition, but getDefinition() is null?"
+                 && Definition);
       FullSourceLoc FL = Context->getFullLoc(Definition->getBeginLoc());
       if (FL.isValid()) {
         SourceManager &SM = Context->getSourceManager();

--- a/clang/lib/CConv/ConstraintResolver.cpp
+++ b/clang/lib/CConv/ConstraintResolver.cpp
@@ -176,8 +176,8 @@ CVarSet ConstraintResolver::getInvalidCastPVCons(Expr *E) {
   // As getInvalidCastPVCons could be called from non-persistent expressions
   // we need to explicitly store the generated PVConstraints into persistent
   // constraints.
-  if (hasPersistentConstraints(E))
-    return getPersistentConstraints(E);
+  if (Info.hasPersistentConstraints(E, Context))
+    return Info.getPersistentConstraints(E, Context);
 
   DstType = E->getType();
   SrcType = E->getType();
@@ -194,7 +194,7 @@ CVarSet ConstraintResolver::getInvalidCastPVCons(Expr *E) {
       "Cast from " + SrcType.getAsString() + " to " + DstType.getAsString();
   P->constrainToWild(Info.getConstraints(), Rsn, &PL);
   Ret = {P};
-  storePersistentConstraints(E, Ret);
+  Info.storePersistentConstraints(E, Ret, Context);
   return Ret;
 }
 
@@ -256,9 +256,8 @@ CVarSet
       // Apart from the above expressions constraints for all the other
       // expressions can be cached.
       // First, check if the expression has constraints that are cached?
-      if (hasPersistentConstraints(E)) {
-        return getPersistentConstraints(E);
-      }
+      if (Info.hasPersistentConstraints(E, Context))
+        return Info.getPersistentConstraints(E, Context);
 
       CVarSet Ret = EmptyCSet;
       if (ExplicitCastExpr *ECE = dyn_cast<ExplicitCastExpr>(E)) {
@@ -597,52 +596,11 @@ CVarSet
           llvm::errs() << "\n";
         }
       }
-      storePersistentConstraints(E, Ret);
+      Info.storePersistentConstraints(E, Ret, Context);
       return Ret;
     }
   }
   return EmptyCSet;
-}
-
-bool ConstraintResolver::hasPersistentConstraints(clang::Expr *E) {
-  auto PSL = PersistentSourceLoc::mkPSL(E, *Context);
-  // Has constraints only if the PSL is valid.
-  if (PSL.valid()) {
-    CVarSet &Persist = Info.getPersistentConstraintVars(E, Context);
-    return !Persist.empty();
-  }
-  return false;
-}
-
-// Get the set of constraint variables for an expression that will persist
-// between the constraint generation and rewriting pass. If the expression
-// already has a set of persistent constraints, this set is returned. Otherwise,
-// the set provided in the arguments is stored persistent and returned. This is
-// required for correct cast insertion.
-CVarSet
-    ConstraintResolver::getPersistentConstraints(clang::Expr *E) {
-  assert (hasPersistentConstraints(E) &&
-         "Persistent constraints not present.");
-  CVarSet &Persist = Info.getPersistentConstraintVars(E, Context);
-  return Persist;
-}
-
-
-void ConstraintResolver::storePersistentConstraints(clang::Expr *E,
-                                                    CVarSet &Vars) {
-  // Store only if the PSL is valid.
-  auto PSL = PersistentSourceLoc::mkPSL(E, *Context);
-  // The check Rewrite::isRewritable is needed here to ensure that the
-  // expression is not inside a macro. If the expression is in a macro, then it
-  // is possible for there to be multiple expressions that map to the same PSL.
-  // This could make it look like the constraint variables for an expression
-  // have been computed and cached when the expression has not in fact been
-  // visited before. To avoid this, the expression is not cached and instead is
-  // recomputed each time it's needed.
-  if (PSL.valid() && Rewriter::isRewritable(E->getBeginLoc())){
-    CVarSet &Persist = Info.getPersistentConstraintVars(E, Context);
-    Persist.insert(Vars.begin(), Vars.end());
-  }
 }
 
 // Collect constraint variables for Exprs int a set

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -375,7 +375,8 @@ PointerVariableConstraint::PointerVariableConstraint(const QualType &QT,
         // inside a macro. Not sure how to handle this, so fall back to tyToStr.
         if (BaseType.empty())
           FoundMatchingType = false;
-      }
+      } else
+        FoundMatchingType = false;
     }
   }
   // Fall back to rebuilding the base type based on type passed to constructor

--- a/clang/lib/CConv/ConstraintVariables.cpp
+++ b/clang/lib/CConv/ConstraintVariables.cpp
@@ -32,7 +32,7 @@ std::string ConstraintVariable::getRewritableOriginalTy() const {
   }
   return OrigTyString;
 }
-bool ConstraintVariable::isChecked(EnvironmentMap &E) const {
+bool ConstraintVariable::isChecked(const EnvironmentMap &E) const {
   return getIsOriginallyChecked() || anyChanges(E);
 }
 
@@ -546,7 +546,7 @@ void PointerVariableConstraint::addArrayAnnotations(
 // variables and potentially nested function pointer declaration. Produces a
 // string that can be replaced in the source code.
 std::string
-PointerVariableConstraint::mkString(EnvironmentMap &E,
+PointerVariableConstraint::mkString(const EnvironmentMap &E,
                                     bool EmitName,
                                     bool ForItype,
                                     bool EmitPointee) const {
@@ -587,7 +587,7 @@ PointerVariableConstraint::mkString(EnvironmentMap &E,
       VarAtom *VA = dyn_cast<VarAtom>(V);
       assert(VA != nullptr && "Constraint variable can "
                               "be either constant or VarAtom.");
-      C = E[VA].first;
+      C = E.at(VA).first;
     }
     assert(C != nullptr);
 
@@ -891,19 +891,22 @@ void FunctionVariableConstraint::constrainToWild
     V->constrainToWild(CS, Rsn, PL);
 }
 
-bool FunctionVariableConstraint::anyChanges(EnvironmentMap &E) const {
+bool FunctionVariableConstraint::anyChanges(const EnvironmentMap &E) const {
   return ReturnVar->anyChanges(E);
 }
 
-bool FunctionVariableConstraint::hasWild(EnvironmentMap &E, int AIdx) const {
+bool FunctionVariableConstraint::hasWild(const EnvironmentMap &E,
+                                         int AIdx) const {
   return ReturnVar->hasWild(E, AIdx);
 }
 
-bool FunctionVariableConstraint::hasArr(EnvironmentMap &E, int AIdx) const {
+bool FunctionVariableConstraint::hasArr(const EnvironmentMap &E,
+                                        int AIdx) const {
   return ReturnVar->hasArr(E, AIdx);
 }
 
-bool FunctionVariableConstraint::hasNtArr(EnvironmentMap &E, int AIdx) const {
+bool FunctionVariableConstraint::hasNtArr(const EnvironmentMap &E,
+                                          int AIdx) const {
   return ReturnVar->hasNtArr(E, AIdx);
 }
 
@@ -1024,7 +1027,7 @@ void PointerVariableConstraint::constrainOuterTo(Constraints &CS, ConstAtom *C,
   }
 }
 
-bool PointerVariableConstraint::anyArgumentIsWild(EnvironmentMap &E) {
+bool PointerVariableConstraint::anyArgumentIsWild(const EnvironmentMap &E) {
   for (auto *ArgVal : argumentConstraints) {
     if (!ArgVal->isChecked(E)) {
       return true;
@@ -1033,7 +1036,7 @@ bool PointerVariableConstraint::anyArgumentIsWild(EnvironmentMap &E) {
   return false;
 }
 
-bool PointerVariableConstraint::anyChanges(EnvironmentMap &E) const {
+bool PointerVariableConstraint::anyChanges(const EnvironmentMap &E) const {
   // If a pointer variable was checked in the input program, it will have the
   // same checked type in the output, so it cannot have changed.
   if (OriginallyChecked)
@@ -1061,21 +1064,21 @@ ConstraintVariable *PointerVariableConstraint::getCopy(Constraints &CS) {
 }
 
 const ConstAtom *
-PointerVariableConstraint::getSolution(const Atom *A, EnvironmentMap &E) const {
+PointerVariableConstraint::getSolution(const Atom *A,
+                                       const EnvironmentMap &E) const {
   const ConstAtom *CS = nullptr;
   if (const ConstAtom *CA = dyn_cast<ConstAtom>(A)) {
     CS = CA;
   } else if (const VarAtom *VA = dyn_cast<VarAtom>(A)) {
-    // If this is a VarAtom?, we need ot fetch from solution
-    // i.e., environment.
-    CS = E[const_cast<VarAtom*>(VA)].first;
+    // If this is a VarAtom?, we need to fetch from solution i.e., environment.
+    CS = E.at(const_cast<VarAtom*>(VA)).first;
   }
   assert(CS != nullptr && "Atom should be either const or var");
   return CS;
 }
 
-bool PointerVariableConstraint::hasWild(EnvironmentMap &E, int AIdx) const
-{
+bool PointerVariableConstraint::hasWild(const EnvironmentMap &E,
+                                        int AIdx) const {
   int VarIdx = 0;
   for (const auto &C : vars) {
     const ConstAtom *CS = getSolution(C, E);
@@ -1092,8 +1095,8 @@ bool PointerVariableConstraint::hasWild(EnvironmentMap &E, int AIdx) const
   return false;
 }
 
-bool PointerVariableConstraint::hasArr(EnvironmentMap &E, int AIdx) const
-{
+bool PointerVariableConstraint::hasArr(const EnvironmentMap &E,
+                                       int AIdx) const {
   int VarIdx = 0;
   for (const auto &C : vars) {
     const ConstAtom *CS = getSolution(C, E);
@@ -1110,8 +1113,8 @@ bool PointerVariableConstraint::hasArr(EnvironmentMap &E, int AIdx) const
   return false;
 }
 
-bool PointerVariableConstraint::hasNtArr(EnvironmentMap &E, int AIdx) const
-{
+bool PointerVariableConstraint::hasNtArr(const EnvironmentMap &E,
+                                         int AIdx) const {
   int VarIdx = 0;
   for (const auto &C : vars) {
     const ConstAtom *CS = getSolution(C, E);
@@ -1237,7 +1240,7 @@ bool FunctionVariableConstraint::
 }
 
 std::string
-FunctionVariableConstraint::mkString(EnvironmentMap &E,
+FunctionVariableConstraint::mkString(const EnvironmentMap &E,
                                      bool EmitName, bool ForItype,
                                      bool EmitPointee) const {
   std::string Ret = "";

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -136,10 +136,6 @@ void DeclRewriter::rewrite(RSet &ToRewrite) {
       errs() << "with " << N->getReplacement() << "\n";
     }
 
-    // Get a FullSourceLoc for the start location and add it to the
-    // list of file ID's we've touched.
-    SourceRange SR = N->getDecl()->getSourceRange();
-
     // Exact rewriting procedure depends on declaration type
     if (auto *PVR = dyn_cast<ParmVarDeclReplacement>(N)) {
       assert(N->getStatement() == nullptr);
@@ -337,7 +333,7 @@ void DeclRewriter::rewriteFunctionDecl(FunctionDeclReplacement *N) {
   //       Additionally, a source range can be (mis) identified as
   //       spanning multiple files. We don't know how to re-write that,
   //       so don't.
-  SourceRange SR = N->getSourceRange();
+  SourceRange SR = N->getSourceRange(A.getSourceManager());
   if (canRewrite(R, SR)) {
     R.ReplaceText(SR, N->getReplacement());
   } else {

--- a/clang/lib/CConv/DeclRewriter.cpp
+++ b/clang/lib/CConv/DeclRewriter.cpp
@@ -57,8 +57,6 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
 
   // Add declarations from this map into the rewriting set
   for (const auto &V : Info.getVarMap()) {
-    PersistentSourceLoc PLoc = V.first;
-    CVarSet Vars = V.second;
     // PLoc specifies the location of the variable whose type it is to
     // re-write, but not where the actual type storage is. To get that, we
     // need to turn PLoc into a Decl and then get the SourceRange for the
@@ -66,16 +64,11 @@ void DeclRewriter::rewriteDecls(ASTContext &Context, ProgramInfo &Info,
     // of the type specifier, since we want where the text is printed before
     // the variable name, not the typedef or #define that creates the
     // name of the type.
+    PersistentSourceLoc PLoc = V.first;
     if (Decl *D = std::get<1>(PSLMap[PLoc])) {
-      // We might have one Decl for multiple Vars, however, one will be a
-      // PointerVar so we'll use that.
-      PVConstraint *PV = nullptr;
-      FVConstraint *FV = nullptr;
-      for (const auto &V : Vars)
-        if (PVConstraint *T = dyn_cast<PVConstraint>(V))
-          PV = T;
-        else if (FVConstraint *T = dyn_cast<FVConstraint>(V))
-          FV = T;
+      ConstraintVariable *CV = V.second;
+      PVConstraint *PV = dyn_cast<PVConstraint>(CV);
+      FVConstraint *FV = dyn_cast<FVConstraint>(CV);
 
       if (PV && PV->anyChanges(Info.getConstraints().getVariables()) &&
           !PV->isPartOfFunctionPrototype()) {

--- a/clang/lib/CConv/PersistentSourceLoc.cpp
+++ b/clang/lib/CConv/PersistentSourceLoc.cpp
@@ -23,9 +23,9 @@ PersistentSourceLoc::mkPSL(const Decl *D, ASTContext &C) {
   SourceLocation SL = D->getLocation();
 
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) 
-    SL = C.getSourceManager().getSpellingLoc(FD->getLocation());
+    SL = C.getSourceManager().getExpansionLoc(FD->getLocation());
   else if (const ParmVarDecl *PV = dyn_cast<ParmVarDecl>(D)) 
-    SL = C.getSourceManager().getSpellingLoc(PV->getLocation());
+    SL = C.getSourceManager().getExpansionLoc(PV->getLocation());
   else if (const VarDecl *V = dyn_cast<VarDecl>(D))
     SL = C.getSourceManager().getExpansionLoc(V->getLocation());
   

--- a/clang/lib/CConv/PersistentSourceLoc.cpp
+++ b/clang/lib/CConv/PersistentSourceLoc.cpp
@@ -14,21 +14,14 @@
 using namespace clang;
 using namespace llvm;
 
-// Given a Decl, look up the source location for that Decl and create a 
-// PersistentSourceLoc that represents the location of the Decl. 
-// For Function and Parameter Decls, use the Spelling location, while for
-// variables, use the expansion location. 
+// Given a Decl, look up the source location for that Decl and create a
+// PersistentSourceLoc that represents the location of the Decl.
+// This currently the expansion location for the declarations source location.
+// If we want to add more complete source for macros in the future, I expect we
+// will need to the spelling location instead.
 PersistentSourceLoc
 PersistentSourceLoc::mkPSL(const Decl *D, ASTContext &C) {
-  SourceLocation SL = D->getLocation();
-
-  if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) 
-    SL = C.getSourceManager().getExpansionLoc(FD->getLocation());
-  else if (const ParmVarDecl *PV = dyn_cast<ParmVarDecl>(D)) 
-    SL = C.getSourceManager().getExpansionLoc(PV->getLocation());
-  else if (const VarDecl *V = dyn_cast<VarDecl>(D))
-    SL = C.getSourceManager().getExpansionLoc(V->getLocation());
-  
+  SourceLocation SL = C.getSourceManager().getExpansionLoc(D->getLocation());
   return mkPSL(D->getSourceRange(), SL, C);
 }
 

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -530,10 +530,13 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
   PersistentSourceLoc PLoc = PersistentSourceLoc::mkPSL(D, *astContext);
   assert(PLoc.valid());
 
-  // We only add a PVConstraint or an FVConstraint if the set at
-  // Variables[PLoc] does not contain one already. TODO: Explain why would this happen
+  // We only add a PVConstraint if the set at Variables[PLoc] does not contain
+  // one already. Two variables can have the same source locations when they are
+  // declared inside the same macro expansion. Functions are exempt from this
+  // check because they need to be added to the Extern/Static function maps
+  // regardless if they are inside a macro expansion.
   CVarSet &S = Variables[PLoc];
-  if (S.size()) return;
+  if (S.size() && !isa<FunctionDecl>(D)) return;
 
   if (FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     // Function Decls have FVConstraints.

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -593,8 +593,8 @@ void ProgramInfo::addVariable(clang::DeclaratorDecl *D,
 bool ProgramInfo::hasPersistentConstraints(Expr *E, ASTContext *C) const {
   auto PSL = PersistentSourceLoc::mkPSL(E, *C);
   // Has constraints only if the PSL is valid.
-  return PSL.valid() && Variables.find(PSL) != Variables.end()
-      && !Variables.at(PSL).empty();
+  return PSL.valid() && ExprConstraintVars.find(PSL) != ExprConstraintVars.end()
+      && !ExprConstraintVars.at(PSL).empty();
 }
 
 // Get the set of constraint variables for an expression that will persist
@@ -607,7 +607,7 @@ const CVarSet &ProgramInfo::getPersistentConstraints(Expr *E,
   assert (hasPersistentConstraints(E, C) &&
            "Persistent constraints not present.");
   PersistentSourceLoc PLoc = PersistentSourceLoc::mkPSL(E, *C);
-  return Variables.at(PLoc);
+  return ExprConstraintVars.at(PLoc);
 }
 
 void ProgramInfo::storePersistentConstraints(Expr *E, const CVarSet &Vars,
@@ -622,7 +622,7 @@ void ProgramInfo::storePersistentConstraints(Expr *E, const CVarSet &Vars,
   // visited before. To avoid this, the expression is not cached and instead is
   // recomputed each time it's needed.
   if (PSL.valid() && Rewriter::isRewritable(E->getBeginLoc()))
-    Variables[PSL].insert(Vars.begin(), Vars.end());
+    ExprConstraintVars[PSL].insert(Vars.begin(), Vars.end());
 }
 
 // The Rewriter won't let us re-write things that are in macros. So, we

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -182,7 +182,7 @@ void ProgramInfo::print_stats(const std::set<std::string> &F, raw_ostream &O,
     O << "Sound handling of var args functions:" << HandleVARARGS << "\n";
   }
   std::map<std::string, std::tuple<int, int, int, int, int>> FilesToVars;
-  EnvironmentMap Env = CS.getVariables();
+  const EnvironmentMap &Env = CS.getVariables();
   CVarSet InSrcCVars;
   unsigned int totC, totP, totNt, totA, totWi;
   totC = totP = totNt = totA = totWi = 0;
@@ -738,7 +738,7 @@ bool ProgramInfo::computeInterimConstraintState
   // Get all the valid vars of interest i.e., all the Vars that are present
   // in one of the files being compiled.
   CAtoms ValidVarsVec;
-  for (auto &I : Variables) {
+  for (const auto &I : Variables) {
     std::string FileName = I.first.getFileName();
     if (FilePaths.count(FileName)) {
       for (auto &C : I.second) {

--- a/clang/lib/CConv/ProgramInfo.cpp
+++ b/clang/lib/CConv/ProgramInfo.cpp
@@ -302,27 +302,6 @@ bool ProgramInfo::link() {
   if (Verbose)
     llvm::errs() << "Linking!\n";
 
-// MWH: Should never happen: Variables set sizes == 1
-  // Multiple Variables can be at the same PersistentSourceLoc. We should
-  // constrain that everything that is at the same location is explicitly
-  // equal.
-//  for (const auto &V : Variables) {
-//    std::set<ConstraintVariable *> C = V.second;
-//
-//    if (C.size() > 1) {
-//      assert(false); // should never get here
-//      std::set<ConstraintVariable *>::iterator I = C.begin();
-//      std::set<ConstraintVariable *>::iterator J = C.begin();
-//      ++J;
-//
-//      while (J != C.end()) {
-//        constrainConsVarGeq(*I, *J, CS, nullptr, Same_to_Same, true, this);
-//        ++I;
-//        ++J;
-//      }
-//    }
-//  }
-
   // Equate the constraints for all global variables.
   // This is needed for variables that are defined as extern.
   for (const auto &V : GlobalVariableSymbols) {

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -224,7 +224,9 @@ private:
   Rewriter &Writer;
 
   void rewriteType(Expr *E, SourceRange &Range) {
-    CVarSet CVSingleton = Info.getPersistentConstraintVars(E, Context);
+    if (!Info.hasPersistentConstraints(E, Context))
+      return;
+    const CVarSet &CVSingleton = Info.getPersistentConstraints(E, Context);
     if (CVSingleton.empty())
       return;
 

--- a/clang/lib/CConv/RewriteUtils.cpp
+++ b/clang/lib/CConv/RewriteUtils.cpp
@@ -233,7 +233,7 @@ private:
     // Macros wil sometimes cause a single expression to have multiple
     // constraint variables. These should have been constrained to wild, so
     // there shouldn't be any rewriting required.
-    EnvironmentMap &Vars = Info.getConstraints().getVariables();
+    const EnvironmentMap &Vars = Info.getConstraints().getVariables();
     assert(CVSingleton.size() == 1 || llvm::none_of(CVSingleton,
       [&Vars](ConstraintVariable *CV) {
         return CV->anyChanges(Vars);
@@ -241,15 +241,10 @@ private:
 
     for (auto *CV : CVSingleton)
       // Only rewrite if the type has changed.
-      if (CV->anyChanges(Info.getConstraints().getVariables())){
-        // The constraint variable is able to tell us what the new type string
-        // should be.
-        std::string
-            NewType = CV->mkString(Info.getConstraints().getVariables(), false);
-
+      if (CV->anyChanges(Vars)){
         // Replace the original type with this new one
         if (canRewrite(Writer, Range))
-          Writer.ReplaceText(Range, NewType);
+          Writer.ReplaceText(Range, CV->mkString(Vars, false));
       }
   }
 };

--- a/clang/lib/CConv/StructInit.cpp
+++ b/clang/lib/CConv/StructInit.cpp
@@ -25,12 +25,14 @@ bool StructVariableInitializer::VariableNeedsInitializer(VarDecl *VD) {
 
     for (auto *const D : Definition->fields()) {
       if (D->getType()->isPointerType() || D->getType()->isArrayType()) {
-        ConstraintVariable *CV = I.getVariable(D, Context).getValueOr(nullptr);
-        PVConstraint *PV = dyn_cast_or_null<PVConstraint>(CV);
-        if (PV && PV->isChecked(I.getConstraints().getVariables())) {
-          // Ok this contains a pointer that is checked. Store it.
-          RecordsWithCPointers.insert(Definition);
-          return true;
+        CVarOption CV = I.getVariable(D, Context);
+        if (CV.hasValue()) {
+          PVConstraint *PV = dyn_cast<PVConstraint>(&CV.getValue());
+          if (PV && PV->isChecked(I.getConstraints().getVariables())) {
+            // Ok this contains a pointer that is checked. Store it.
+            RecordsWithCPointers.insert(Definition);
+            return true;
+          }
         }
       }
     }

--- a/clang/lib/CConv/StructInit.cpp
+++ b/clang/lib/CConv/StructInit.cpp
@@ -25,14 +25,12 @@ bool StructVariableInitializer::VariableNeedsInitializer(VarDecl *VD) {
 
     for (auto *const D : Definition->fields()) {
       if (D->getType()->isPointerType() || D->getType()->isArrayType()) {
-        CVarSet FieldConsVars = I.getVariable(D, Context);
-        for (auto *CV : FieldConsVars) {
-          PVConstraint *PV = dyn_cast<PVConstraint>(CV);
-          if (PV && PV->isChecked(I.getConstraints().getVariables())) {
-            // Ok this contains a pointer that is checked. Store it.
-            RecordsWithCPointers.insert(Definition);
-            return true;
-          }
+        ConstraintVariable *CV = I.getVariable(D, Context);
+        PVConstraint *PV = dyn_cast_or_null<PVConstraint>(CV);
+        if (PV && PV->isChecked(I.getConstraints().getVariables())) {
+          // Ok this contains a pointer that is checked. Store it.
+          RecordsWithCPointers.insert(Definition);
+          return true;
         }
       }
     }

--- a/clang/lib/CConv/StructInit.cpp
+++ b/clang/lib/CConv/StructInit.cpp
@@ -25,7 +25,7 @@ bool StructVariableInitializer::VariableNeedsInitializer(VarDecl *VD) {
 
     for (auto *const D : Definition->fields()) {
       if (D->getType()->isPointerType() || D->getType()->isArrayType()) {
-        ConstraintVariable *CV = I.getVariable(D, Context);
+        ConstraintVariable *CV = I.getVariable(D, Context).getValueOr(nullptr);
         PVConstraint *PV = dyn_cast_or_null<PVConstraint>(CV);
         if (PV && PV->isChecked(I.getConstraints().getVariables())) {
           // Ok this contains a pointer that is checked. Store it.

--- a/clang/test/CheckedCRewriter/definedType.c
+++ b/clang/test/CheckedCRewriter/definedType.c
@@ -110,3 +110,31 @@ baz (*(*lua_test3));
 typedef int *StkId;
 void lua_test4(StkId *x) {}
 // CHECK: void lua_test4(_Ptr<_Ptr<int>> x) _Checked {}
+
+// Things declared inside macros should be WILD unless we start doing something extremely clever
+
+#define declare_function(x) int *foo##x(int *a) {return a; } int *bar##x(int *a) { return a; }
+
+declare_function(1)
+
+#define declare_var(x) int * x##1; int ** x##2; int *** x##3;
+
+declare_var(y)
+
+void test() {
+  int *x = 0;
+  int *y = 0;
+  int *a = foo1(x);
+  int *b = bar1(y);
+  int *c = y1;
+  int **d = y2;
+  int ***e = y3;
+}
+// CHECK: void test() {
+// CHECK: int *x = 0;
+// CHECK: int *y = 0;
+// CHECK: int *a = foo1(x);
+// CHECK: int *b = bar1(y);
+// CHECK: int *c = y1;
+// CHECK: int **d = y2;
+// CHECK: int ***e = y3;

--- a/clang/test/CheckedCRewriter/definedType.c
+++ b/clang/test/CheckedCRewriter/definedType.c
@@ -144,3 +144,14 @@ void test() {
 
 void parm_test(parm_decl) {}
 // CHECK: void parm_test(parm_decl) {}
+
+
+#define declare_single_var(x) int *x = 0; 
+int *another_test(void) {
+// CHECK: int *another_test(void) {
+  declare_single_var(z)
+  // CHECK: declare_single_var(z)
+  declare_single_var(y)
+  // CHECK: declare_single_var(y)
+  return z;
+}

--- a/clang/test/CheckedCRewriter/definedType.c
+++ b/clang/test/CheckedCRewriter/definedType.c
@@ -138,3 +138,9 @@ void test() {
 // CHECK: int *c = y1;
 // CHECK: int **d = y2;
 // CHECK: int ***e = y3;
+
+
+#define parm_decl int *a, int *b
+
+void parm_test(parm_decl) {}
+// CHECK: void parm_test(parm_decl) {}

--- a/clang/test/CheckedCRewriter/macroConcat.c
+++ b/clang/test/CheckedCRewriter/macroConcat.c
@@ -1,0 +1,21 @@
+// RUN: cconv-standalone -addcr -alltypes %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_ALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | FileCheck -match-full-lines -check-prefixes="CHECK_NOALL","CHECK" %s
+// RUN: cconv-standalone -addcr %s -- | %clang -c -fcheckedc-extension -x c -o /dev/null -
+// RUN: cconv-standalone -alltypes -output-postfix=checked %s
+// RUN: cconv-standalone -alltypes %S/macroConcat.checked.c -- | count 0
+// RUN: rm %S/macroConcat.checked.c
+
+#define c(g) void FOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO##g () 
+c(BAR0); c(BAR1); c(BAR2); c(BAR3); c(BAR4); c(BAR5); c(BAR6); c(BAR7);
+c(BAR8); c(BAR9); c(BAR10); c(BAR11); c(BAR12); c(BAR13); c(BAR14); c(BAR15); 
+c(BAR16); c(BAR17); c(BAR18); c(BAR19); c(BAR20); c(BAR21); c(BAR22); c(BAR23);
+c(BAR24); c(BAR25); c(BAR26); c(BAR27); c(BAR28); c(BAR29); c(BAR30); c(BAR31);
+c(BAR32); c(BAR33); c(BAR34); c(BAR35); c(BAR36); c(BAR37); c(BAR38);
+
+#define u(d) void add##d(g) {}
+// CHECK: #define u(d) void add##d(g) {}
+u(2);
+// CHECK: u(2);
+
+int *a = 0;
+// CHECK: _Ptr<int> a = 0;

--- a/clang/test/CheckedCRewriter/qualifiers.c
+++ b/clang/test/CheckedCRewriter/qualifiers.c
@@ -1,6 +1,6 @@
-// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checkedALL %s %S/qualifiers.c
-// RUN: cconv-standalone -base-dir=%S -output-postfix=checkedNOALL %s %S/qualifiers.c
-// RUN: %clang -c %S/qualifiers.checkedNOALL.c %S/qualifiers.checkedNOALL.c
+// RUN: cconv-standalone -base-dir=%S -alltypes -output-postfix=checkedALL %s
+// RUN: cconv-standalone -base-dir=%S -output-postfix=checkedNOALL %s
+// RUN: %clang -c %S/qualifiers.checkedNOALL.c
 // RUN: FileCheck -match-full-lines --input-file %S/qualifiers.checkedNOALL.c %s
 // RUN: FileCheck -match-full-lines --input-file %S/qualifiers.checkedALL.c %s
 // RUN: rm %S/qualifiers.checkedALL.c %S/qualifiers.checkedNOALL.c


### PR DESCRIPTION
This pull request is a fix for the macro expansion bug in issues #255 and #18 . This bug was caused because by collisions between persistent source locations. Using our current source location representation, it is possible to for two distinct objects to reside at the same source location. The fix I've implemented does not directly address this. Instead it improves the how we handle situations when such a collision is found.

When a source location collision is found, the affected constraint variables are immediately constrained to wild, and a single wild constraint variable is stored in the variables map. Forcing these constraints to be wild is fine because source location collisions occur inside macros, which are always wild anyways. This avoids inconsistent handling of non-singleton constraint variable sets in the `Variables` map.

As part of this fix, the `Variables` map in `ProgramInfo` has been updated to map source locations to a single `ConstraintVariable *` instead of a `std::set<ConstraintVariable *>`. This reflects how the map is actually used. Somewhat recently we began storing constraints for expressions in this set instead of using it only for declaration constraints. This change is problematic because expressions (unlike declaration) have non-singleton sets of constraint variables. I have created a new map for storing these constraint variables sets. I think this is a generally good organizational change because the declaration and expression constraint variables are used for very different purposes in the code (rewriting declaration vs. caching pre-computed constraint sets).

